### PR TITLE
refactor(framework): Use ORM for run series context reads

### DIFF
--- a/framework/py/flwr/supercore/corestate/corestate_test.py
+++ b/framework/py/flwr/supercore/corestate/corestate_test.py
@@ -24,6 +24,7 @@ from unittest.mock import call, patch
 
 from parameterized import parameterized
 
+from flwr.app import Context, RecordDict
 from flwr.common.constant import (
     HEARTBEAT_DEFAULT_INTERVAL,
     HEARTBEAT_PATIENCE,
@@ -145,6 +146,30 @@ class StateTest(unittest.TestCase):  # pylint: disable=R0904
             state.bind_connectors_to_run(run_id=43, connector_refs="notion")
         )
         self.assertEqual(list(state.get_run_connector_refs(run_id=43)), [])
+
+    def test_run_series_context_roundtrip(self) -> None:
+        """A run series context can be stored and retrieved."""
+        state = self.state_factory()
+
+        self.assertIsNone(state.get_run_series_context(series_id=42))
+        context = Context(
+            run_id=123,
+            node_id=SUPERLINK_NODE_ID,
+            node_config={"node": "value"},
+            state=RecordDict(),
+            run_config={"run": "value"},
+            series_id=42,
+        )
+        state.set_run_series_context(series_id=42, context=context)
+
+        retrieved = state.get_run_series_context(series_id=42)
+
+        assert retrieved is not None
+        self.assertEqual(retrieved.run_id, context.run_id)
+        self.assertEqual(retrieved.node_id, context.node_id)
+        self.assertEqual(retrieved.node_config, context.node_config)
+        self.assertEqual(retrieved.run_config, context.run_config)
+        self.assertEqual(retrieved.series_id, context.series_id)
 
     def test_connector_oauth_session_lifecycle(self) -> None:
         """An OAuth session can be created, retrieved, and completed once."""

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -68,6 +68,9 @@ from flwr.supercore.state.schema.corestate_models import Fab as FabModel
 from flwr.supercore.state.schema.corestate_models import (
     RunConnector as RunConnectorModel,
 )
+from flwr.supercore.state.schema.corestate_models import (
+    SeriesContext as SeriesContextModel,
+)
 from flwr.supercore.state.schema.corestate_tables import create_corestate_metadata
 from flwr.supercore.typing import ConnectorOAuthSessionRecord, ConnectorRecord
 from flwr.supercore.utils import build_sql_in_params, int64_to_uint64, uint64_to_int64
@@ -712,17 +715,15 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
 
     def get_run_series_context(self, series_id: int) -> Context | None:
         """Return the shared Context for the specified RunSeries, if present."""
-        rows = self.query(
-            """
-            SELECT context
-            FROM series_context
-            WHERE series_id = :series_id
-            """,
-            {"series_id": uint64_to_int64(series_id)},
-        )
-        if not rows or rows[0]["context"] is None:
-            return None
-        return context_from_bytes(rows[0]["context"])
+        with self.session() as session:
+            row = session.get(
+                SeriesContextModel,
+                uint64_to_int64(series_id),
+                populate_existing=True,
+            )
+            if row is None or row.context is None:
+                return None
+            return context_from_bytes(row.context)
 
     def set_run_series_context(self, series_id: int, context: Context) -> None:
         """Set the shared Context for the specified RunSeries."""


### PR DESCRIPTION
## Issue

### Description

`SqlCoreState.get_run_series_context` still reads series context rows through direct SQL even though the `series_context` table now has a declarative model.

### Related issues/PRs

Follow-up to the CoreState declarative model PRs.

## Proposal

### Explanation

Use the `SeriesContext` ORM model for `SqlCoreState.get_run_series_context` while preserving the existing return value. The write/upsert path remains unchanged.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [x] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

Validation:

```shell
cd framework
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m pytest py/flwr/server/superlink/linkstate/linkstate_test.py -k 'run_series_context or run_series'
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m ruff check py/flwr/supercore/corestate/sql_corestate.py py/flwr/supercore/corestate/corestate_test.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m mypy py/flwr/supercore/corestate/sql_corestate.py py/flwr/supercore/corestate/corestate_test.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m black --check py/flwr/supercore/corestate/sql_corestate.py py/flwr/supercore/corestate/corestate_test.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m devtool.check_pr_title 'refactor(framework): Use ORM for run series context reads'
```

No Alembic or schema files are changed.