### PR TITLE
refactor(framework): Use ORM for simple CoreState writes

### DIFF
--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -2424,6 +2424,39 @@ class SqlInMemoryStateTest(StateTest, unittest.TestCase):
         )
         self.assertEqual([row["nonce"] for row in rows], ["duplicate"])
 
+    def test_reserve_nonce_duplicate_returns_false_in_shared_session(self) -> None:
+        """Duplicate nonce reservation is handled before outer commit."""
+        state = self.state_factory()
+        current = now().timestamp()
+
+        self.assertTrue(state.reserve_nonce("namespace", "duplicate", current + 100.0))
+        state.query(
+            """
+            INSERT INTO nonce_store (namespace, nonce, expires_at)
+            VALUES (:namespace, :nonce, :expires_at)
+            """,
+            {
+                "namespace": "namespace",
+                "nonce": "expired",
+                "expires_at": current - 100.0,
+            },
+        )
+
+        with state.session():
+            self.assertFalse(
+                state.reserve_nonce("namespace", "duplicate", current + 100.0)
+            )
+
+        rows = state.query(
+            """
+            SELECT nonce
+            FROM nonce_store
+            ORDER BY nonce
+            """,
+            {},
+        )
+        self.assertEqual([row["nonce"] for row in rows], ["duplicate"])
+
     def test_get_task_message_commits_claim_before_deserialization(self) -> None:
         """Malformed claimed task Messages should not remain queued forever."""
         state = self.state_factory()

--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -2395,6 +2395,35 @@ class SqlInMemoryStateTest(StateTest, unittest.TestCase):
         self.assertEqual(second.credentials_json, '{"token":"new"}')
         self.assertEqual(second.config_json, '{"calendar":"work"}')
 
+    def test_reserve_nonce_cleans_expired_rows_on_duplicate(self) -> None:
+        """Expired nonce cleanup commits even when reservation is duplicate."""
+        state = self.state_factory()
+        current = now().timestamp()
+
+        self.assertTrue(state.reserve_nonce("namespace", "duplicate", current + 100.0))
+        state.query(
+            """
+            INSERT INTO nonce_store (namespace, nonce, expires_at)
+            VALUES (:namespace, :nonce, :expires_at)
+            """,
+            {
+                "namespace": "namespace",
+                "nonce": "expired",
+                "expires_at": current - 100.0,
+            },
+        )
+
+        self.assertFalse(state.reserve_nonce("namespace", "duplicate", current + 100.0))
+        rows = state.query(
+            """
+            SELECT nonce
+            FROM nonce_store
+            ORDER BY nonce
+            """,
+            {},
+        )
+        self.assertEqual([row["nonce"] for row in rows], ["duplicate"])
+
     def test_get_task_message_commits_claim_before_deserialization(self) -> None:
         """Malformed claimed task Messages should not remain queued forever."""
         state = self.state_factory()

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -1643,12 +1643,6 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Atomically reserve a nonce in a namespace."""
         if namespace == "" or nonce == "":
             return False
-        with self.session() as session:
-            session.execute(
-                delete(NonceStoreModel).where(
-                    NonceStoreModel.expires_at < now().timestamp()
-                )
-            )
         stmt = sqlite_insert(NonceStoreModel).values(
             namespace=namespace, nonce=nonce, expires_at=expires_at
         )
@@ -1656,6 +1650,11 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
             index_elements=[NonceStoreModel.namespace, NonceStoreModel.nonce]
         )
         with self.session() as session:
+            session.execute(
+                delete(NonceStoreModel).where(
+                    NonceStoreModel.expires_at < now().timestamp()
+                )
+            )
             inserted_nonce = session.scalar(stmt.returning(NonceStoreModel.nonce))
             return inserted_nonce is not None
 

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -25,6 +25,7 @@ from typing import Any, Literal, cast
 from uuid import uuid4
 
 from sqlalchemy import MetaData, delete, or_, select, update
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
 
 from flwr.app import Context, Message
@@ -404,8 +405,16 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         }
         # Keep launch behavior: last write wins for metadata under the same
         # content hash.
+        stmt = sqlite_insert(FabModel).values(**params)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=[FabModel.fab_hash],
+            set_={
+                "content": stmt.excluded.content,
+                "verifications": stmt.excluded.verifications,
+            },
+        )
         with self.session() as session:
-            session.merge(FabModel(**params))
+            session.execute(stmt)
         return fab_hash
 
     def get_fab(self, fab_hash: str) -> Fab | None:
@@ -438,8 +447,16 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
             "credentials_json": credentials_json,
             "config_json": config_json,
         }
+        stmt = sqlite_insert(ConnectorModel).values(**params)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=[ConnectorModel.flwr_aid, ConnectorModel.connector_ref],
+            set_={
+                "credentials_json": stmt.excluded.credentials_json,
+                "config_json": stmt.excluded.config_json,
+            },
+        )
         with self.session() as session:
-            session.merge(ConnectorModel(**params))
+            session.execute(stmt)
         return True
 
     def get_connector(
@@ -669,10 +686,15 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Set the shared Context for the specified RunSeries."""
         sint_series_id = uint64_to_int64(series_id)
         context_bytes = context_to_bytes(context)
