### PR TITLE
fix(framework): Improve ServerAppIo/ClientAppIo consistency

### DIFF
--- a/framework/py/flwr/supercore/servicer/appio/error_details.py
+++ b/framework/py/flwr/supercore/servicer/appio/error_details.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Stable error details shared by Runtime API implementations."""
+
+
+RUN_ID_MISMATCH = "Run ID does not match the authenticated task."
+
+
+def malformed_request(method: str, reason: str) -> str:
+    """Return stable details for a malformed request."""
+    return f"Malformed {method} request: {reason.rstrip('.')}."
+
+
+def task_transition_failed(task_id: int) -> str:
+    """Return stable details for a failed task-completion transition."""
+    return f"Task {task_id} cannot transition to FINISHED."

--- a/framework/py/flwr/superlink/servicer/serverappio/serverappio_servicer.py
+++ b/framework/py/flwr/superlink/servicer/serverappio/serverappio_servicer.py
@@ -74,6 +74,11 @@ from flwr.supercore.inflatable.inflatable_object import (
 from flwr.supercore.interceptors import get_authenticated_task
 from flwr.supercore.object_store import NoObjectInStoreError, ObjectStoreFactory
 from flwr.supercore.servicer.appio import AppIoServicer
+from flwr.supercore.servicer.appio.error_details import (
+    RUN_ID_MISMATCH,
+    malformed_request,
+    task_transition_failed,
+)
 from flwr.superlink.servicer.control.control_handlers import (
     process_due_automations,
     start_automation,
@@ -133,30 +138,14 @@ class ServerAppIoServicer(AppIoServicer, serverappio_pb2_grpc.ServerAppIoService
 
         run_id = _get_authenticated_serverapp_run_id(context)
 
-        # Validate request and insert in State
-        _raise_if(
-            validation_error=len(request.messages_list) == 0,
-            request_name="PushMessages",
-            detail="`messages_list` must not be empty",
-        )
+        messages = _validate_push_messages_request(request, context, run_id)
+
         session_id = state.start_session(run_id)
         message_ids: list[str] = []
         missing_objects_lists: list[list[str]] = []
-        for message_proto, object_tree in zip(
-            request.messages_list, request.message_object_trees, strict=True
+        for message, object_tree in zip(
+            messages, request.message_object_trees, strict=True
         ):
-            message = message_from_proto(message_proto=message_proto)
-            validation_errors = validate_message(message, is_reply_message=False)
-            _raise_if(
-                validation_error=bool(validation_errors),
-                request_name="PushMessages",
-                detail=", ".join(validation_errors),
-            )
-            _raise_if(
-                validation_error=run_id != message.metadata.run_id,
-                request_name="PushMessages",
-                detail="`Message.metadata` has mismatched `run_id`",
-            )
             # Store message and register in ObjectStore
             stored, missing_objects = state.store_message_and_object_tree(
                 message, object_tree, session_id
@@ -343,26 +332,26 @@ class ServerAppIoServicer(AppIoServicer, serverappio_pb2_grpc.ServerAppIoService
         # Init state and store
         state = self.state_factory.state()
 
-        # Store Simulation Runtime usage before finishing the primary task.
-        # This ensures usage is captured even if the task fails to finish properly.
-        if request.HasField("clientapp_runtime"):
-            state.add_clientapp_runtime(run_id, request.clientapp_runtime)
-
         # Finish the task
-        if state.finish_task(
+        if not state.finish_task(
             task.task_id, sub_status=request.sub_status, details=request.details
         ):
-            log(INFO, "Finished task %d of run %d", task.task_id, run_id)
-            if request.HasField("context"):
-                runs = state.get_run_info(run_ids=[run_id])
-                run = runs[0] if runs else None
-                if run and run.series_id and run.primary_task_id == task.task_id:
-                    state.set_run_series_context(
-                        run.series_id,
-                        context_from_proto(request.context),
-                    )
-        else:
-            log(ERROR, "Failed to finish task %d of run %s", task.task_id, run_id)
+            context.abort(
+                grpc.StatusCode.FAILED_PRECONDITION,
+                task_transition_failed(task.task_id),
+            )
+
+        log(INFO, "Finished task %d of run %d", task.task_id, run_id)
+        if request.HasField("clientapp_runtime"):
+            state.add_clientapp_runtime(run_id, request.clientapp_runtime)
+        if request.HasField("context"):
+            runs = state.get_run_info(run_ids=[run_id])
+            run = runs[0] if runs else None
+            if run and run.series_id and run.primary_task_id == task.task_id:
+                state.set_run_series_context(
+                    run.series_id,
+                    context_from_proto(request.context),
+                )
         return PushTaskOutputResponse()
 
     def StartAutomation(
@@ -470,6 +459,56 @@ def _get_authenticated_serverapp_run_id(context: grpc.ServicerContext) -> int:
             SERVERAPPIO_ENDPOINT_UNAVAILABLE_MESSAGE,
         )
     return task.run_id
+
+
+def _validate_push_messages_request(
+    request: PushAppMessagesRequest,
+    context: grpc.ServicerContext,
+    run_id: int,
+) -> list[Message]:
+    """Validate and deserialize PushMessages without mutating state."""
+    message_count = len(request.messages_list)
+    if message_count == 0:
+        context.abort(
+            grpc.StatusCode.INVALID_ARGUMENT,
+            malformed_request("PushMessages", "messages_list must not be empty"),
+        )
+    if message_count != len(request.message_object_trees):
+        context.abort(
+            grpc.StatusCode.INVALID_ARGUMENT,
+            malformed_request(
+                "PushMessages",
+                "messages_list and message_object_trees must contain the same number "
+                "of entries",
+            ),
+        )
+
+    messages: list[Message] = []
+    for index, (message_proto, object_tree) in enumerate(
+        zip(request.messages_list, request.message_object_trees, strict=True)
+    ):
+        message = message_from_proto(message_proto=message_proto)
+        validation_errors = validate_message(message, is_reply_message=False)
+        if validation_errors:
+            context.abort(
+                grpc.StatusCode.INVALID_ARGUMENT,
+                malformed_request(
+                    "PushMessages",
+                    f"message at index {index}: {', '.join(validation_errors)}",
+                ),
+            )
+        if run_id != message.metadata.run_id:
+            context.abort(grpc.StatusCode.PERMISSION_DENIED, RUN_ID_MISMATCH)
+        if object_tree.object_id != message.metadata.message_id:
+            context.abort(
+                grpc.StatusCode.INVALID_ARGUMENT,
+                malformed_request(
+                    "PushMessages",
+                    f"object tree at index {index} does not match the message ID",
+                ),
+            )
+        messages.append(message)
+    return messages
 
 
 def _raise_if(validation_error: bool, request_name: str, detail: str) -> None:

--- a/framework/py/flwr/superlink/servicer/serverappio/serverappio_servicer_test.py
+++ b/framework/py/flwr/superlink/servicer/serverappio/serverappio_servicer_test.py
@@ -548,6 +548,29 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
         assert run.primary_task_id is not None
         return run.primary_task_id
 
+    def _assert_push_messages_rejected(
+        self,
+        request: PushAppMessagesRequest,
+        code: grpc.StatusCode,
+        details: str,
+    ) -> None:
+        """Assert PushMessages rejects a request before starting a session."""
+        message_ins_count = self.state.num_message_ins()
+        message_res_count = self.state.num_message_res()
+        with (
+            patch.object(
+                self.state, "start_session", wraps=self.state.start_session
+            ) as start_session,
+            self.assertRaises(grpc.RpcError) as exc,
+        ):
+            self._push_messages(request)
+
+        self.assertEqual(exc.exception.code(), code)
+        self.assertEqual(exc.exception.details(), details)
+        start_session.assert_not_called()
+        self.assertEqual(self.state.num_message_ins(), message_ins_count)
+        self.assertEqual(self.state.num_message_res(), message_res_count)
+
     def _transition_run_status(self, run_id: int, num_transitions: int) -> None:
         task_id = self._primary_task_id(run_id)
         if num_transitions > 0:
@@ -698,6 +721,39 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
         run = self.state.get_run_info(run_ids=[self._auth_run_id])[0]
         assert run.clientapp_runtime == 7.89
 
+    def test_push_task_output_rejects_failed_transition(self) -> None:
+        """PushTaskOutput should expose a failed finish transition."""
+        task_id = self._primary_task_id(self._auth_run_id)
+        request = PushTaskOutputRequest(
+            sub_status=SubStatus.COMPLETED,
+            clientapp_runtime=7.89,
+            context=context_to_proto(
+                Context(
+                    run_id=self._auth_run_id,
+                    node_id=SUPERLINK_NODE_ID,
+                    node_config={},
+                    state=RecordDict(),
+                    run_config={},
+                )
+            ),
+        )
+
+        with (
+            patch.object(self.state, "finish_task", return_value=False),
+            patch.object(self.state, "add_clientapp_runtime") as add_runtime,
+            patch.object(self.state, "set_run_series_context") as set_context,
+            self.assertRaises(grpc.RpcError) as exc,
+        ):
+            self._push_task_output(request)
+
+        self.assertEqual(exc.exception.code(), grpc.StatusCode.FAILED_PRECONDITION)
+        self.assertEqual(
+            exc.exception.details(),
+            f"Task {task_id} cannot transition to FINISHED.",
+        )
+        add_runtime.assert_not_called()
+        set_context.assert_not_called()
+
     def test_push_task_output_stores_run_series_context(self) -> None:
         """PushTaskOutput should persist context in the authenticated run series."""
         # Prepare
@@ -737,6 +793,83 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
         # Assert
         assert isinstance(response, GetNodesResponse)
         assert grpc.StatusCode.OK == call.code()
+
+    def test_push_messages_rejects_empty_request(self) -> None:
+        """PushMessages should reject an empty request as malformed."""
+        self._assert_push_messages_rejected(
+            PushAppMessagesRequest(),
+            grpc.StatusCode.INVALID_ARGUMENT,
+            "Malformed PushMessages request: messages_list must not be empty.",
+        )
+
+    def test_push_messages_rejects_mismatched_cardinality(self) -> None:
+        """PushMessages should reject unpaired repeated fields."""
+        message = create_ins_message(
+            src_node_id=SUPERLINK_NODE_ID,
+            dst_node_id=self.node_id,
+            run_id=self._auth_run_id,
+        )
+        self._assert_push_messages_rejected(
+            PushAppMessagesRequest(messages_list=[message]),
+            grpc.StatusCode.INVALID_ARGUMENT,
+            "Malformed PushMessages request: messages_list and "
+            "message_object_trees must contain the same number of entries.",
+        )
+
+    def test_push_messages_rejects_invalid_direction(self) -> None:
+        """PushMessages should reject a message sent in the wrong direction."""
+        message = create_ins_message(
+            src_node_id=self.node_id,
+            dst_node_id=self.node_id,
+            run_id=self._auth_run_id,
+        )
+        self._assert_push_messages_rejected(
+            PushAppMessagesRequest(
+                messages_list=[message],
+                message_object_trees=[
+                    ObjectTree(object_id=message.metadata.message_id)
+                ],
+            ),
+            grpc.StatusCode.INVALID_ARGUMENT,
+            "Malformed PushMessages request: message at index 0: "
+            f"`metadata.src_node_id` is not {SUPERLINK_NODE_ID} "
+            "(SuperLink node ID).",
+        )
+
+    def test_push_messages_rejects_run_mismatch(self) -> None:
+        """PushMessages should reject an authenticated run mismatch."""
+        message = create_ins_message(
+            src_node_id=SUPERLINK_NODE_ID,
+            dst_node_id=self.node_id,
+            run_id=self._auth_run_id + 1,
+        )
+        self._assert_push_messages_rejected(
+            PushAppMessagesRequest(
+                messages_list=[message],
+                message_object_trees=[
+                    ObjectTree(object_id=message.metadata.message_id)
+                ],
+            ),
+            grpc.StatusCode.PERMISSION_DENIED,
+            "Run ID does not match the authenticated task.",
+        )
+
+    def test_push_messages_rejects_object_tree_mismatch(self) -> None:
+        """PushMessages should reject an unpaired object tree."""
+        message = create_ins_message(
+            src_node_id=SUPERLINK_NODE_ID,
+            dst_node_id=self.node_id,
+            run_id=self._auth_run_id,
+        )
+        self._assert_push_messages_rejected(
+            PushAppMessagesRequest(
+                messages_list=[message],
+                message_object_trees=[ObjectTree(object_id="different-message-id")],
+            ),
+            grpc.StatusCode.INVALID_ARGUMENT,
+            "Malformed PushMessages request: object tree at index 0 does not "
+            "match the message ID.",
+        )
 
     def test_push_messages_keeps_shared_upload_hint_after_rejection(self) -> None:
         """PushMessages should keep accepted-message upload hints."""

--- a/framework/py/flwr/supernode/nodestate/nodestate_test.py
+++ b/framework/py/flwr/supernode/nodestate/nodestate_test.py
@@ -131,6 +131,19 @@ class StateTest(CoreStateTest):  # pylint: disable=R0904
         result = self.state.get_messages()
         self.assertEqual(len(result), 0)
 
+    def test_get_message_limit_leaves_later_messages_unretrieved(self) -> None:
+        """Retrieving one message should leave later messages available."""
+        first = make_dummy_message(msg_id="first")
+        second = make_dummy_message(msg_id="second")
+        self.state.store_message(first)
+        self.state.store_message(second)
+
+        first_result = self.state.get_messages(limit=1)
+        second_result = self.state.get_messages(limit=1)
+
+        self.assertEqual(first_result, [first])
+        self.assertEqual(second_result, [second])
+
     def test_store_message_and_object_tree(self) -> None:
         """Test storing a message and preregistering its object tree."""
         # Prepare

--- a/framework/py/flwr/supernode/runtime/run_clientapp.py
+++ b/framework/py/flwr/supernode/runtime/run_clientapp.py
@@ -15,6 +15,7 @@
 """Flower ClientApp process."""
 
 
+import time
 from logging import DEBUG, ERROR
 
 import grpc
@@ -76,6 +77,8 @@ from flwr.supercore.superexec.dependency_installer import (
     install_app_dependencies,
 )
 from flwr.supercore.telemetry import EventType, event
+
+_MESSAGE_POLL_INTERVAL_SECONDS = 0.5
 
 
 def run_clientapp(  # pylint: disable=R0913, R0914, R0915, R0917
@@ -243,7 +246,22 @@ def pull_task_input(stub: ClientAppIoStub) -> tuple[Message, Context, Run, Fab]:
     fab = fab_from_proto(res.fab)
 
     # Pull and inflate the message
-    pull_msg_res: PullAppMessagesResponse = stub.PullMessages(PullAppMessagesRequest())
+    while True:
+        pull_msg_res: PullAppMessagesResponse = stub.PullMessages(
+            PullAppMessagesRequest()
+        )
+        message_count = len(pull_msg_res.messages_list)
+        tree_count = len(pull_msg_res.message_object_trees)
+        if message_count == 0 and tree_count == 0:
+            time.sleep(_MESSAGE_POLL_INTERVAL_SECONDS)
+            continue
+        if message_count == 1 and tree_count == 1:
+            break
+        raise RuntimeError(
+            "Runtime communication error: PullMessages must return either an empty "
+            "response or exactly one message/object-tree pair."
+        )
+
     run_id = context.run_id
     node = Node(node_id=context.node_id)
     object_tree = pull_msg_res.message_object_trees[0]

--- a/framework/py/flwr/supernode/servicer/clientappio/clientappio_servicer.py
+++ b/framework/py/flwr/supernode/servicer/clientappio/clientappio_servicer.py
@@ -58,9 +58,15 @@ from flwr.proto.message_pb2 import (
     PushObjectResponse,
 )
 from flwr.proto.run_pb2 import GetRunRequest, GetRunResponse
+from flwr.server.utils.validator import validate_message
 from flwr.supercore.interceptors import get_authenticated_task
 from flwr.supercore.object_store import ObjectStoreFactory
 from flwr.supercore.servicer.appio import AppIoServicer
+from flwr.supercore.servicer.appio.error_details import (
+    RUN_ID_MISMATCH,
+    malformed_request,
+    task_transition_failed,
+)
 from flwr.supernode.nodestate import NodeState, NodeStateFactory
 
 
@@ -169,22 +175,24 @@ class ClientAppIoServicer(AppIoServicer, clientappio_pb2_grpc.ClientAppIoService
         state = self.state_factory.state()
 
         # Flag task as finished
-        if state.finish_task(
+        if not state.finish_task(
             task_id=task.task_id,
             sub_status=request.sub_status,
             details=request.details,
         ):
-            log(DEBUG, "Finished task %d of run %s", task.task_id, run_id)
-            # Save the context to the state
-            if request.HasField("context"):
-                run = state.get_run(run_id)
-                if run is not None:
-                    state.set_run_series_context(
-                        run.series_id,
-                        context_from_proto(request.context),
-                    )
-        else:
-            log(ERROR, "Failed to finish task %d of run %s", task.task_id, run_id)
+            context.abort(
+                grpc.StatusCode.FAILED_PRECONDITION,
+                task_transition_failed(task.task_id),
+            )
+
+        log(DEBUG, "Finished task %d of run %s", task.task_id, run_id)
+        if request.HasField("context"):
+            run = state.get_run(run_id)
+            if run is not None:
+                state.set_run_series_context(
+                    run.series_id,
+                    context_from_proto(request.context),
+                )
 
         return PushTaskOutputResponse()
 
@@ -203,13 +211,9 @@ class ClientAppIoServicer(AppIoServicer, clientappio_pb2_grpc.ClientAppIoService
         store = self.objectstore_factory.store()
 
         # Retrieve message for this run
-        messages = state.get_messages(run_ids=[run_id], is_reply=False)
+        messages = state.get_messages(run_ids=[run_id], is_reply=False, limit=1)
         if not messages:
-            context.abort(
-                grpc.StatusCode.NOT_FOUND,
-                f"No message found for run {run_id} in NodeState.",
-            )
-            raise RuntimeError("Unreachable code")  # for mypy
+            return PullAppMessagesResponse()
         message = messages[0]
 
         # Record message processing start time
@@ -233,26 +237,42 @@ class ClientAppIoServicer(AppIoServicer, clientappio_pb2_grpc.ClientAppIoService
         task = get_authenticated_task()
         run_id = task.run_id
 
-        # Initialize state connection
-        state = self.state_factory.state()
-
         if len(request.messages_list) != 1 or len(request.message_object_trees) != 1:
             context.abort(
                 grpc.StatusCode.INVALID_ARGUMENT,
-                "ClientAppIo.PushMessages expects exactly one message and "
-                "one object tree.",
+                malformed_request(
+                    "PushMessages",
+                    "messages_list and message_object_trees must each contain exactly "
+                    "one entry",
+                ),
             )
-            raise RuntimeError("Unreachable code")  # for mypy
 
-        if run_id != request.messages_list[0].metadata.run_id:
+        message = message_from_proto(request.messages_list[0])
+        validation_errors = validate_message(message, is_reply_message=True)
+        if validation_errors:
             context.abort(
-                grpc.StatusCode.PERMISSION_DENIED,
-                "Run ID in message does not match authenticated task's run ID.",
+                grpc.StatusCode.INVALID_ARGUMENT,
+                malformed_request(
+                    "PushMessages",
+                    f"message at index 0: {', '.join(validation_errors)}",
+                ),
             )
-            raise RuntimeError("Unreachable code")  # for mypy
+        if run_id != message.metadata.run_id:
+            context.abort(grpc.StatusCode.PERMISSION_DENIED, RUN_ID_MISMATCH)
+        object_tree = request.message_object_trees[0]
+        if object_tree.object_id != message.metadata.message_id:
+            context.abort(
+                grpc.StatusCode.INVALID_ARGUMENT,
+                malformed_request(
+                    "PushMessages",
+                    "object tree at index 0 does not match the message ID",
+                ),
+            )
+
+        # Initialize state only after validating the complete request
+        state = self.state_factory.state()
 
         # Record message processing end time
-        message = message_from_proto(request.messages_list[0])
         state.record_message_processing_end(
             message_id=message.metadata.reply_to_message_id
         )
@@ -260,7 +280,7 @@ class ClientAppIoServicer(AppIoServicer, clientappio_pb2_grpc.ClientAppIoService
         # Save the message to the state and preregister its objects
         session_id = state.start_session(run_id)
         _, objects_to_push = state.store_message_and_object_tree(
-            message, request.message_object_trees[0], session_id
+            message, object_tree, session_id
         )
 
         return PushAppMessagesResponse(

--- a/framework/py/flwr/supernode/servicer/clientappio/clientappio_servicer_test.py
+++ b/framework/py/flwr/supernode/servicer/clientappio/clientappio_servicer_test.py
@@ -16,14 +16,14 @@
 
 
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import grpc
 from parameterized import parameterized
 
-from flwr.app import Context
+from flwr.app import Context, Message, Metadata, RecordDict
 from flwr.app.message import make_message
-from flwr.common.constant import SubStatus
+from flwr.common.constant import SUPERLINK_NODE_ID, SubStatus
 from flwr.common.serde import context_to_proto, fab_to_proto, message_to_proto
 from flwr.common.serde_test import RecordMaker
 from flwr.proto.appio_pb2 import (  # pylint:disable=E0611
@@ -43,12 +43,14 @@ from flwr.proto.appio_pb2 import (  # pylint:disable=E0611
 from flwr.proto.control_pb2 import StartAutomationRequest  # pylint:disable=E0611
 from flwr.proto.message_pb2 import Context as ProtoContext  # pylint:disable=E0611
 from flwr.proto.message_pb2 import (  # pylint:disable=E0611
+    ObjectTree,
     PullObjectRequest,
     PullObjectResponse,
     PushObjectRequest,
     PushObjectResponse,
 )
 from flwr.proto.run_pb2 import Run as ProtoRun  # pylint:disable=E0611
+from flwr.supercore.date import now
 from flwr.supercore.fab import Fab
 from flwr.supercore.inflatable.inflatable_object import (
     get_all_nested_objects,
@@ -63,6 +65,27 @@ from flwr.supernode.runtime.run_clientapp import (
 )
 
 from .clientappio_servicer import ClientAppIoServicer
+
+
+def _make_reply_message(run_id: int = 61016) -> Message:
+    """Create a valid ClientApp reply message."""
+    message = make_message(
+        metadata=Metadata(
+            run_id=run_id,
+            message_id="",
+            src_node_id=123,
+            dst_node_id=SUPERLINK_NODE_ID,
+            reply_to_message_id="instruction-id",
+            group_id="",
+            created_at=now().timestamp(),
+            ttl=60.0,
+            message_type="query",
+        ),
+        content=RecordDict(),
+    )
+    # pylint: disable-next=protected-access
+    message.metadata._message_id = message.object_id  # type: ignore
+    return message
 
 
 class TestClientAppIoServicer(unittest.TestCase):
@@ -94,10 +117,14 @@ class TestClientAppIoServicer(unittest.TestCase):
             run=ProtoRun(run_id=61016, fab_id="mock/mock", fab_version="v1.0.0"),
             fab=fab_to_proto(mock_fab),
         )
-        self.mock_stub.PullMessages.return_value = PullAppMessagesResponse(
-            messages_list=[message_to_proto(mock_message)],
-            message_object_trees=[get_object_tree(mock_message)],
-        )
+        self.mock_stub.PullMessages.side_effect = [
+            PullAppMessagesResponse(),
+            PullAppMessagesResponse(),
+            PullAppMessagesResponse(
+                messages_list=[message_to_proto(mock_message)],
+                message_object_trees=[get_object_tree(mock_message)],
+            ),
+        ]
         # Create series of responses for PullObject
         # Adding responses for objects in a post-order traversal of object tree order
         all_objects = get_all_nested_objects(mock_message)
@@ -116,7 +143,8 @@ class TestClientAppIoServicer(unittest.TestCase):
         self.mock_stub.PullTaskInput.return_value = mock_response
 
         # Execute
-        message, context, run, fab = pull_task_input(self.mock_stub)
+        with patch("flwr.supernode.runtime.run_clientapp.time.sleep") as mock_sleep:
+            message, context, run, fab = pull_task_input(self.mock_stub)
 
         # Assert
         self.mock_stub.PullTaskInput.assert_called_once()
@@ -129,6 +157,33 @@ class TestClientAppIoServicer(unittest.TestCase):
         self.assertEqual(run.fab_version, "v1.0.0")
         self.assertEqual(fab.hash_str, mock_fab.hash_str)
         self.assertEqual(fab.content, mock_fab.content)
+        self.assertEqual(self.mock_stub.PullMessages.call_count, 3)
+        self.assertEqual(mock_sleep.call_args_list, [call(0.5)] * 2)
+
+    @parameterized.expand([(1, 0), (0, 1), (2, 2)])  # type: ignore
+    def test_pull_task_input_rejects_invalid_message_response_shape(
+        self, message_count: int, object_tree_count: int
+    ) -> None:
+        """ClientApp polling should reject non-empty, non-paired responses."""
+        message = make_message(
+            metadata=self.maker.metadata(),
+            content=self.maker.recorddict(1, 0, 0),
+        )
+        self.mock_stub.PullTaskInput.return_value = PullTaskInputResponse(
+            context=ProtoContext(node_id=123),
+            run=ProtoRun(run_id=61016),
+            fab=fab_to_proto(Fab("hash", b"content", {})),
+        )
+        self.mock_stub.PullMessages.return_value = PullAppMessagesResponse(
+            messages_list=[message_to_proto(message)] * message_count,
+            message_object_trees=[get_object_tree(message)] * object_tree_count,
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Runtime communication error: PullMessages must return",
+        ):
+            pull_task_input(self.mock_stub)
 
     def test_push_task_output(self) -> None:
         """Test pushing messages to SuperNode."""
@@ -263,11 +318,38 @@ class TestClientAppIoServicer(unittest.TestCase):
         self.assertEqual(finish_task_kwargs["task_id"], task_id)
         self.assertEqual(finish_task_kwargs["sub_status"], request.sub_status)
 
-    def test_servicer_pull_messages_aborts_when_no_message_found(self) -> None:
-        """PullMessages should abort cleanly when no message is available."""
-        run_id = 61016
+    def test_servicer_push_task_output_rejects_failed_transition(self) -> None:
+        """PushTaskOutput should expose a failed finish transition."""
+        task_id = 123
         context = Mock()
         context.abort.side_effect = grpc.RpcError()
+        self.mock_state.finish_task.return_value = False
+        request = PushTaskOutputRequest(
+            context=ProtoContext(run_id=61016),
+            sub_status=SubStatus.COMPLETED,
+        )
+
+        with (
+            patch(
+                "flwr.supernode.servicer.clientappio.clientappio_servicer."
+                "get_authenticated_task",
+                return_value=Mock(task_id=task_id, run_id=61016),
+            ),
+            self.assertRaises(grpc.RpcError),
+        ):
+            self.servicer.PushTaskOutput(request, context)
+
+        context.abort.assert_called_once_with(
+            grpc.StatusCode.FAILED_PRECONDITION,
+            f"Task {task_id} cannot transition to FINISHED.",
+        )
+        self.mock_state.set_run_series_context.assert_not_called()
+
+    def test_servicer_pull_messages_returns_empty_response_when_no_message(
+        self,
+    ) -> None:
+        """PullMessages should treat an empty queue as a successful poll."""
+        run_id = 61016
         self.mock_state.get_messages.return_value = []
 
         with patch(
@@ -275,12 +357,12 @@ class TestClientAppIoServicer(unittest.TestCase):
             "get_authenticated_task",
             return_value=Mock(run_id=run_id),
         ):
-            with self.assertRaises(grpc.RpcError):
-                self.servicer.PullMessages(PullAppMessagesRequest(), context)
+            response = self.servicer.PullMessages(PullAppMessagesRequest(), Mock())
 
-        context.abort.assert_called_once_with(
-            grpc.StatusCode.NOT_FOUND,
-            f"No message found for run {run_id} in NodeState.",
+        self.assertEqual(list(response.messages_list), [])
+        self.assertEqual(list(response.message_object_trees), [])
+        self.mock_state.get_messages.assert_called_once_with(
+            run_ids=[run_id], is_reply=False, limit=1
         )
         self.mock_state.record_message_processing_start.assert_not_called()
 
@@ -311,17 +393,16 @@ class TestClientAppIoServicer(unittest.TestCase):
 
         context.abort.assert_called_once_with(
             grpc.StatusCode.INVALID_ARGUMENT,
-            "ClientAppIo.PushMessages expects exactly one message and one object tree.",
+            "Malformed PushMessages request: messages_list and "
+            "message_object_trees must each contain exactly one entry.",
         )
+        self.mock_state.start_session.assert_not_called()
         self.mock_state.record_message_processing_end.assert_not_called()
         self.mock_state.store_message_and_object_tree.assert_not_called()
 
     def test_servicer_push_messages_stores_message_and_object_tree(self) -> None:
         """PushMessages should store the message and preregister its object tree."""
-        message = make_message(
-            metadata=self.maker.metadata(),
-            content=self.maker.recorddict(1, 1, 1),
-        )
+        message = _make_reply_message()
         object_tree = get_object_tree(message)
         request = PushAppMessagesRequest(
             messages_list=[message_to_proto(message)],
@@ -332,14 +413,16 @@ class TestClientAppIoServicer(unittest.TestCase):
             ["object-id"],
         )
         self.mock_state.start_session.return_value = "session-id"
+        context = Mock()
 
         with patch(
             "flwr.supernode.servicer.clientappio.clientappio_servicer."
             "get_authenticated_task",
             return_value=Mock(run_id=message.metadata.run_id),
         ):
-            response = self.servicer.PushMessages(request, Mock())
+            response = self.servicer.PushMessages(request, context)
 
+        context.abort.assert_not_called()
         self.mock_state.record_message_processing_end.assert_called_once_with(
             message_id=message.metadata.reply_to_message_id
         )
@@ -355,6 +438,93 @@ class TestClientAppIoServicer(unittest.TestCase):
         self.assertEqual(session_id, "session-id")
         self.assertEqual(list(response.objects_to_push), ["object-id"])
         self.assertEqual(response.session_id, "session-id")
+
+    def test_servicer_push_messages_rejects_instruction_message(self) -> None:
+        """ClientApp PushMessages should reject instruction direction."""
+        message = _make_reply_message()
+        message.metadata.__dict__["_reply_to_message_id"] = ""
+        request = PushAppMessagesRequest(
+            messages_list=[message_to_proto(message)],
+            message_object_trees=[get_object_tree(message)],
+        )
+        context = Mock()
+        context.abort.side_effect = grpc.RpcError()
+
+        with (
+            patch(
+                "flwr.supernode.servicer.clientappio.clientappio_servicer."
+                "get_authenticated_task",
+                return_value=Mock(run_id=message.metadata.run_id),
+            ),
+            self.assertRaises(grpc.RpcError),
+        ):
+            self.servicer.PushMessages(request, context)
+
+        context.abort.assert_called_once_with(
+            grpc.StatusCode.INVALID_ARGUMENT,
+            "Malformed PushMessages request: message at index 0: "
+            "`metadata.reply_to_message_id` MUST be set.",
+        )
+        self.mock_state.start_session.assert_not_called()
+        self.mock_state.record_message_processing_end.assert_not_called()
+        self.mock_state.store_message_and_object_tree.assert_not_called()
+
+    def test_servicer_push_messages_rejects_run_mismatch(self) -> None:
+        """ClientApp PushMessages should reject an authenticated run mismatch."""
+        message = _make_reply_message()
+        request = PushAppMessagesRequest(
+            messages_list=[message_to_proto(message)],
+            message_object_trees=[get_object_tree(message)],
+        )
+        context = Mock()
+        context.abort.side_effect = grpc.RpcError()
+
+        with (
+            patch(
+                "flwr.supernode.servicer.clientappio.clientappio_servicer."
+                "get_authenticated_task",
+                return_value=Mock(run_id=message.metadata.run_id + 1),
+            ),
+            self.assertRaises(grpc.RpcError),
+        ):
+            self.servicer.PushMessages(request, context)
+
+        context.abort.assert_called_once_with(
+            grpc.StatusCode.PERMISSION_DENIED,
+            "Run ID does not match the authenticated task.",
+        )
+        self.mock_state.start_session.assert_not_called()
+        self.mock_state.record_message_processing_end.assert_not_called()
+        self.mock_state.store_message_and_object_tree.assert_not_called()
+
+    def test_servicer_push_messages_rejects_object_tree_mismatch(self) -> None:
+        """ClientApp PushMessages should reject an unpaired object tree."""
+        message = _make_reply_message()
+        request = PushAppMessagesRequest(
+            messages_list=[message_to_proto(message)],
+            message_object_trees=[ObjectTree(object_id="different-message-id")],
+        )
+        context = Mock()
+        context.abort.side_effect = grpc.RpcError()
+
+        with (
+            patch(
+                "flwr.supernode.servicer.clientappio.clientappio_servicer."
+                "get_authenticated_task",
+                return_value=Mock(run_id=message.metadata.run_id),
+            ),
+            self.assertRaises(grpc.RpcError),
+        ):
+            self.servicer.PushMessages(request, context)
+
+        context.abort.assert_called_once_with(
+            grpc.StatusCode.INVALID_ARGUMENT,
+            "Malformed PushMessages request: object tree at index 0 does not "
+            "match the message ID.",
+        )
+        self.mock_state.start_session.assert_not_called()
+        self.mock_state.record_message_processing_end.assert_not_called()
+        self.mock_state.store_message_and_object_tree.assert_not_called()
 
     def test_push_object_uses_state(self) -> None:
         """PushObject should delegate session validation and storage to state."""


### PR DESCRIPTION
## Summary

Align the highest-priority public behavior across `ServerAppIo` and `ClientAppIo` without changing their protobuf definitions or merging their implementations.

## Changes

### ClientApp message polling

- Return an empty successful `PullMessages` response when no message is available.
- Retrieve at most one message per SuperNode call, preventing later messages from being marked retrieved and discarded.
- Poll every 0.5 seconds in the ClientApp runtime while the response is empty.
- Reject malformed non-empty responses that do not contain exactly one message/object-tree pair.
- Existing task heartbeats continue while polling.

### `PushMessages` validation

- Validate the complete request before starting a session or modifying message-processing state.
- Return:
  - `INVALID_ARGUMENT` for invalid cardinality, malformed messages, invalid direction, or message/object-tree mismatches.
  - `PERMISSION_DENIED` when a message run ID conflicts with the authenticated task.
- Preserve the existing cardinality behavior:
  - ServerAppIo accepts one or more message/tree pairs.
  - ClientAppIo accepts exactly one pair.
- Reuse the existing canonical message validator for both services.
- Preserve existing ServerAppIo positional results and partial storage behavior.

### Task completion

- Return `FAILED_PRECONDITION` when `finish_task` rejects a `PushTaskOutput` transition.
- Use the stable detail:
  - `Task {task_id} cannot transition to FINISHED.`
- Persist context and Simulation runtime usage only after the task transition succeeds.

## Compatibility

- No protobuf or generated-file changes.
- No authentication or transport changes.
- Valid built-in callers remain compatible.
- ClientApp empty polling changes from `NOT_FOUND` to an empty successful response.
- Malformed ServerAppIo requests now receive explicit gRPC errors instead of `UNKNOWN`.
- Failed task completion no longer returns silent success.

## Out of scope

- ClientApp multi-message `PushMessages`.
- Positional ClientApp `message_ids`.
- Missing-resource alignment in `PullTaskInput`.
- SuperNode capability endpoints returning `UNIMPLEMENTED`.
- Object run/node authorization.
- Missing object-tree invariant handling.
- `runtime.proto` or service registration changes.

## Testing

Added coverage for:

- Empty ClientApp polling and retry behavior.
- One-message retrieval without losing subsequent messages.
- Invalid ClientApp polling response shapes.
- `PushMessages` cardinality, direction, run identity, and object-tree validation.
- No session or message-state mutation for invalid requests.
- Failed task completion transitions and absence of persistence side effects.
- Exact gRPC status codes and error details.

The focused ServerAppIo, ClientAppIo, runtime, NodeState, authentication, and validator suites pass, along with targeted formatting, linting, typing, and diff checks.