### PR TITLE
refactor(framework): Use ORM for connector write paths

### DIFF
--- a/framework/py/flwr/supercore/corestate/corestate_test.py
+++ b/framework/py/flwr/supercore/corestate/corestate_test.py
@@ -126,6 +126,9 @@ class StateTest(unittest.TestCase):  # pylint: disable=R0904
         self.assertIsNone(
             state.get_connector(flwr_aid="account-a", connector_ref="calendar")
         )
+        self.assertFalse(
+            state.delete_connector(flwr_aid="account-a", connector_ref="calendar")
+        )
 
     def test_bind_and_get_run_connectors(self) -> None:
         """Run connector bindings should be deterministic and idempotent."""
@@ -195,7 +198,23 @@ class StateTest(unittest.TestCase):  # pylint: disable=R0904
             session,
         )
         self.assertIsNone(
+            state.create_connector_oauth_session(
+                oauth_session_id="session-1",
+                flwr_aid="account-a",
+                connector_ref="calendar",
+                state="oauth-state",
+                redirect_uri="https://example.test/callback",
+                pkce_verifier=None,
+                expires_at=expires_at,
+            )
+        )
+        self.assertIsNone(
             state.get_connector_oauth_session(
+                oauth_session_id="session-1", flwr_aid="account-b"
+            )
+        )
+        self.assertFalse(
+            state.complete_connector_oauth_session(
                 oauth_session_id="session-1", flwr_aid="account-b"
             )
         )
@@ -212,6 +231,21 @@ class StateTest(unittest.TestCase):  # pylint: disable=R0904
         self.assertFalse(
             state.complete_connector_oauth_session(
                 oauth_session_id="session-1", flwr_aid="account-a"
+            )
+        )
+        expired = state.create_connector_oauth_session(
+            oauth_session_id="expired-session",
+            flwr_aid="account-a",
+            connector_ref="calendar",
+            state="oauth-state",
+            redirect_uri="https://example.test/callback",
+            pkce_verifier=None,
+            expires_at=now() - timedelta(minutes=10),
+        )
+        assert expired is not None
+        self.assertFalse(
+            state.complete_connector_oauth_session(
+                oauth_session_id="expired-session", flwr_aid="account-a"
             )
         )
 

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -24,7 +24,7 @@ from logging import ERROR
 from typing import Any, Literal, cast
 from uuid import uuid4
 
-from sqlalchemy import MetaData, select, update
+from sqlalchemy import MetaData, delete, select, update
 from sqlalchemy.exc import IntegrityError
 
 from flwr.app import Context, Message
@@ -481,15 +481,15 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         if not flwr_aid or not connector_ref:
             return False
         with self.session() as session:
