### PR TITLE
refactor(framework): Fix ORM refactor error

### DIFF
--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -25,7 +25,6 @@ from typing import Any, Literal, cast
 from uuid import uuid4
 
 from sqlalchemy import MetaData, delete, or_, select, update
-from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
 
 from flwr.app import Context, Message
@@ -66,7 +65,6 @@ from flwr.supercore.state.schema.corestate_models import (
     ConnectorOAuthSession as ConnectorOAuthSessionModel,
 )
 from flwr.supercore.state.schema.corestate_models import Fab as FabModel
-from flwr.supercore.state.schema.corestate_models import NonceStore as NonceStoreModel
 from flwr.supercore.state.schema.corestate_models import (
     RunConnector as RunConnectorModel,
 )
@@ -400,20 +398,20 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
             )
         # Keep launch behavior: last write wins for metadata under the same
         # content hash.
-        stmt = sqlite_insert(FabModel).values(
-            fab_hash=fab_hash,
-            content=fab.content,
-            verifications=json.dumps(fab.verifications),
-        )
-        stmt = stmt.on_conflict_do_update(
-            index_elements=[FabModel.fab_hash],
-            set_={
-                "content": stmt.excluded.content,
-                "verifications": stmt.excluded.verifications,
+        self.query(
+            """
+            INSERT INTO fab (fab_hash, content, verifications)
+            VALUES (:fab_hash, :content, :verifications)
+            ON CONFLICT(fab_hash) DO UPDATE SET
+                content = excluded.content,
+                verifications = excluded.verifications
+            """,
+            {
+                "fab_hash": fab_hash,
+                "content": fab.content,
+                "verifications": json.dumps(fab.verifications),
             },
         )
-        with self.session() as session:
-            session.execute(stmt)
         return fab_hash
 
     def get_fab(self, fab_hash: str) -> Fab | None:
@@ -440,21 +438,25 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Create or update a connector for an account."""
         if not flwr_aid or not connector_ref:
             return False
-        stmt = sqlite_insert(ConnectorModel).values(
-            flwr_aid=flwr_aid,
-            connector_ref=connector_ref,
-            credentials_json=credentials_json,
-            config_json=config_json,
-        )
-        stmt = stmt.on_conflict_do_update(
-            index_elements=[ConnectorModel.flwr_aid, ConnectorModel.connector_ref],
-            set_={
-                "credentials_json": stmt.excluded.credentials_json,
-                "config_json": stmt.excluded.config_json,
+        self.query(
+            """
+            INSERT INTO connector (
+                flwr_aid, connector_ref, credentials_json, config_json
+            )
+            VALUES (
+                :flwr_aid, :connector_ref, :credentials_json, :config_json
+            )
+            ON CONFLICT(flwr_aid, connector_ref) DO UPDATE SET
+                credentials_json = excluded.credentials_json,
+                config_json = excluded.config_json
+            """,
+            {
+                "flwr_aid": flwr_aid,
+                "connector_ref": connector_ref,
+                "credentials_json": credentials_json,
+                "config_json": config_json,
             },
         )
-        with self.session() as session:
-            session.execute(stmt)
         return True
 
     def get_connector(
@@ -681,15 +683,15 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Set the shared Context for the specified RunSeries."""
         sint_series_id = uint64_to_int64(series_id)
         context_bytes = context_to_bytes(context)
-        stmt = sqlite_insert(SeriesContextModel).values(
-            series_id=sint_series_id, context=context_bytes
+        self.query(
+            """
+            INSERT INTO series_context (series_id, context)
+            VALUES (:series_id, :context)
+            ON CONFLICT(series_id) DO UPDATE SET
+                context = excluded.context
+            """,
+            {"series_id": sint_series_id, "context": context_bytes},
         )
-        stmt = stmt.on_conflict_do_update(
-            index_elements=[SeriesContextModel.series_id],
-            set_={"context": stmt.excluded.context},
-        )
-        with self.session() as session:
-            session.execute(stmt)
 
     def store_run_in_series(
         self,
@@ -1638,20 +1640,28 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Atomically reserve a nonce in a namespace."""
         if namespace == "" or nonce == "":
             return False
-        stmt = sqlite_insert(NonceStoreModel).values(
-            namespace=namespace, nonce=nonce, expires_at=expires_at
-        )
-        stmt = stmt.on_conflict_do_nothing(
-            index_elements=[NonceStoreModel.namespace, NonceStoreModel.nonce]
-        )
-        with self.session() as session:
-            session.execute(
-                delete(NonceStoreModel).where(
-                    NonceStoreModel.expires_at < now().timestamp()
-                )
+        with self.session():
+            self.query(
+                """
+                DELETE FROM nonce_store
+                WHERE expires_at < :current
+                """,
+                {"current": now().timestamp()},
             )
-            inserted_nonce = session.scalar(stmt.returning(NonceStoreModel.nonce))
-            return inserted_nonce is not None
+            rows = self.query(
+                """
+                INSERT INTO nonce_store (namespace, nonce, expires_at)
+                VALUES (:namespace, :nonce, :expires_at)
+                ON CONFLICT(namespace, nonce) DO NOTHING
+                RETURNING nonce
+                """,
+                {
+                    "namespace": namespace,
+                    "nonce": nonce,
+                    "expires_at": expires_at,
+                },
+            )
+            return bool(rows)
 
 
 def _connector_oauth_session_from_model(

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -65,7 +65,6 @@ from flwr.supercore.state.schema.corestate_models import (
     ConnectorOAuthSession as ConnectorOAuthSessionModel,
 )
 from flwr.supercore.state.schema.corestate_models import Fab as FabModel
-from flwr.supercore.state.schema.corestate_models import NonceStore as NonceStoreModel
 from flwr.supercore.state.schema.corestate_models import (
     RunConnector as RunConnectorModel,
 )
@@ -399,14 +398,20 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
             )
         # Keep launch behavior: last write wins for metadata under the same
         # content hash.
-        with self.session() as session:
-            session.merge(
-                FabModel(
-                    fab_hash=fab_hash,
-                    content=fab.content,
-                    verifications=json.dumps(fab.verifications),
-                )
-            )
+        self.query(
+            """
+            INSERT INTO fab (fab_hash, content, verifications)
+            VALUES (:fab_hash, :content, :verifications)
+            ON CONFLICT(fab_hash) DO UPDATE SET
+                content = excluded.content,
+                verifications = excluded.verifications
+            """,
+            {
+                "fab_hash": fab_hash,
+                "content": fab.content,
+                "verifications": json.dumps(fab.verifications),
+            },
+        )
         return fab_hash
 
     def get_fab(self, fab_hash: str) -> Fab | None:
@@ -433,15 +438,25 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Create or update a connector for an account."""
         if not flwr_aid or not connector_ref:
             return False
-        with self.session() as session:
-            session.merge(
-                ConnectorModel(
-                    flwr_aid=flwr_aid,
-                    connector_ref=connector_ref,
-                    credentials_json=credentials_json,
-                    config_json=config_json,
-                )
+        self.query(
+            """
+            INSERT INTO connector (
+                flwr_aid, connector_ref, credentials_json, config_json
             )
+            VALUES (
+                :flwr_aid, :connector_ref, :credentials_json, :config_json
+            )
+            ON CONFLICT(flwr_aid, connector_ref) DO UPDATE SET
+                credentials_json = excluded.credentials_json,
+                config_json = excluded.config_json
+            """,
+            {
+                "flwr_aid": flwr_aid,
+                "connector_ref": connector_ref,
+                "credentials_json": credentials_json,
+                "config_json": config_json,
+            },
+        )
         return True
 
     def get_connector(
@@ -668,10 +683,15 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Set the shared Context for the specified RunSeries."""
         sint_series_id = uint64_to_int64(series_id)
         context_bytes = context_to_bytes(context)
-        with self.session() as session:
-            session.merge(
-                SeriesContextModel(series_id=sint_series_id, context=context_bytes)
-            )
+        self.query(
+            """
+            INSERT INTO series_context (series_id, context)
+            VALUES (:series_id, :context)
+            ON CONFLICT(series_id) DO UPDATE SET
+                context = excluded.context
+            """,
+            {"series_id": sint_series_id, "context": context_bytes},
+        )
 
     def store_run_in_series(
         self,
@@ -1620,27 +1640,28 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Atomically reserve a nonce in a namespace."""
         if namespace == "" or nonce == "":
             return False
-        with self.session() as session:
-            session.execute(
-                delete(NonceStoreModel).where(
-                    NonceStoreModel.expires_at < now().timestamp()
-                )
+        with self.session():
+            self.query(
+                """
+                DELETE FROM nonce_store
+                WHERE expires_at < :current
+                """,
+                {"current": now().timestamp()},
             )
-            try:
-                # Isolate a uniqueness conflict so an existing outer transaction
-                # remains usable and the expired-row cleanup can still commit.
-                with session.begin_nested():
-                    session.add(
-                        NonceStoreModel(
-                            namespace=namespace,
-                            nonce=nonce,
-                            expires_at=expires_at,
-                        )
-                    )
-                    session.flush()
-                return True
-            except IntegrityError:
-                return False
+            rows = self.query(
+                """
+                INSERT INTO nonce_store (namespace, nonce, expires_at)
+                VALUES (:namespace, :nonce, :expires_at)
+                ON CONFLICT(namespace, nonce) DO NOTHING
+                RETURNING nonce
+                """,
+                {
+                    "namespace": namespace,
+                    "nonce": nonce,
+                    "expires_at": expires_at,
+                },
+            )
+            return bool(rows)
 
 
 def _connector_oauth_session_from_model(

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -65,6 +65,7 @@ from flwr.supercore.state.schema.corestate_models import (
     ConnectorOAuthSession as ConnectorOAuthSessionModel,
 )
 from flwr.supercore.state.schema.corestate_models import Fab as FabModel
+from flwr.supercore.state.schema.corestate_models import NonceStore as NonceStoreModel
 from flwr.supercore.state.schema.corestate_models import (
     RunConnector as RunConnectorModel,
 )
@@ -398,20 +399,14 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
             )
         # Keep launch behavior: last write wins for metadata under the same
         # content hash.
-        self.query(
-            """
-            INSERT INTO fab (fab_hash, content, verifications)
-            VALUES (:fab_hash, :content, :verifications)
-            ON CONFLICT(fab_hash) DO UPDATE SET
-                content = excluded.content,
-                verifications = excluded.verifications
-            """,
-            {
-                "fab_hash": fab_hash,
-                "content": fab.content,
-                "verifications": json.dumps(fab.verifications),
-            },
-        )
+        with self.session() as session:
+            session.merge(
+                FabModel(
+                    fab_hash=fab_hash,
+                    content=fab.content,
+                    verifications=json.dumps(fab.verifications),
+                )
+            )
         return fab_hash
 
     def get_fab(self, fab_hash: str) -> Fab | None:
@@ -438,25 +433,15 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Create or update a connector for an account."""
         if not flwr_aid or not connector_ref:
             return False
-        self.query(
-            """
-            INSERT INTO connector (
-                flwr_aid, connector_ref, credentials_json, config_json
+        with self.session() as session:
+            session.merge(
+                ConnectorModel(
+                    flwr_aid=flwr_aid,
+                    connector_ref=connector_ref,
+                    credentials_json=credentials_json,
+                    config_json=config_json,
+                )
             )
-            VALUES (
-                :flwr_aid, :connector_ref, :credentials_json, :config_json
-            )
-            ON CONFLICT(flwr_aid, connector_ref) DO UPDATE SET
-                credentials_json = excluded.credentials_json,
-                config_json = excluded.config_json
-            """,
-            {
-                "flwr_aid": flwr_aid,
-                "connector_ref": connector_ref,
-                "credentials_json": credentials_json,
-                "config_json": config_json,
-            },
-        )
         return True
 
     def get_connector(
@@ -683,15 +668,10 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Set the shared Context for the specified RunSeries."""
         sint_series_id = uint64_to_int64(series_id)
         context_bytes = context_to_bytes(context)
-        self.query(
-            """
-            INSERT INTO series_context (series_id, context)
-            VALUES (:series_id, :context)
-            ON CONFLICT(series_id) DO UPDATE SET
-                context = excluded.context
-            """,
-            {"series_id": sint_series_id, "context": context_bytes},
-        )
+        with self.session() as session:
+            session.merge(
+                SeriesContextModel(series_id=sint_series_id, context=context_bytes)
+            )
 
     def store_run_in_series(
         self,
@@ -1640,28 +1620,27 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         """Atomically reserve a nonce in a namespace."""
         if namespace == "" or nonce == "":
             return False
-        with self.session():
-            self.query(
-                """
-                DELETE FROM nonce_store
-                WHERE expires_at < :current
-                """,
-                {"current": now().timestamp()},
+        with self.session() as session:
+            session.execute(
+                delete(NonceStoreModel).where(
+                    NonceStoreModel.expires_at < now().timestamp()
+                )
             )
-            rows = self.query(
-                """
-                INSERT INTO nonce_store (namespace, nonce, expires_at)
-                VALUES (:namespace, :nonce, :expires_at)
-                ON CONFLICT(namespace, nonce) DO NOTHING
-                RETURNING nonce
-                """,
-                {
-                    "namespace": namespace,
-                    "nonce": nonce,
-                    "expires_at": expires_at,
-                },
-            )
-            return bool(rows)
+            try:
+                # Isolate a uniqueness conflict so an existing outer transaction
+                # remains usable and the expired-row cleanup can still commit.
+                with session.begin_nested():
+                    session.add(
+                        NonceStoreModel(
+                            namespace=namespace,
+                            nonce=nonce,
+                            expires_at=expires_at,
+                        )
+                    )
+                    session.flush()
+                return True
+            except IntegrityError:
+                return False
 
 
 def _connector_oauth_session_from_model(


### PR DESCRIPTION
Fix ORM refactor error for PostgresSQL:
  - Removed SQLite-specific sqlite_insert.
  - Restored portable upserts for:
      - FAB storage
      - connectors
      - run-series context
      - nonce reservation

  - Preserved duplicate handling and shared-session transaction behavior.