### PR TITLE
refactor(framework): Use ORM for connector reads

### DIFF
--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -68,6 +68,7 @@ from flwr.supercore.fab import Fab
 from flwr.supercore.inflatable.inflatable_object import get_object_tree
 from flwr.supercore.object_store.object_store_factory import ObjectStoreFactory
 from flwr.supercore.primitives.asymmetric import generate_key_pairs, public_key_to_bytes
+from flwr.supercore.state.schema.corestate_models import Connector as ConnectorModel
 from flwr.supercore.state.schema.corestate_models import Fab as FabModel
 from flwr.superlink.federation import NoOpFederationManager
 
@@ -2364,6 +2365,32 @@ class SqlInMemoryStateTest(StateTest, unittest.TestCase):
 
         assert second is not None
         self.assertEqual(second.verifications, {"meta": "new"})
+
+    def test_get_connector_refreshes_cached_row_in_shared_session(self) -> None:
+        """Test get_connector observes raw SQL updates in a shared session."""
+        state = self.state_factory()
+
+        with state.session() as session:
+            state.upsert_connector(
+                flwr_aid="account-a",
+                connector_ref="calendar",
+                credentials_json='{"token":"old"}',
+                config_json='{"calendar":"primary"}',
+            )
+            cached_row = session.get(ConnectorModel, ("account-a", "calendar"))
+            assert cached_row is not None
+            self.assertEqual(cached_row.credentials_json, '{"token":"old"}')
+            state.upsert_connector(
+                flwr_aid="account-a",
+                connector_ref="calendar",
+                credentials_json='{"token":"new"}',
+                config_json='{"calendar":"work"}',
+            )
+            second = state.get_connector(flwr_aid="account-a", connector_ref="calendar")
+
+        assert second is not None
+        self.assertEqual(second.credentials_json, '{"token":"new"}')
+        self.assertEqual(second.config_json, '{"calendar":"work"}')
 
     def test_run_series_distinguishes_missing_and_empty_descriptions(self) -> None:
         """Missing and explicitly empty descriptions remain distinct in SQL."""

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -60,6 +60,7 @@ from flwr.supercore.constant import OBJECT_PUSH_SESSION_TTL_SECONDS, AutomationS
 from flwr.supercore.date import now
 from flwr.supercore.fab import Fab
 from flwr.supercore.sql_mixin import SqlMixin
+from flwr.supercore.state.schema.corestate_models import Connector as ConnectorModel
 from flwr.supercore.state.schema.corestate_models import Fab as FabModel
 from flwr.supercore.state.schema.corestate_tables import create_corestate_metadata
 from flwr.supercore.typing import ConnectorOAuthSessionRecord, ConnectorRecord
@@ -449,24 +450,20 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Return an account's connector, if present."""
         if not flwr_aid or not connector_ref:
             return None
-        rows = self.query(
-            """
-            SELECT flwr_aid, connector_ref, credentials_json, config_json
-            FROM connector
-            WHERE flwr_aid = :flwr_aid
-              AND connector_ref = :connector_ref
-            """,
-            {"flwr_aid": flwr_aid, "connector_ref": connector_ref},
-        )
-        if not rows:
-            return None
-        row = rows[0]
-        return ConnectorRecord(
-            flwr_aid=row["flwr_aid"],
-            connector_ref=row["connector_ref"],
-            credentials_json=row["credentials_json"],
-            config_json=row["config_json"],
-        )
+        with self.session() as session:
+            row = session.get(
+                ConnectorModel,
+                (flwr_aid, connector_ref),
+                populate_existing=True,
+            )
+            if row is None:
+                return None
+            return ConnectorRecord(
+                flwr_aid=row.flwr_aid,
+                connector_ref=row.connector_ref,
+                credentials_json=row.credentials_json,
+                config_json=row.config_json,
+            )
 
     def delete_connector(self, flwr_aid: str, connector_ref: str) -> bool:
         """Delete an account's connector if it exists."""


### PR DESCRIPTION
### Description

`SqlCoreState.get_connector` still reads connector rows through direct SQL even though the connector table now has a declarative model.

### Related issues/PRs

Follow-up to the CoreState declarative model PRs.

## Proposal

### Explanation

Use the `Connector` ORM model for `SqlCoreState.get_connector` while preserving the existing public return type and behavior. The write/upsert path remains unchanged.

The read uses `populate_existing=True` so mixed raw-SQL/ORM access inside a shared state session observes the latest row values during the transition.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [x] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

Validation:

```shell
cd framework
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m pytest py/flwr/server/superlink/linkstate/linkstate_test.py -k 'connector or fab'
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m ruff check py/flwr/supercore/corestate/sql_corestate.py py/flwr/server/superlink/linkstate/linkstate_test.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m mypy py/flwr/supercore/corestate/sql_corestate.py py/flwr/server/superlink/linkstate/linkstate_test.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m black --check py/flwr/supercore/corestate/sql_corestate.py py/flwr/server/superlink/linkstate/linkstate_test.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m devtool.check_pr_title 'refactor(framework): Use ORM for connector reads'
```

The regression test was also checked without `populate_existing=True`; it failed by returning stale cached connector credentials, then passed again after restoring the option.

No Alembic or schema files are changed.