+        stmt = sqlite_insert(SeriesContextModel).values(
+            series_id=sint_series_id, context=context_bytes
+        )
+        stmt = stmt.on_conflict_do_update(
+            index_elements=[SeriesContextModel.series_id],
+            set_={"context": stmt.excluded.context},
+        )
         with self.session() as session:
-            session.merge(
-                SeriesContextModel(series_id=sint_series_id, context=context_bytes)
-            )
+            session.execute(stmt)
 
     def store_run_in_series(
         self,
@@ -1621,13 +1643,14 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Atomically reserve a nonce in a namespace."""
         if namespace == "" or nonce == "":
             return False
+        with self.session() as session:
+            session.execute(
+                delete(NonceStoreModel).where(
+                    NonceStoreModel.expires_at < now().timestamp()
+                )
+            )
         try:
             with self.session() as session:
-                session.execute(
-                    delete(NonceStoreModel).where(
-                        NonceStoreModel.expires_at < now().timestamp()
-                    )
-                )
                 session.add(
                     NonceStoreModel(
                         namespace=namespace,

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -65,6 +65,7 @@ from flwr.supercore.state.schema.corestate_models import (
     ConnectorOAuthSession as ConnectorOAuthSessionModel,
 )
 from flwr.supercore.state.schema.corestate_models import Fab as FabModel
+from flwr.supercore.state.schema.corestate_models import NonceStore as NonceStoreModel
 from flwr.supercore.state.schema.corestate_models import (
     RunConnector as RunConnectorModel,
 )
@@ -403,14 +404,8 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         }
         # Keep launch behavior: last write wins for metadata under the same
         # content hash.
-        query = """
-            INSERT INTO fab (fab_hash, content, verifications)
-            VALUES (:fab_hash, :content, :verifications)
-            ON CONFLICT(fab_hash) DO UPDATE SET
-                content = excluded.content,
-                verifications = excluded.verifications
-        """
-        self.query(query, params)
+        with self.session() as session:
+            session.merge(FabModel(**params))
         return fab_hash
 
     def get_fab(self, fab_hash: str) -> Fab | None:
@@ -443,20 +438,8 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
             "credentials_json": credentials_json,
             "config_json": config_json,
         }
-        self.query(
-            """
-            INSERT INTO connector (
-                flwr_aid, connector_ref, credentials_json, config_json
-            )
-            VALUES (
-                :flwr_aid, :connector_ref, :credentials_json, :config_json
-            )
-            ON CONFLICT(flwr_aid, connector_ref) DO UPDATE SET
-                credentials_json = excluded.credentials_json,
-                config_json = excluded.config_json
-            """,
-            params,
-        )
+        with self.session() as session:
+            session.merge(ConnectorModel(**params))
         return True
 
     def get_connector(
@@ -512,13 +495,8 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
             if connector_ref not in bound_refs
         ]
         if data:
-            self.query(
-                """
-                INSERT INTO run_connector (run_id, connector_ref)
-                VALUES (:run_id, :connector_ref)
-                """,
-                data,
-            )
+            with self.session() as session:
+                session.add_all(RunConnectorModel(**row) for row in data)
         return True
 
     def get_run_connector_refs(self, run_id: int) -> Sequence[str]:
@@ -691,15 +669,9 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Set the shared Context for the specified RunSeries."""
         sint_series_id = uint64_to_int64(series_id)
         context_bytes = context_to_bytes(context)
-        with self.session():
-            self.query(
-                """
-                INSERT INTO series_context (series_id, context)
-                VALUES (:series_id, :context)
-                ON CONFLICT(series_id) DO UPDATE SET
-                    context = excluded.context
-                """,
-                {"series_id": sint_series_id, "context": context_bytes},
+        with self.session() as session:
+            session.merge(
+                SeriesContextModel(series_id=sint_series_id, context=context_bytes)
             )
 
     def store_run_in_series(
@@ -1649,20 +1621,20 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Atomically reserve a nonce in a namespace."""
         if namespace == "" or nonce == "":
             return False
-        cleanup_query = """
-            DELETE FROM nonce_store
-            WHERE expires_at < :current;
-        """
-        insert_query = """
-            INSERT INTO nonce_store (namespace, nonce, expires_at)
-            VALUES (:namespace, :nonce, :expires_at);
-        """
-        self.query(cleanup_query, {"current": now().timestamp()})
         try:
-            self.query(
-                insert_query,
-                {"namespace": namespace, "nonce": nonce, "expires_at": expires_at},
-            )
+            with self.session() as session:
+                session.execute(
+                    delete(NonceStoreModel).where(
+                        NonceStoreModel.expires_at < now().timestamp()
+                    )
+                )
+                session.add(
+                    NonceStoreModel(
+                        namespace=namespace,
+                        nonce=nonce,
+                        expires_at=expires_at,
+                    )
+                )
             return True
         # Duplicate nonce detected, treated as a replay attempt.
         # IntegrityError can only arise from (namespace, nonce) uniqueness.

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -398,14 +398,13 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
             raise ValueError(
                 f"FAB hash mismatch: provided {fab.hash_str}, computed {fab_hash}"
             )
-        params = {
-            "fab_hash": fab_hash,
-            "content": fab.content,
-            "verifications": json.dumps(fab.verifications),
-        }
         # Keep launch behavior: last write wins for metadata under the same
         # content hash.
-        stmt = sqlite_insert(FabModel).values(**params)
+        stmt = sqlite_insert(FabModel).values(
+            fab_hash=fab_hash,
+            content=fab.content,
+            verifications=json.dumps(fab.verifications),
+        )
         stmt = stmt.on_conflict_do_update(
             index_elements=[FabModel.fab_hash],
             set_={
@@ -441,13 +440,12 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Create or update a connector for an account."""
         if not flwr_aid or not connector_ref:
             return False
-        params = {
-            "flwr_aid": flwr_aid,
-            "connector_ref": connector_ref,
-            "credentials_json": credentials_json,
-            "config_json": config_json,
-        }
-        stmt = sqlite_insert(ConnectorModel).values(**params)
+        stmt = sqlite_insert(ConnectorModel).values(
+            flwr_aid=flwr_aid,
+            connector_ref=connector_ref,
+            credentials_json=credentials_json,
+            config_json=config_json,
+        )
         stmt = stmt.on_conflict_do_update(
             index_elements=[ConnectorModel.flwr_aid, ConnectorModel.connector_ref],
             set_={
@@ -503,17 +501,14 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
             return False
         stored_run_id = uint64_to_int64(run_id)
         bound_refs = set(self.get_run_connector_refs(run_id))
-        data = [
-            {
-                "run_id": stored_run_id,
-                "connector_ref": connector_ref,
-            }
+        run_connectors = [
+            RunConnectorModel(run_id=stored_run_id, connector_ref=connector_ref)
             for connector_ref in dict.fromkeys(connector_refs)
             if connector_ref not in bound_refs
         ]
-        if data:
+        if run_connectors:
             with self.session() as session:
-                session.add_all(RunConnectorModel(**row) for row in data)
+                session.add_all(run_connectors)
         return True
 
     def get_run_connector_refs(self, run_id: int) -> Sequence[str]:

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -1649,20 +1649,15 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
                     NonceStoreModel.expires_at < now().timestamp()
                 )
             )
-        try:
-            with self.session() as session:
-                session.add(
-                    NonceStoreModel(
-                        namespace=namespace,
-                        nonce=nonce,
-                        expires_at=expires_at,
-                    )
-                )
-            return True
-        # Duplicate nonce detected, treated as a replay attempt.
-        # IntegrityError can only arise from (namespace, nonce) uniqueness.
-        except IntegrityError:
-            return False
+        stmt = sqlite_insert(NonceStoreModel).values(
+            namespace=namespace, nonce=nonce, expires_at=expires_at
+        )
+        stmt = stmt.on_conflict_do_nothing(
+            index_elements=[NonceStoreModel.namespace, NonceStoreModel.nonce]
+        )
+        with self.session() as session:
+            inserted_nonce = session.scalar(stmt.returning(NonceStoreModel.nonce))
+            return inserted_nonce is not None
 
 
 def _connector_oauth_session_from_model(


### PR DESCRIPTION
## Issue

### Description

Some simple `SqlCoreState` write paths still used raw SQL even though matching declarative SQLAlchemy models exist.

### Related issues/PRs

Follow-up to the CoreState ORM migration series.

## Proposal

### Explanation

Use ORM model operations for simple CoreState writes that do not require custom SQL control flow: FAB upsert, connector upsert, run connector binding, run-series context upsert, and nonce cleanup/reservation. This keeps behavior covered by the existing LinkState/CoreState test suite and avoids changing schema or migration files.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [x] Address LLM-reviewer comments, if applicable
- [x] Make CI checks pass
- [x] Ping maintainers on Slack

### Any other comments?

Validation:

```bash
cd framework
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m pytest py/flwr/server/superlink/linkstate/linkstate_test.py -k 'fab or connector or run_series_context or reserve_nonce'
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m pytest py/flwr/server/superlink/linkstate/linkstate_test.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m ruff check py/flwr/supercore/corestate/sql_corestate.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m mypy py/flwr/supercore/corestate/sql_corestate.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m black --check py/flwr/supercore/corestate/sql_corestate.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m isort --check-only py/flwr/supercore/corestate/sql_corestate.py
git diff --check
```

Remaining raw SQL inventory:

```bash
rg -n "self\\.query\\(|session\\.execute\\(|text\\(" framework/py/flwr/supercore/corestate/sql_corestate.py
```

Remaining raw SQL is still present in object-push sessions, run-series creation, automation, task lifecycle/logging/usage/message writes, and cleanup paths. Those paths are more concurrency-sensitive and/or timestamp-heavy, so they should be converted separately with targeted transaction and timestamp coverage.