### PR TITLE
feat(framework): Fix unsupported automation query in Postgres

### DIFF
--- a/framework/py/flwr/supercore/corestate/corestate_test.py
+++ b/framework/py/flwr/supercore/corestate/corestate_test.py
@@ -772,6 +772,60 @@ class StateTest(unittest.TestCase):  # pylint: disable=R0904
         )
         self.assertEqual(failed[0].next_run_at, failed_previous_next_run_at)
 
+    def test_claim_automation(self) -> None:
+        """Claiming should return the request and advance one occurrence."""
+        state = self.state_factory()
+        current = now()
+        first_run_at = current.isoformat()
+        second_run_at = (current + timedelta(seconds=60)).isoformat()
+        automation = self.store_automation(
+            state,
+            series_id=123,
+            flwr_aid="aid-claim",
+            next_run_at=first_run_at,
+            fixed_interval=60,
+            max_runs=2,
+        )
+        self.assertIsNone(
+            state.claim_automation(
+                automation.automation_id,
+                previous_next_run_at=first_run_at,
+                next_run_at=None,
+            )
+        )
+
+        claimed = state.claim_automation(
+            automation.automation_id,
+            previous_next_run_at=first_run_at,
+            next_run_at=second_run_at,
+        )
+
+        self.assertIsNotNone(claimed)
+        assert claimed is not None
+        request, flwr_aid = claimed
+        self.assertEqual(request.series_id, 123)
+        self.assertEqual(flwr_aid, "aid-claim")
+        self.assertIsNone(
+            state.claim_automation(
+                automation.automation_id,
+                previous_next_run_at=first_run_at,
+                next_run_at=second_run_at,
+            )
+        )
+
+        final_claim = state.claim_automation(
+            automation.automation_id,
+            previous_next_run_at=second_run_at,
+            next_run_at=None,
+        )
+
+        self.assertIsNotNone(final_claim)
+        updated = state.list_automations(
+            automation_ids=[automation.automation_id],
+            order_by="updated_at",
+        )
+        self.assertEqual(updated[0].remaining_runs, 0)
+
     def test_store_automation_preserves_series_id_without_validation(self) -> None:
         """Automation storage should preserve caller-provided series IDs."""
         state = self.state_factory()

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -820,9 +820,12 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         next_run_at: str | None,
     ) -> tuple[StartRunRequest, str] | None:
         """Claim an automation occurrence and return its unresolved run request."""
+        terminal_occurrence_condition = (
+            "AND remaining_runs <= 1" if next_run_at is None else ""
+        )
         with self.session():
             rows = self.query(
-                """
+                f"""
                 SELECT start_run_request, flwr_aid
                 FROM automation
                 WHERE automation_id = :automation_id
@@ -830,13 +833,12 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
                 AND start_run_request IS NOT NULL
                 AND next_run_at = :previous_next_run_at
                 AND (remaining_runs IS NULL OR remaining_runs > 0)
-                AND (:next_run_at IS NOT NULL OR remaining_runs <= 1)
+                {terminal_occurrence_condition}
                 """,
                 {
                     "automation_id": automation_id,
                     "active_status": AutomationStatus.ACTIVE,
                     "previous_next_run_at": previous_next_run_at,
-                    "next_run_at": next_run_at,
                 },
             )
             if not rows or not self.advance_automation(


### PR DESCRIPTION
## Summary

  Fix PostgreSQL automation dispatch failures caused by an untyped next_run_at IS NOT NULL bind parameter.

  The terminal-occurrence condition is now constructed in Python, preserving behavior across PostgreSQL and SQLite.
