### PR TITLE
refactor(framework): Use ORM for task usage and event reads

### DIFF
--- a/framework/py/flwr/supercore/corestate/corestate_test.py
+++ b/framework/py/flwr/supercore/corestate/corestate_test.py
@@ -885,9 +885,10 @@ class StateTest(unittest.TestCase):  # pylint: disable=R0904
     def test_add_and_get_task_usage(self) -> None:
         """Task usage should round-trip and filter by task ID."""
         state = self.state_factory()
+        run_id = self.task_run_id(state)
         task_id = state.create_task(
             task_type=TaskType.MODEL,
-            run_id=self.task_run_id(state),
+            run_id=run_id,
         )
         assert task_id is not None
 
@@ -911,8 +912,14 @@ class StateTest(unittest.TestCase):  # pylint: disable=R0904
         )
 
         usages = state.get_task_usage(task_ids=[task_id])
+        usages_by_run = state.get_task_usage(run_ids=[run_id])
+        empty_by_task = state.get_task_usage(task_ids=[])
+        empty_by_run = state.get_task_usage(run_ids=[])
 
         self.assertEqual(len(usages), 2)
+        self.assertEqual(usages_by_run, usages)
+        self.assertEqual(empty_by_task, [])
+        self.assertEqual(empty_by_run, [])
         usage = usages[0]
         self.assertEqual(usage.input_tokens, 10)
         self.assertEqual(usage.output_tokens, 20)

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -26,6 +26,7 @@ from uuid import uuid4
 
 from sqlalchemy import MetaData, select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.sql.elements import ColumnElement
 
 from flwr.app import Context, Message
 from flwr.app.message import make_message
@@ -71,6 +72,8 @@ from flwr.supercore.state.schema.corestate_models import (
 from flwr.supercore.state.schema.corestate_models import (
     SeriesContext as SeriesContextModel,
 )
+from flwr.supercore.state.schema.corestate_models import TaskEvent as TaskEventModel
+from flwr.supercore.state.schema.corestate_models import TaskUsage as TaskUsageModel
 from flwr.supercore.state.schema.corestate_tables import create_corestate_metadata
 from flwr.supercore.typing import ConnectorOAuthSessionRecord, ConnectorRecord
 from flwr.supercore.utils import build_sql_in_params, int64_to_uint64, uint64_to_int64
@@ -1309,36 +1312,27 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         task_ids: Sequence[int] | None = None,
     ) -> Sequence[TaskUsage]:
         """Retrieve task usage records based on the specified filters."""
-        conditions = []
-        params: dict[str, Any] = {}
+        conditions: list[ColumnElement[bool]] = []
 
         if run_ids is not None:
             if not run_ids:
                 return []
             sint64_run_ids = [uint64_to_int64(run_id) for run_id in run_ids]
-            placeholders, in_params = build_sql_in_params(sint64_run_ids, "rid")
-            conditions.append(f"run_id IN ({placeholders})")
-            params.update(in_params)
+            conditions.append(TaskUsageModel.run_id.in_(sint64_run_ids))
 
         if task_ids is not None:
             if not task_ids:
                 return []
             sint64_task_ids = [uint64_to_int64(task_id) for task_id in task_ids]
-            placeholders, in_params = build_sql_in_params(sint64_task_ids, "tid")
-            conditions.append(f"task_id IN ({placeholders})")
-            params.update(in_params)
+            conditions.append(TaskUsageModel.task_id.in_(sint64_task_ids))
 
-        where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        query = select(TaskUsageModel).order_by(TaskUsageModel.id.asc())
+        if conditions:
+            query = query.where(*conditions)
 
-        query = f"""
-            SELECT input_tokens, output_tokens, total_tokens, usage_type, provider
-            FROM task_usage
-            {where_clause}
-            ORDER BY id ASC
-        """
-
-        rows = self.query(query, params)
-        return [_task_usage_from_row(row) for row in rows]
+        with self.session() as session:
+            rows = session.scalars(query).all()
+            return [_task_usage_from_model(row) for row in rows]
 
     def claim_task(self, task_id: int) -> str | None:
         """Atomically claim a pending task."""
@@ -1581,33 +1575,17 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
     ) -> Sequence[TaskEvent]:
         """Return task-produced run events after the cursor."""
         cursor = after_task_event_id if after_task_event_id is not None else 0
-        conditions = ["id > :after_task_event_id"]
-        params = {"after_task_event_id": cursor}
+        conditions: list[ColumnElement[bool]] = [TaskEventModel.id > cursor]
         if run_id is not None:
-            conditions.append("run_id = :run_id")
-            params["run_id"] = uint64_to_int64(run_id)
+            conditions.append(TaskEventModel.run_id == uint64_to_int64(run_id))
 
