### PR TITLE
refactor(framework): Use ORM for task message reads

### DIFF
--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -32,6 +32,7 @@ from typing import Any
 from unittest.mock import Mock, PropertyMock, patch
 from uuid import uuid4
 
+from google.protobuf.message import DecodeError
 from parameterized import parameterized
 
 from flwr.app import DEFAULT_TTL, Error, Message, RecordDict
@@ -63,6 +64,7 @@ from flwr.supercore.constant import (
 )
 from flwr.supercore.corestate import CoreState
 from flwr.supercore.corestate.corestate_test import StateTest as CoreStateTest
+from flwr.supercore.corestate.utils_test import create_task_message
 from flwr.supercore.date import now
 from flwr.supercore.fab import Fab
 from flwr.supercore.inflatable.inflatable_object import get_object_tree
@@ -70,6 +72,7 @@ from flwr.supercore.object_store.object_store_factory import ObjectStoreFactory
 from flwr.supercore.primitives.asymmetric import generate_key_pairs, public_key_to_bytes
 from flwr.supercore.state.schema.corestate_models import Connector as ConnectorModel
 from flwr.supercore.state.schema.corestate_models import Fab as FabModel
+from flwr.supercore.utils import uint64_to_int64
 from flwr.superlink.federation import NoOpFederationManager
 
 
@@ -2391,6 +2394,64 @@ class SqlInMemoryStateTest(StateTest, unittest.TestCase):
         assert second is not None
         self.assertEqual(second.credentials_json, '{"token":"new"}')
         self.assertEqual(second.config_json, '{"calendar":"work"}')
+
+    def test_get_task_message_commits_claim_before_deserialization(self) -> None:
+        """Malformed claimed task Messages should not remain queued forever."""
+        state = self.state_factory()
+        run_id = create_dummy_run(state)
+        src_task_id = state.create_task(task_type=TaskType.AGENT_APP, run_id=run_id)
+        dst_task_id = state.create_task(task_type=TaskType.MODEL, run_id=run_id)
+        assert src_task_id is not None and dst_task_id is not None
+
+        current = now().timestamp()
+        valid_message = create_task_message(
+            src_task_id,
+            dst_task_id,
+            run_id,
+            created_at=current + 1.0,
+        )
+        self.assertTrue(state.store_task_message(valid_message))
+        state.query(
+            """
+            INSERT INTO task_message (
+                message_id, run_id, src_task_id, dst_task_id,
+                reply_to_message_id, created_at, ttl, message_type, content, error
+            )
+            VALUES (
+                :message_id, :run_id, :src_task_id, :dst_task_id,
+                :reply_to_message_id, :created_at, :ttl, :message_type, :content,
+                :error
+            )
+            """,
+            {
+                "message_id": str(uuid4()),
+                "run_id": uint64_to_int64(run_id),
+                "src_task_id": uint64_to_int64(src_task_id),
+                "dst_task_id": uint64_to_int64(dst_task_id),
+                "reply_to_message_id": "",
+                "created_at": current,
+                "ttl": DEFAULT_TTL,
+                "message_type": valid_message.metadata.message_type,
+                "content": b"\xff",
+                "error": None,
+            },
+        )
+
+        with self.assertRaises(DecodeError):
+            state.get_task_message(
+                dst_task_ids=[dst_task_id], order_by="created_at", limit=2
+            )
+
+        rows = state.query(
+            """
+            SELECT COUNT(*) AS message_count
+            FROM task_message
+            WHERE dst_task_id = :dst_task_id
+            """,
+            {"dst_task_id": uint64_to_int64(dst_task_id)},
+        )
+        self.assertEqual(rows[0]["message_count"], 0)
+        self.assertEqual(state.get_task_message(dst_task_ids=[dst_task_id]), [])
 
     def test_run_series_distinguishes_missing_and_empty_descriptions(self) -> None:
         """Missing and explicitly empty descriptions remain distinct in SQL."""

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -1552,8 +1552,13 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
             # Materialize candidates before deleting. Some backends can otherwise
             # re-evaluate same-table subqueries while DELETE scans rows.
             if self.select_lock_sql:
