### PR TITLE
fix(framework): Make factory init thread safe

### DIFF
--- a/framework/py/flwr/server/superlink/linkstate/linkstate_factory.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_factory.py
@@ -52,7 +52,7 @@ class LinkStateFactory:
     ) -> None:
         self.database = database
         self.state_instance: LinkState | None = None
-        # Guard lazy initialization so migrations run exactly once per process.
+        # Guard lazy initialization so migrations run exactly once per process
         self._init_lock = Lock()
         self.federation_manager = federation_manager
         self.objectstore_factory = objectstore_factory
@@ -68,7 +68,7 @@ class LinkStateFactory:
             return self.state_instance
 
         with self._init_lock:
-            # Another thread may have initialized while we waited.
+            # Another thread may have initialized while we waited
             if self.state_instance is not None:
                 if self.database == FLWR_IN_MEMORY_DB_NAME:
                     log(DEBUG, "Using InMemoryState")

--- a/framework/py/flwr/supercore/object_store/object_store_factory.py
+++ b/framework/py/flwr/supercore/object_store/object_store_factory.py
@@ -41,7 +41,7 @@ class ObjectStoreFactory:
     def __init__(self, database: str = FLWR_IN_MEMORY_DB_NAME) -> None:
         self.database = database
         self.store_instance: ObjectStore | None = None
-        # Guard lazy initialization so DB migrations happen exactly once.
+        # Guard lazy initialization so DB migrations happen exactly once
         self._init_lock = Lock()
 
     def store(self) -> ObjectStore:
@@ -61,7 +61,7 @@ class ObjectStoreFactory:
             return self.store_instance
 
         with self._init_lock:
-            # Another thread may have initialized while we waited.
+            # Another thread may have initialized while we waited
             if self.store_instance is not None:
                 if self.database == FLWR_IN_MEMORY_DB_NAME:
                     log(DEBUG, "Using InMemoryObjectStore")


### PR DESCRIPTION
To hopefully solve the following error I got in the CI (caused by a race condition on the DB initialization):
```
{'success': False, 'error-message': '\n<_InactiveRpcError of RPC that terminated with:\n\tstatus = StatusCode.UNKNOWN\n\tdetails = "Exception calling application: (sqlite3.OperationalError) table node
  already exists\n ....
```