-            row = session.get(
-                ConnectorModel,
-                (flwr_aid, connector_ref),
-                populate_existing=True,
+            deleted_connector_ref = session.scalar(
+                delete(ConnectorModel)
+                .where(
+                    ConnectorModel.flwr_aid == flwr_aid,
+                    ConnectorModel.connector_ref == connector_ref,
+                )
+                .returning(ConnectorModel.connector_ref)
             )
-            if row is None:
-                return False
-            session.delete(row)
-        return True
+            return deleted_connector_ref is not None
 
     def bind_connectors_to_run(
         self, run_id: int, connector_refs: Sequence[str]
@@ -548,36 +548,24 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
             return None
         expires_at = expires_at.astimezone(UTC)
         created_at = now()
-        session = ConnectorOAuthSessionRecord(
+        model = ConnectorOAuthSessionModel(
             oauth_session_id=oauth_session_id,
             flwr_aid=flwr_aid,
             connector_ref=connector_ref,
             state=state,
             redirect_uri=redirect_uri,
             pkce_verifier=pkce_verifier,
-            created_at=created_at.isoformat(),
-            expires_at=expires_at.isoformat(),
+            created_at=created_at,
+            expires_at=expires_at,
             completed_at=None,
         )
         try:
             with self.session() as db_session:
-                db_session.add(
-                    ConnectorOAuthSessionModel(
-                        oauth_session_id=session.oauth_session_id,
-                        flwr_aid=session.flwr_aid,
-                        connector_ref=session.connector_ref,
-                        state=session.state,
-                        redirect_uri=session.redirect_uri,
-                        pkce_verifier=session.pkce_verifier,
-                        created_at=created_at,
-                        expires_at=expires_at,
-                        completed_at=None,
-                    )
-                )
+                db_session.add(model)
                 db_session.flush()
+                return _connector_oauth_session_from_model(model)
         except IntegrityError:
             return None
-        return session
 
     def get_connector_oauth_session(
         self, oauth_session_id: str, flwr_aid: str

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -1708,9 +1708,11 @@ def _connector_oauth_session_from_model(
 
 
 def _utc_timestamp_to_iso(value: datetime | str | None) -> str:
-    """Return an OAuth timestamp as an ISO string with UTC if omitted by SQLite."""
-    if isinstance(value, datetime) and value.tzinfo is None:
-        value = value.replace(tzinfo=UTC)
+    """Return an OAuth timestamp as a UTC ISO string."""
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=UTC)
+        value = value.astimezone(UTC)
     return timestamp_to_iso(value)
 
 

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -1701,18 +1701,16 @@ def _connector_oauth_session_from_model(
         state=row.state,
         redirect_uri=row.redirect_uri,
         pkce_verifier=row.pkce_verifier,
-        created_at=_utc_timestamp_to_iso(row.created_at),
-        expires_at=_utc_timestamp_to_iso(row.expires_at),
-        completed_at=_utc_timestamp_to_iso(row.completed_at) or None,
+        created_at=_timestamp_to_iso_assuming_utc(row.created_at),
+        expires_at=_timestamp_to_iso_assuming_utc(row.expires_at),
+        completed_at=_timestamp_to_iso_assuming_utc(row.completed_at) or None,
     )
 
 
-def _utc_timestamp_to_iso(value: datetime | str | None) -> str:
-    """Return an OAuth timestamp as a UTC ISO string."""
-    if isinstance(value, datetime):
-        if value.tzinfo is None:
-            value = value.replace(tzinfo=UTC)
-        value = value.astimezone(UTC)
+def _timestamp_to_iso_assuming_utc(value: datetime | str | None) -> str:
+    """Return an ISO string, treating naïve SQLite timestamps as UTC."""
+    if isinstance(value, datetime) and value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
     return timestamp_to_iso(value)
 
 

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -24,7 +24,7 @@ from logging import ERROR
 from typing import Any, Literal, cast
 from uuid import uuid4
 
-from sqlalchemy import MetaData, select
+from sqlalchemy import MetaData, select, update
 from sqlalchemy.exc import IntegrityError
 
 from flwr.app import Context, Message
@@ -480,27 +480,15 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Delete an account's connector if it exists."""
         if not flwr_aid or not connector_ref:
             return False
-        params = {"flwr_aid": flwr_aid, "connector_ref": connector_ref}
-        with self.session():
-            rows = self.query(
-                """
-                SELECT connector_ref
-                FROM connector
-                WHERE flwr_aid = :flwr_aid
-                  AND connector_ref = :connector_ref
-                """,
-                params,
+        with self.session() as session:
+            row = session.get(
+                ConnectorModel,
+                (flwr_aid, connector_ref),
+                populate_existing=True,
             )
-            if not rows:
+            if row is None:
                 return False
-            self.query(
-                """
-                DELETE FROM connector
-                WHERE flwr_aid = :flwr_aid
-                  AND connector_ref = :connector_ref
-                """,
-                params,
-            )
+            session.delete(row)
         return True
 
     def bind_connectors_to_run(
@@ -572,31 +560,21 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
             completed_at=None,
         )
         try:
-            self.query(
-                """
-                INSERT INTO connector_oauth_session (
-                    oauth_session_id, flwr_aid, connector_ref, state,
-                    redirect_uri, pkce_verifier, created_at, expires_at,
-                    completed_at
+            with self.session() as db_session:
+                db_session.add(
+                    ConnectorOAuthSessionModel(
+                        oauth_session_id=session.oauth_session_id,
+                        flwr_aid=session.flwr_aid,
+                        connector_ref=session.connector_ref,
+                        state=session.state,
+                        redirect_uri=session.redirect_uri,
+                        pkce_verifier=session.pkce_verifier,
+                        created_at=created_at,
+                        expires_at=expires_at,
+                        completed_at=None,
+                    )
                 )
-                VALUES (
-                    :oauth_session_id, :flwr_aid, :connector_ref, :state,
-                    :redirect_uri, :pkce_verifier, :created_at, :expires_at,
-                    :completed_at
-                )
-                """,
-                {
-                    "oauth_session_id": session.oauth_session_id,
-                    "flwr_aid": session.flwr_aid,
-                    "connector_ref": session.connector_ref,
-                    "state": session.state,
-                    "redirect_uri": session.redirect_uri,
-                    "pkce_verifier": session.pkce_verifier,
-                    "created_at": created_at,
-                    "expires_at": expires_at,
-                    "completed_at": session.completed_at,
-                },
-            )
+                db_session.flush()
         except IntegrityError:
             return None
         return session
@@ -625,23 +603,19 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         if not oauth_session_id or not flwr_aid:
             return False
         completed_at = now()
-        updated = self.query(
-            """
-            UPDATE connector_oauth_session
-            SET completed_at = :completed_at
-            WHERE oauth_session_id = :oauth_session_id
-              AND flwr_aid = :flwr_aid
-              AND completed_at IS NULL
-              AND expires_at > :completed_at
-            RETURNING oauth_session_id
-            """,
-            {
-                "oauth_session_id": oauth_session_id,
-                "flwr_aid": flwr_aid,
-                "completed_at": completed_at,
-            },
-        )
-        return bool(updated)
+        with self.session() as session:
+            updated_oauth_session_id = session.scalar(
+                update(ConnectorOAuthSessionModel)
+                .where(
+                    ConnectorOAuthSessionModel.oauth_session_id == oauth_session_id,
+                    ConnectorOAuthSessionModel.flwr_aid == flwr_aid,
+                    ConnectorOAuthSessionModel.completed_at.is_(None),
+                    ConnectorOAuthSessionModel.expires_at > completed_at,
+                )
+                .values(completed_at=completed_at)
+                .returning(ConnectorOAuthSessionModel.oauth_session_id)
+            )
+            return updated_oauth_session_id is not None
 
     def get_run_series(  # pylint: disable=R0914
         self,
@@ -1739,10 +1713,17 @@ def _connector_oauth_session_from_model(
         state=row.state,
         redirect_uri=row.redirect_uri,
         pkce_verifier=row.pkce_verifier,
-        created_at=timestamp_to_iso(row.created_at),
-        expires_at=timestamp_to_iso(row.expires_at),
-        completed_at=timestamp_to_iso(row.completed_at) or None,
+        created_at=_utc_timestamp_to_iso(row.created_at),
+        expires_at=_utc_timestamp_to_iso(row.expires_at),
+        completed_at=_utc_timestamp_to_iso(row.completed_at) or None,
     )
+
+
+def _utc_timestamp_to_iso(value: datetime | str | None) -> str:
+    """Return an OAuth timestamp as an ISO string with UTC if omitted by SQLite."""
+    if isinstance(value, datetime) and value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return timestamp_to_iso(value)
 
 
 def determine_task_status(row: dict[str, Any]) -> TaskStatus:


### PR DESCRIPTION
## Issue

### Description

Some CoreState connector write paths still use raw SQL even though matching SQLAlchemy ORM models exist.

### Related issues/PRs

Follow-up to the recent CoreState ORM read-path PRs.

## Proposal

### Explanation

Use SQLAlchemy ORM operations for connector deletion and connector OAuth session creation/completion while preserving existing ownership checks, duplicate-session handling, expiry checks, and one-time completion behavior.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [x] Address LLM-reviewer comments, if applicable
- [x] Make CI checks pass locally
- [x] Ping maintainers on Slack

### Any other comments?

Local validation:

```shell
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/server/superlink/linkstate/linkstate_test.py -k 'connector'
uv run --no-sync --python=3.11.14 python -m black --check py/flwr/supercore/corestate/sql_corestate.py py/flwr/supercore/corestate/corestate_test.py
uv run --no-sync --python=3.11.14 python -m isort --check-only py/flwr/supercore/corestate/sql_corestate.py py/flwr/supercore/corestate/corestate_test.py
uv run --no-sync --python=3.11.14 python -m ruff check py/flwr/supercore/corestate/sql_corestate.py py/flwr/supercore/corestate/corestate_test.py
uv run --no-sync --python=3.11.14 python -m mypy py/flwr/supercore/corestate/sql_corestate.py py/flwr/supercore/corestate/corestate_test.py
PYTHONPATH=dev PYENV_VERSION=3.11 pyenv exec python -m devtool.check_pr_title 'refactor(framework): Use ORM for connector write paths'
git diff --check
```