### PR TITLE
refactor(framework): Use ORM for run connector reads

### DIFF
--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -24,7 +24,7 @@ from logging import ERROR
 from typing import Any, Literal, cast
 from uuid import uuid4
 
-from sqlalchemy import MetaData
+from sqlalchemy import MetaData, select
 from sqlalchemy.exc import IntegrityError
 
 from flwr.app import Context, Message
@@ -62,6 +62,9 @@ from flwr.supercore.fab import Fab
 from flwr.supercore.sql_mixin import SqlMixin
 from flwr.supercore.state.schema.corestate_models import Connector as ConnectorModel
 from flwr.supercore.state.schema.corestate_models import Fab as FabModel
+from flwr.supercore.state.schema.corestate_models import (
+    RunConnector as RunConnectorModel,
+)
 from flwr.supercore.state.schema.corestate_tables import create_corestate_metadata
 from flwr.supercore.typing import ConnectorOAuthSessionRecord, ConnectorRecord
 from flwr.supercore.utils import build_sql_in_params, int64_to_uint64, uint64_to_int64
@@ -520,16 +523,14 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
 
     def get_run_connector_refs(self, run_id: int) -> Sequence[str]:
         """Return connector references associated with a run."""
-        rows = self.query(
-            """
-            SELECT connector_ref
-            FROM run_connector
-            WHERE run_id = :run_id
-            ORDER BY connector_ref
-            """,
-            {"run_id": uint64_to_int64(run_id)},
-        )
-        return [row["connector_ref"] for row in rows]
+        with self.session() as session:
+            return list(
+                session.scalars(
+                    select(RunConnectorModel.connector_ref)
+                    .where(RunConnectorModel.run_id == uint64_to_int64(run_id))
+                    .order_by(RunConnectorModel.connector_ref)
+                )
+            )
 
     def create_connector_oauth_session(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,


### PR DESCRIPTION
## Issue

### Description

`SqlCoreState.get_run_connector_refs` still reads run connector rows through direct SQL even though the `run_connector` table now has a declarative model.

### Related issues/PRs

Follow-up to the CoreState declarative model PRs.

## Proposal

### Explanation

Use the `RunConnector` ORM model for `SqlCoreState.get_run_connector_refs` while preserving the existing return value and deterministic ordering. The write/bind path remains unchanged.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [x] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

Validation:

```shell
cd framework
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m pytest py/flwr/server/superlink/linkstate/linkstate_test.py -k 'run_connector or connector'
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m ruff check py/flwr/supercore/corestate/sql_corestate.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m mypy py/flwr/supercore/corestate/sql_corestate.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m black --check py/flwr/supercore/corestate/sql_corestate.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m devtool.check_pr_title 'refactor(framework): Use ORM for run connector reads'
```

No Alembic or schema files are changed.