### PR TITLE
fix(framework): Raise when aggregate() and aggregate_inplace() receive zero total examples

### DIFF
--- a/framework/py/flwr/server/strategy/aggregate.py
+++ b/framework/py/flwr/server/strategy/aggregate.py
@@ -34,8 +34,8 @@ def aggregate(results: list[tuple[NDArrays, int]]) -> NDArrays:
     # silently returned as the new global model.
     if num_examples_total == 0:
         raise ValueError(
-            "aggregate() requires the total number of examples to be greater than "
-            "zero, but every result reported num_examples=0"
+            "aggregate() requires the total number of examples across all results "
+            "to be greater than zero"
         )
 
     # Create a list of weights, each multiplied by the related number of examples

--- a/framework/py/flwr/server/strategy/aggregate.py
+++ b/framework/py/flwr/server/strategy/aggregate.py
@@ -30,6 +30,14 @@ def aggregate(results: list[tuple[NDArrays, int]]) -> NDArrays:
     # Calculate the total number of examples used during training
     num_examples_total = sum(num_examples for (_, num_examples) in results)
 
+    # Guard against a zero total: dividing by it yields NaN weights that would be
+    # silently returned as the new global model.
+    if num_examples_total == 0:
+        raise ValueError(
+            "aggregate() requires the total number of examples to be greater than "
+            "zero, but every result reported num_examples=0"
+        )
+
     # Create a list of weights, each multiplied by the related number of examples
     weighted_weights = [
         [layer * num_examples for layer in weights] for weights, num_examples in results

--- a/framework/py/flwr/server/strategy/aggregate.py
+++ b/framework/py/flwr/server/strategy/aggregate.py
@@ -55,6 +55,13 @@ def aggregate_inplace(results: list[tuple[ClientProxy, FitRes]]) -> NDArrays:
     """Compute in-place weighted average."""
     # Count total examples
     num_examples_total = sum(fit_res.num_examples for (_, fit_res) in results)
+    # Guard against a zero total: FedAvg uses this in-place path by default, and
+    # dividing by zero here would abort the round with a ZeroDivisionError.
+    if num_examples_total == 0:
+        raise ValueError(
+            "aggregate_inplace() requires the total number of examples across all "
+            "results to be greater than zero"
+        )
 
     # Compute scaling factors for each result
     scaling_factors = np.asarray(

--- a/framework/py/flwr/server/strategy/aggregate_test.py
+++ b/framework/py/flwr/server/strategy/aggregate_test.py
@@ -16,6 +16,7 @@
 
 
 import numpy as np
+import pytest
 
 from .aggregate import (
     _aggregate_n_closest_weights,
@@ -24,6 +25,16 @@ from .aggregate import (
     aggregate,
     weighted_loss_avg,
 )
+
+
+def test_aggregate_zero_num_examples_total() -> None:
+    """Test aggregate raises when every result reports zero examples."""
+    # Prepare: a round in which no client trained on any example
+    results = [([np.array([1.0, 2.0])], 0), ([np.array([3.0, 4.0])], 0)]
+
+    # Execute & Assert: must raise rather than return NaN weights
+    with pytest.raises(ValueError):
+        aggregate(results)
 
 
 def test_aggregate() -> None:

--- a/framework/py/flwr/server/strategy/aggregate_test.py
+++ b/framework/py/flwr/server/strategy/aggregate_test.py
@@ -15,10 +15,15 @@
 """Aggregation function tests."""
 
 
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
 
+from flwr.common import Code, FitRes, Status, ndarrays_to_parameters
+
 from .aggregate import (
+    aggregate_inplace,
     _aggregate_n_closest_weights,
     _check_weights_equality,
     _find_reference_weights,
@@ -35,6 +40,22 @@ def test_aggregate_zero_num_examples_total() -> None:
     # Execute & Assert: must raise rather than return NaN weights
     with pytest.raises(ValueError):
         aggregate(results)
+
+
+def test_aggregate_inplace_zero_num_examples_total() -> None:
+    """Test aggregate_inplace raises when every client reports zero examples."""
+    # Prepare: a round in which no client trained on any example (FedAvg default path)
+    fit_res = FitRes(
+        status=Status(code=Code.OK, message="Success"),
+        parameters=ndarrays_to_parameters([np.array([1.0, 2.0])]),
+        num_examples=0,
+        metrics={},
+    )
+    results = [(MagicMock(), fit_res), (MagicMock(), fit_res)]
+
+    # Execute & Assert: must raise rather than divide by zero
+    with pytest.raises(ValueError):
+        aggregate_inplace(results)
 
 
 def test_aggregate() -> None:


### PR DESCRIPTION
### Problem

`aggregate()` and `aggregate_inplace()` both divide by the total number of training examples with no zero guard. If every sampled client reports `num_examples=0` (an empty/degenerate local partition), this raises `ZeroDivisionError` (or produces NaN weights) and aborts the round.

`FedAvg` uses **`aggregate_inplace()` by default** (`inplace=True`), so guarding only `aggregate()` would leave the default path exposed — this PR guards both.

### Change

Raise a descriptive `ValueError` in each function when the total is zero.

### Testing

`test_aggregate_zero_num_examples_total` and `test_aggregate_inplace_zero_num_examples_total`. Both fail on the original code (`ZeroDivisionError`) and pass after the guard; the existing aggregate tests are unaffected.