### PR TITLE
refactor(framework): Add LinkState ORM lookup pattern

### DIFF
--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -1433,6 +1433,18 @@ class StateTest(CoreStateTest):
         # Assert
         assert retrieved_node_id is None
 
+    def test_get_node_id_by_public_key_of_unknown_node(self) -> None:
+        """Test get_node_id_by_public_key of an unknown node."""
+        # Prepare
+        state: LinkState = self.state_factory()
+        state.create_node("fake_aid", "fake_name", b"known", 10)
+
+        # Execute
+        retrieved_node_id = state.get_node_id_by_public_key(b"unknown")
+
+        # Assert
+        assert retrieved_node_id is None
+
     def test_num_message_ins(self) -> None:
         """Test if num_message_ins returns correct number of not delivered Messages."""
         # Prepare

--- a/framework/py/flwr/server/superlink/linkstate/orm_models.py
+++ b/framework/py/flwr/server/superlink/linkstate/orm_models.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""SQLAlchemy ORM models for LinkState tables."""
+
+from sqlalchemy.orm import DeclarativeBase, Mapped
+
+from flwr.supercore.state.schema.linkstate_tables import create_linkstate_metadata
+
+LINKSTATE_METADATA = create_linkstate_metadata()
+NODE_TABLE = LINKSTATE_METADATA.tables["node"]
+
+
+class LinkStateBase(DeclarativeBase):
+    """Base class for LinkState ORM models."""
+
+    metadata = LINKSTATE_METADATA
+
+
+class LinkStateNode(LinkStateBase):
+    """Represent a LinkState node."""
+
+    __table__ = NODE_TABLE
+    __mapper_args__ = {"primary_key": [NODE_TABLE.c.node_id]}
+
+    node_id: Mapped[int]
+    status: Mapped[str]
+    public_key: Mapped[bytes]

--- a/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
@@ -22,7 +22,7 @@ from datetime import UTC, datetime
 from logging import ERROR, WARNING
 from typing import Any, Literal, cast
 
-from sqlalchemy import MetaData
+from sqlalchemy import MetaData, select
 from sqlalchemy.exc import IntegrityError
 
 from flwr.app import Message
@@ -61,6 +61,7 @@ from flwr.supercore.utils import (
 from flwr.superlink.federation import FederationManager
 
 from .linkstate import LinkState
+from .orm_models import LinkStateNode
 from .utils import (
     check_node_availability_for_in_message,
     convert_sint64_values_in_dict_to_uint64,
@@ -951,19 +952,18 @@ class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
     def get_node_id_by_public_key(self, public_key: bytes) -> int | None:
         """Get `node_id` for the specified `public_key` if it exists and is not
         deleted."""
-        query = """SELECT node_id FROM node
-                   WHERE public_key = :public_key AND status != :unregistered;"""
-        rows = self.query(
-            query, {"public_key": public_key, "unregistered": NodeStatus.UNREGISTERED}
+        statement = select(LinkStateNode.node_id).where(
+            LinkStateNode.public_key == public_key,
+            LinkStateNode.status != NodeStatus.UNREGISTERED,
         )
 
-        # If no result is found, return None
-        if not rows:
+        with self.session() as session:
+            node_id = session.execute(statement).scalar_one_or_none()
+
+        if node_id is None:
             return None
 
-        # Convert sint64 node_id to uint64
-        node_id = int64_to_uint64(rows[0]["node_id"])
-        return node_id
+        return int64_to_uint64(node_id)
 
     def create_run(  # pylint: disable=R0913, R0914, R0917
         self,


### PR DESCRIPTION
## Issue

### Description

LinkState currently uses direct SQL text for database access. To prepare for the gradual LinkState SQLAlchemy ORM migration, this PR establishes the first small ORM lookup pattern on a low-risk read-only path.

The selected path is `SqlLinkState.get_node_id_by_public_key`, which only reads the existing `node` table and does not affect run/task scheduling, message delivery, object state, locking, migrations, API routes, or deployment behavior.

### Related issues/PRs

Related to the Platform API and Framework consolidation work. This is the first small Flower-side LinkState ORM migration pattern PR.

## Proposal

### Explanation

This PR:

- adds a private LinkState ORM model mapping for the existing `node` table;
- changes `SqlLinkState.get_node_id_by_public_key` from raw SQL text to a SQLAlchemy ORM `select`;
- adds regression coverage for unknown public-key lookup returning `None`;
- keeps the database schema unchanged;
- does not add an Alembic migration.

This is intentionally small so reviewers can validate the ORM pattern before any sensitive LinkState areas are migrated.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [ ] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [ ] Make CI checks pass
- [ ] Ping maintainers on Slack (channel `#contributions`)

### Any other comments?

No documentation update is included because this is an internal implementation-pattern change with no public API, user-facing behavior, configuration, schema, or deployment impact.

Tested from `framework/`:

```bash
uv sync --locked --python=3.11.14 --all-extras --all-groups
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/server/superlink/linkstate/linkstate_test.py -k "get_node_id_by_public_key"
uv run --no-sync --python=3.11.14 python -m ruff check py/flwr/server/superlink/linkstate/orm_models.py py/flwr/server/superlink/linkstate/sql_linkstate.py py/flwr/server/superlink/linkstate/linkstate_test.py
uv run --no-sync --python=3.11.14 python -m mypy py/flwr/server/superlink/linkstate/orm_models.py py/flwr/server/superlink/linkstate/sql_linkstate.py py/flwr/server/superlink/linkstate/linkstate_test.py
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/server/superlink/linkstate/linkstate_test.py
uv run --no-sync --python=3.11.14 python -m black --check py/flwr/server/superlink/linkstate/orm_models.py py/flwr/server/superlink/linkstate/sql_linkstate.py py/flwr/server/superlink/linkstate/linkstate_test.py
```

All commands passed locally.