### PR TITLE
ci(framework:skip): Allow overriding Pylint ignore paths

### DIFF
--- a/framework/dev/test.sh
+++ b/framework/dev/test.sh
@@ -58,7 +58,11 @@ python -m mypy py
 echo "- mypy: done"
 
 echo "- pylint: start"
-python -m pylint --ignore=py/flwr/proto py/flwr
+pylint_args=(--ignore=py/flwr/proto)
+if [[ -n "${PYLINT_IGNORE_PATHS:-}" ]]; then
+    pylint_args+=(--ignore-paths="${PYLINT_IGNORE_PATHS}")
+fi
+python -m pylint "${pylint_args[@]}" py/flwr
 echo "- pylint: done"
 
 echo "- pytest: start"


### PR DESCRIPTION
## Summary

- allow Framework quality checks to accept an optional `PYLINT_IGNORE_PATHS` value
- preserve the existing Pylint invocation when the variable is unset
- forward the override as one safely quoted command-line argument

## Motivation

`framework/dev/test.sh` currently hardcodes the Pylint invocation. An optional
ignore-path override makes the script reusable for targeted local and CI checks
without requiring callers to edit the shared test script. Existing callers keep
the same behavior by default.

## Validation

- `RUN_PYTEST=false uv run --no-sync --python=3.11.14 ./dev/test.sh false`
- `RUN_PYTEST=false PYLINT_IGNORE_PATHS='^py/flwr/supercore/state/alembic/.*$' uv run --no-sync --python=3.11.14 ./dev/test.sh false`
- `bash -n framework/dev/test.sh`
- `git diff --check`