### PR TITLE
feat(framework): Add agent docs scaffolding

### DIFF
--- a/framework/docs/agent/Makefile
+++ b/framework/docs/agent/Makefile
@@ -1,0 +1,12 @@
+SPHINXOPTS ?= -W --keep-going
+SPHINXBUILD ?= sphinx-build
+SOURCEDIR = source
+BUILDDIR = build
+
+.PHONY: html clean
+
+html:
+	$(SPHINXBUILD) $(SPHINXOPTS) -b html "$(SOURCEDIR)" "$(BUILDDIR)/html"
+
+clean:
+	$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)"

--- a/framework/docs/agent/README.md
+++ b/framework/docs/agent/README.md
@@ -1,0 +1,21 @@
+# Flower Agent documentation
+
+This directory contains the standalone documentation site for Flower Agent.
+It is compiled separately from the Flower framework documentation in
+`framework/docs/source`.
+
+The Agent documentation covers task-oriented guides, concepts, examples, and
+operational guidance. The generated Python API reference remains in the
+framework documentation because `flwr.agentapp` is part of the `flwr` package.
+
+## Build locally
+
+From the `framework` directory, run:
+
+```bash
+uv run --no-sync --python=3.11.14 \
+  sphinx-build -W --keep-going -b html \
+  docs/agent/source docs/agent/build/html
+```
+
+Open `docs/agent/build/html/index.html` in a browser to view the result.

--- a/framework/docs/agent/source/conf.py
+++ b/framework/docs/agent/source/conf.py
@@ -1,0 +1,34 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Sphinx configuration for the standalone Flower Agent documentation."""
+
+from datetime import date
+
+project = "Flower Agent"
+copyright = f"{date.today().year} Flower Labs GmbH"
+author = "The Flower Authors"
+
+extensions = ["myst_parser"]
+
+source_suffix = {
+    ".md": "markdown",
+}
+root_doc = "index"
+
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+html_theme = "furo"
+html_title = "Flower Agent"

--- a/framework/docs/agent/source/index.md
+++ b/framework/docs/agent/source/index.md
@@ -1,0 +1,27 @@
+# Flower Agent
+
+Flower Agent provides the runtime and building blocks for creating agentic
+applications on Flower.
+
+This documentation will help application developers:
+
+- build and configure an AgentApp;
+- call models and connectors through an AgentSession;
+- run and observe agents on Flower infrastructure; and
+- deploy agents with appropriate security and operational controls.
+
+## Documentation boundaries
+
+This site is compiled independently and contains Flower Agent tutorials,
+guides, concepts, examples, and operational documentation. The `flwr.agentapp`
+Python API reference remains in the Flower framework documentation, where it is
+generated from the public API and its docstrings.
+
+Design proposals and unimplemented features are not published here as product
+capabilities. They remain engineering RFCs until the corresponding behavior is
+available.
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+```


### PR DESCRIPTION
Adds minimal scaffolding for a standalone Flower Agent documentation site under framework/docs/agent.

The site builds independently from the framework docs, allowing it to be deployed later at flower.ai/docs/agent.