-        rows = self.query(
-            f"""
-            SELECT id, timestamp, run_id, task_id, event, data
-            FROM task_event
-            WHERE {" AND ".join(conditions)}
-            ORDER BY id ASC
-            """,
-            params,
+        query = (
+            select(TaskEventModel).where(*conditions).order_by(TaskEventModel.id.asc())
         )
 
-        return [
-            TaskEvent(
-                id=row["id"],
-                timestamp=timestamp_to_iso(row["timestamp"]),
-                run_id=int64_to_uint64(row["run_id"]),
-                task_id=int64_to_uint64(row["task_id"]),
-                event=row["event"],
-                data=row["data"],
-            )
-            for row in rows
-        ]
+        with self.session() as session:
+            rows = session.scalars(query).all()
+            return [_task_event_from_model(row) for row in rows]
 
     def _claim_task_message_rows(
         self,
@@ -1832,14 +1810,26 @@ def _task_usage_to_row(task_id: int, usage: TaskUsage) -> dict[str, Any]:
     }
 
 
-def _task_usage_from_row(row: dict[str, Any]) -> TaskUsage:
-    """Convert a task_usage row to a TaskUsage proto."""
+def _task_usage_from_model(row: TaskUsageModel) -> TaskUsage:
+    """Convert a task_usage ORM model to a TaskUsage proto."""
     return TaskUsage(
-        usage_type=row["usage_type"],
-        provider=row["provider"],
-        input_tokens=row["input_tokens"],
-        output_tokens=row["output_tokens"],
-        total_tokens=row["total_tokens"],
+        usage_type=row.usage_type,
+        provider=row.provider,
+        input_tokens=row.input_tokens,
+        output_tokens=row.output_tokens,
+        total_tokens=row.total_tokens,
+    )
+
+
+def _task_event_from_model(row: TaskEventModel) -> TaskEvent:
+    """Convert a task_event ORM model to a TaskEvent proto."""
+    return TaskEvent(
+        id=row.id,
+        timestamp=timestamp_to_iso(row.timestamp),
+        run_id=int64_to_uint64(row.run_id),
+        task_id=int64_to_uint64(row.task_id),
+        event=row.event,
+        data=row.data,
     )
 
 

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -26,7 +26,6 @@ from uuid import uuid4
 
 from sqlalchemy import MetaData, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.sql.elements import ColumnElement
 
 from flwr.app import Context, Message
 from flwr.app.message import make_message
@@ -1312,23 +1311,19 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         task_ids: Sequence[int] | None = None,
     ) -> Sequence[TaskUsage]:
         """Retrieve task usage records based on the specified filters."""
-        conditions: list[ColumnElement[bool]] = []
+        query = select(TaskUsageModel).order_by(TaskUsageModel.id.asc())
 
         if run_ids is not None:
             if not run_ids:
                 return []
             sint64_run_ids = [uint64_to_int64(run_id) for run_id in run_ids]
-            conditions.append(TaskUsageModel.run_id.in_(sint64_run_ids))
+            query = query.where(TaskUsageModel.run_id.in_(sint64_run_ids))
 
         if task_ids is not None:
             if not task_ids:
                 return []
             sint64_task_ids = [uint64_to_int64(task_id) for task_id in task_ids]
-            conditions.append(TaskUsageModel.task_id.in_(sint64_task_ids))
-
-        query = select(TaskUsageModel).order_by(TaskUsageModel.id.asc())
-        if conditions:
-            query = query.where(*conditions)
+            query = query.where(TaskUsageModel.task_id.in_(sint64_task_ids))
 
         with self.session() as session:
             rows = session.scalars(query).all()
@@ -1575,13 +1570,13 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
     ) -> Sequence[TaskEvent]:
         """Return task-produced run events after the cursor."""
         cursor = after_task_event_id if after_task_event_id is not None else 0
-        conditions: list[ColumnElement[bool]] = [TaskEventModel.id > cursor]
-        if run_id is not None:
-            conditions.append(TaskEventModel.run_id == uint64_to_int64(run_id))
-
         query = (
-            select(TaskEventModel).where(*conditions).order_by(TaskEventModel.id.asc())
+            select(TaskEventModel)
+            .where(TaskEventModel.id > cursor)
+            .order_by(TaskEventModel.id.asc())
         )
+        if run_id is not None:
+            query = query.where(TaskEventModel.run_id == uint64_to_int64(run_id))
 
         with self.session() as session:
             rows = session.scalars(query).all()


### PR DESCRIPTION
## Issue

### Description

Some CoreState read paths still use raw SQL even though matching SQLAlchemy ORM models exist.

### Related issues/PRs

Follow-up to the recent CoreState ORM model and read-path PRs.

## Proposal

### Explanation

Use SQLAlchemy ORM reads for task usage and task event lookup while preserving the existing filters, ordering, and proto conversion behavior.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [x] Address LLM-reviewer comments, if applicable
- [x] Make CI checks pass locally
- [x] Ping maintainers on Slack

### Any other comments?

Local validation:

```shell
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m pytest py/flwr/server/superlink/linkstate/linkstate_test.py -k 'task_usage or task_events'
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m black --check py/flwr/supercore/corestate/sql_corestate.py py/flwr/supercore/corestate/corestate_test.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m isort --check-only py/flwr/supercore/corestate/sql_corestate.py py/flwr/supercore/corestate/corestate_test.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m ruff check py/flwr/supercore/corestate/sql_corestate.py py/flwr/supercore/corestate/corestate_test.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m mypy py/flwr/supercore/corestate/sql_corestate.py py/flwr/supercore/corestate/corestate_test.py
PYTHONPATH=dev PYENV_VERSION=3.11 pyenv exec python -m devtool.check_pr_title 'refactor(framework): Use ORM for task usage and event reads'
git diff --check
```