+                if self.select_lock_sql.strip().upper() != "FOR UPDATE SKIP LOCKED":
+                    raise NotImplementedError(
+                        "Custom select_lock_sql values are not supported for ORM "
+                        "task_message claims."
+                    )
                 query = query.with_for_update(skip_locked=True)
-            selected = query.subquery()
+            selected = query.cte("selected")
             delete_query = delete(TaskMessageModel).where(
                 TaskMessageModel.message_id.in_(select(selected.c.message_id))
             )
@@ -1619,7 +1624,7 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
             self._on_task_tokens_expired([task_from_row(row) for row in rows])
 
     def _cleanup_invalid_task_messages(self) -> None:
-        """Remove expired Messages and Messages for invalid destination tasks."""
+        """Remove expired task Messages."""
         with self.session() as session:
             session.execute(
                 delete(TaskMessageModel).where(

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -1471,7 +1471,8 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
             self._cleanup_expired_task_tokens()
             self._cleanup_invalid_task_messages()
             rows = self._claim_task_message_models(dst_task_ids, order_by, limit)
-            return [_task_message_from_model(row) for row in rows]
+            snapshots = [_task_message_snapshot_from_model(row) for row in rows]
+        return [_task_message_from_snapshot(row) for row in snapshots]
 
     def store_task_events(
         self,
@@ -1863,25 +1864,41 @@ def _task_message_to_row(message: Message) -> dict[str, Any]:
     }
 
 
-def _task_message_from_model(model: TaskMessageModel) -> Message:
-    """Convert a task_message ORM model to a Message."""
+def _task_message_snapshot_from_model(model: TaskMessageModel) -> dict[str, Any]:
+    """Snapshot a claimed task_message model before the transaction commits."""
+    return {
+        "message_id": model.message_id,
+        "run_id": model.run_id,
+        "src_task_id": model.src_task_id,
+        "dst_task_id": model.dst_task_id,
+        "reply_to_message_id": model.reply_to_message_id,
+        "created_at": model.created_at,
+        "ttl": model.ttl,
+        "message_type": model.message_type,
+        "content": model.content,
+        "error": model.error,
+    }
+
+
+def _task_message_from_snapshot(row: dict[str, Any]) -> Message:
+    """Convert a claimed task_message snapshot to a Message."""
     content, error = None, None
-    if model.content is not None:
-        content = recorddict_from_proto(ProtoRecordDict.FromString(model.content))
-    if model.error is not None:
-        error = error_from_proto(ProtoError.FromString(model.error))
+    if row["content"] is not None:
+        content = recorddict_from_proto(ProtoRecordDict.FromString(row["content"]))
+    if row["error"] is not None:
+        error = error_from_proto(ProtoError.FromString(row["error"]))
 
     metadata = Metadata(
-        run_id=int64_to_uint64(model.run_id),
-        message_id=model.message_id,
+        run_id=int64_to_uint64(row["run_id"]),
+        message_id=row["message_id"],
         src_node_id=SUPERLINK_NODE_ID,
         dst_node_id=SUPERLINK_NODE_ID,
-        reply_to_message_id=model.reply_to_message_id or "",
+        reply_to_message_id=row["reply_to_message_id"] or "",
         group_id="",  # Task messages don't have this field for now
-        created_at=model.created_at,
-        ttl=model.ttl,
-        message_type=model.message_type,
-        src_task_id=int64_to_uint64(model.src_task_id),
-        dst_task_id=int64_to_uint64(model.dst_task_id),
+        created_at=row["created_at"],
+        ttl=row["ttl"],
+        message_type=row["message_type"],
+        src_task_id=int64_to_uint64(row["src_task_id"]),
+        dst_task_id=int64_to_uint64(row["dst_task_id"]),
     )
     return make_message(metadata=metadata, content=content, error=error)

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -75,6 +75,7 @@ from flwr.supercore.state.schema.corestate_models import (
 from flwr.supercore.state.schema.corestate_models import SeriesRuns as SeriesRunsModel
 from flwr.supercore.state.schema.corestate_models import Task as TaskModel
 from flwr.supercore.state.schema.corestate_models import TaskEvent as TaskEventModel
+from flwr.supercore.state.schema.corestate_models import TaskMessage as TaskMessageModel
 from flwr.supercore.state.schema.corestate_models import TaskUsage as TaskUsageModel
 from flwr.supercore.state.schema.corestate_tables import create_corestate_metadata
 from flwr.supercore.typing import ConnectorOAuthSessionRecord, ConnectorRecord
@@ -1469,9 +1470,8 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         with self.session():
             self._cleanup_expired_task_tokens()
             self._cleanup_invalid_task_messages()
-            rows = self._claim_task_message_rows(dst_task_ids, order_by, limit)
-
-        return [_task_message_from_row(row) for row in rows]
+            rows = self._claim_task_message_models(dst_task_ids, order_by, limit)
+            return [_task_message_from_model(row) for row in rows]
 
     def store_task_events(
         self,
@@ -1530,62 +1530,50 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
             rows = session.scalars(query).all()
             return [_task_event_from_model(row) for row in rows]
 
-    def _claim_task_message_rows(
+    def _claim_task_message_models(
         self,
         dst_task_ids: Sequence[int] | None,
         order_by: Literal["created_at"] | None,
         limit: int | None,
-    ) -> list[dict[str, Any]]:
+    ) -> list[TaskMessageModel]:
         """Atomically claim eligible task Messages."""
-        conditions: list[str] = []
-        params: dict[str, Any] = {}
+        query = select(TaskMessageModel.message_id)
 
         # Filter by destination task IDs
         if dst_task_ids is not None:
             sint64_dst_task_ids = [uint64_to_int64(t) for t in dst_task_ids]
-            placeholders, in_params = build_sql_in_params(sint64_dst_task_ids, "dtid")
-            conditions.append(f"dst_task_id IN ({placeholders})")
-            params.update(in_params)
-
-        where_clause = ("WHERE " + " AND ".join(conditions)) if conditions else ""
-        order_clause = f"ORDER BY {order_by}" if order_by else ""
-        limit_clause = "LIMIT :limit" if limit is not None else ""
-
+            query = query.where(TaskMessageModel.dst_task_id.in_(sint64_dst_task_ids))
+        if order_by is not None:
+            query = query.order_by(TaskMessageModel.created_at.asc())
         if limit is not None:
-            params["limit"] = limit
+            query = query.limit(limit)
 
         if order_by is not None or limit is not None:
             # Materialize candidates before deleting. Some backends can otherwise
             # re-evaluate same-table subqueries while DELETE scans rows.
-            # `self.select_lock_sql` is an optional clause for backends that support
-            # row-locking while selecting candidates. Keep it before LIMIT so locked
-            # rows are skipped before limiting the result set.
-            query = f"""
-                WITH selected AS (
-                    SELECT message_id
-                    FROM task_message
-                    {where_clause} {order_clause}
-                    {self.select_lock_sql}
-                    {limit_clause}
-                )
-                DELETE FROM task_message
-                WHERE message_id IN (SELECT message_id FROM selected)
-                RETURNING *
-            """
+            if self.select_lock_sql:
+                query = query.with_for_update(skip_locked=True)
+            selected = query.subquery()
+            delete_query = delete(TaskMessageModel).where(
+                TaskMessageModel.message_id.in_(select(selected.c.message_id))
+            )
         else:
-            query = f"""
-                DELETE FROM task_message
-                {where_clause}
-                RETURNING *
-            """
+            delete_query = delete(TaskMessageModel)
+            if dst_task_ids is not None:
+                sint64_dst_task_ids = [uint64_to_int64(t) for t in dst_task_ids]
+                delete_query = delete_query.where(
+                    TaskMessageModel.dst_task_id.in_(sint64_dst_task_ids)
+                )
 
-        rows = self.query(query, params)
+        returning_query = delete_query.returning(TaskMessageModel)
+        with self.session() as session:
+            rows = list(session.scalars(returning_query))
 
-        # Sort claimed rows in-memory if requested
-        # `ORDER BY` in the CTE determines which rows are claimed, but SQL does not
-        # guarantee that `DELETE ... RETURNING` returns them in that order.
+        # Sort claimed rows in memory if requested. `ORDER BY` in the candidate
+        # query determines which rows are claimed, but SQL does not guarantee that
+        # `DELETE ... RETURNING` returns them in that order.
         if order_by is not None:
-            rows.sort(key=lambda row: row[order_by])
+            rows.sort(key=lambda row: row.created_at)
 
         return rows
 
@@ -1632,13 +1620,13 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
 
     def _cleanup_invalid_task_messages(self) -> None:
         """Remove expired Messages and Messages for invalid destination tasks."""
-        self.query(
-            """
-            DELETE FROM task_message
-            WHERE (created_at + ttl) <= :current
-            """,
-            {"current": now().timestamp()},
-        )
+        with self.session() as session:
+            session.execute(
+                delete(TaskMessageModel).where(
+                    (TaskMessageModel.created_at + TaskMessageModel.ttl)
+                    <= now().timestamp()
+                )
+            )
 
     def _on_task_tokens_expired(self, tasks: list[Task]) -> None:
         """Handle cleanup of expired task tokens.
@@ -1870,25 +1858,25 @@ def _task_message_to_row(message: Message) -> dict[str, Any]:
     }
 
 
-def _task_message_from_row(row: dict[str, Any]) -> Message:
-    """Convert a task_message row to a Message."""
+def _task_message_from_model(model: TaskMessageModel) -> Message:
+    """Convert a task_message ORM model to a Message."""
     content, error = None, None
-    if row["content"] is not None:
-        content = recorddict_from_proto(ProtoRecordDict.FromString(row["content"]))
-    if row["error"] is not None:
-        error = error_from_proto(ProtoError.FromString(row["error"]))
+    if model.content is not None:
+        content = recorddict_from_proto(ProtoRecordDict.FromString(model.content))
+    if model.error is not None:
+        error = error_from_proto(ProtoError.FromString(model.error))
 
     metadata = Metadata(
-        run_id=int64_to_uint64(row["run_id"]),
-        message_id=row["message_id"],
+        run_id=int64_to_uint64(model.run_id),
+        message_id=model.message_id,
         src_node_id=SUPERLINK_NODE_ID,
         dst_node_id=SUPERLINK_NODE_ID,
-        reply_to_message_id=row["reply_to_message_id"] or "",
+        reply_to_message_id=model.reply_to_message_id or "",
         group_id="",  # Task messages don't have this field for now
-        created_at=row["created_at"],
-        ttl=row["ttl"],
-        message_type=row["message_type"],
-        src_task_id=int64_to_uint64(row["src_task_id"]),
-        dst_task_id=int64_to_uint64(row["dst_task_id"]),
+        created_at=model.created_at,
+        ttl=model.ttl,
+        message_type=model.message_type,
+        src_task_id=int64_to_uint64(model.src_task_id),
+        dst_task_id=int64_to_uint64(model.dst_task_id),
     )
     return make_message(metadata=metadata, content=content, error=error)


### PR DESCRIPTION
## Issue

### Description

`SqlCoreState.get_task_message` still claims task messages through manually assembled SQL even though the `task_message` table has a declarative SQLAlchemy model.

### Related issues/PRs

Follow-up to the CoreState ORM migration series.

## Proposal

### Explanation

Use the `TaskMessage` ORM model for task-message claim reads and expired-message cleanup while preserving the existing atomic delete-and-return behavior. The limited/ordered claim path still materializes candidates before deleting, and backends with row-locking enabled keep the `FOR UPDATE SKIP LOCKED` behavior through SQLAlchemy.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [x] Address LLM-reviewer comments, if applicable
- [x] Make CI checks pass
- [x] Ping maintainers on Slack

### Any other comments?

Validation:

```bash
cd framework
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m pytest py/flwr/server/superlink/linkstate/linkstate_test.py -k 'task_message'
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m pytest py/flwr/server/superlink/linkstate/linkstate_test.py -k 'commits_claim_before_deserialization'
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m pytest py/flwr/server/superlink/linkstate/linkstate_test.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m ruff check py/flwr/supercore/corestate/sql_corestate.py py/flwr/server/superlink/linkstate/linkstate_test.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m mypy py/flwr/supercore/corestate/sql_corestate.py py/flwr/server/superlink/linkstate/linkstate_test.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m black --check py/flwr/supercore/corestate/sql_corestate.py py/flwr/server/superlink/linkstate/linkstate_test.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m isort --check-only py/flwr/supercore/corestate/sql_corestate.py py/flwr/server/superlink/linkstate/linkstate_test.py
git diff --check
```