### PR TITLE
feat(framework): Introduce Connector Structure

### DIFF
--- a/framework/dev/format.sh
+++ b/framework/dev/format.sh
@@ -5,6 +5,7 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 taplo fmt
 
 # Python
+python -m dev.generate_connector
 python -m devtool.check_copyright py/flwr
 python -m devtool.init_py_fix py/flwr
 python -m isort --skip py/flwr/proto py

--- a/framework/dev/generate_connector.py
+++ b/framework/dev/generate_connector.py
@@ -1,0 +1,206 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Scaffold connector providers and generate their static registry."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+_FRAMEWORK_DIR = Path(__file__).resolve().parents[1]
+_PROVIDERS_DIR = _FRAMEWORK_DIR / "py/flwr/supercore/task_process/connector/providers"
+_REGISTRY_PATH = _PROVIDERS_DIR / "registry_generated.py"
+_PACKAGE_PREFIX = "flwr.supercore.task_process.connector.providers"
+_LICENSE = """# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""
+
+
+def main() -> None:
+    """Scaffold an optional provider and update its generated registry."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("provider", nargs="?", help="Lowercase snake-case provider ID")
+    parser.add_argument("--display-name", help="Provider name shown to users")
+    parser.add_argument(
+        "--check", action="store_true", help="Fail if the registry is stale"
+    )
+    args = parser.parse_args()
+    if args.check and args.provider:
+        parser.error("--check cannot be combined with a provider")
+    if args.provider:
+        scaffold_provider(args.provider, args.display_name)
+    update_registry(check=args.check)
+
+
+def scaffold_provider(provider: str, display_name: str | None = None) -> None:
+    """Create a minimal provider package without overwriting existing files."""
+    _validate_identifier(provider)
+    target = _PROVIDERS_DIR / provider
+    if target.exists():
+        raise FileExistsError(f"Connector provider already exists: {provider}")
+    target.mkdir()
+    shown_name = display_name or provider.replace("_", " ").title()
+    for filename, content in _provider_templates(provider, shown_name).items():
+        (target / filename).write_text(content, encoding="utf-8")
+    print(f"Created connector provider: {target.relative_to(_FRAMEWORK_DIR)}")
+
+
+def update_registry(*, check: bool = False) -> None:
+    """Write or verify the deterministic provider package registry."""
+    content = render_registry(_provider_ids())
+    current = _REGISTRY_PATH.read_text(encoding="utf-8")
+    if check:
+        if current != content:
+            raise RuntimeError(
+                "Connector provider registry is stale; run "
+                "`python -m dev.generate_connector`."
+            )
+        return
+    if current != content:
+        _REGISTRY_PATH.write_text(content, encoding="utf-8")
+        print(f"Updated {_REGISTRY_PATH.relative_to(_FRAMEWORK_DIR)}")
+
+
+def render_registry(providers: list[str]) -> str:
+    """Render the generated Python provider registry."""
+    packages = "\n".join(
+        f'    "{_PACKAGE_PREFIX}.{provider}",' for provider in providers
+    )
+    if packages:
+        value = f"(\n{packages}\n)"
+    else:
+        value = "()"
+    return (
+        _LICENSE
+        + '"""Generated connector provider package registry. Do not edit."""\n\n'
+        + f"PROVIDER_PACKAGES: tuple[str, ...] = {value}\n"
+    )
+
+
+def _provider_ids() -> list[str]:
+    """Return provider package directory names in deterministic order."""
+    providers = [
+        path.name
+        for path in _PROVIDERS_DIR.iterdir()
+        if path.is_dir() and not path.name.startswith("_")
+    ]
+    for provider in providers:
+        _validate_identifier(provider)
+        required = {"actions.py", "definition.py", "executors.py"}
+        missing = required.difference(
+            path.name for path in (_PROVIDERS_DIR / provider).iterdir()
+        )
+        if missing:
+            raise RuntimeError(
+                f"Provider '{provider}' is missing: {', '.join(sorted(missing))}."
+            )
+    return sorted(providers)
+
+
+def _validate_identifier(provider: str) -> None:
+    """Require the same provider identifier accepted by definitions."""
+    if not provider or not provider.isidentifier() or provider.lower() != provider:
+        raise ValueError("Provider ID must be a lowercase snake-case identifier.")
+
+
+def _provider_templates(provider: str, display_name: str) -> dict[str, str]:
+    """Return minimal source files for one standard OAuth provider."""
+    env_prefix = provider.upper()
+    init = _LICENSE + f'"""{display_name} connector provider."""\n'
+    actions = (
+        _LICENSE
+        + f'''"""{display_name} action definitions."""
+
+from ...definition import ActionAccess, ActionDefinition
+
+READ = ActionDefinition(
+    name="read",
+    description="Read resources from {display_name}.",
+    access=ActionAccess.READ,
+    input_schema={{
+        "type": "object",
+        "properties": {{}},
+        "additionalProperties": False,
+    }},
+)
+
+ACTIONS = (READ,)
+'''
+    )
+    definition = (
+        _LICENSE
+        + f'''"""{display_name} provider definition."""
+
+from ...definition import OAuth2Definition, ProviderDefinition
+from .actions import ACTIONS
+
+PROVIDER = ProviderDefinition(
+    ref="{provider}",
+    display_name="{display_name}",
+    description="Connect to {display_name}.",
+    actions=ACTIONS,
+    oauth=OAuth2Definition(
+        authorization_url="https://provider.example/oauth/authorize",
+        token_url="https://provider.example/oauth/token",
+        client_id_env="FLWR_{env_prefix}_CLIENT_ID",
+        client_secret_env="FLWR_{env_prefix}_CLIENT_SECRET",
+        redirect_uri_env="FLWR_{env_prefix}_REDIRECT_URI",
+    ),
+    api_base_url="https://api.provider.example/v1",
+)
+'''
+    )
+    executors = (
+        _LICENSE
+        + f'''"""{display_name} action executors."""
+
+from flwr.supercore.typing import JSONObject
+
+from ...runtime import ConnectorContext, ConnectorExecutor
+
+
+def read(arguments: JSONObject, context: ConnectorContext) -> JSONObject:
+    """Read resources from {display_name}."""
+    del arguments
+    if context.http is None:
+        raise RuntimeError("{display_name} HTTP client is not configured.")
+    return context.http.request("GET", "/resources")
+
+
+EXECUTORS: dict[str, ConnectorExecutor] = {{"read": read}}
+'''
+    )
+    return {
+        "__init__.py": init,
+        "actions.py": actions,
+        "definition.py": definition,
+        "executors.py": executors,
+    }
+
+
+if __name__ == "__main__":
+    main()

--- a/framework/dev/generate_connector_test.py
+++ b/framework/dev/generate_connector_test.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for connector provider scaffolding."""
+
+from pathlib import Path
+
+import pytest
+
+import dev.generate_connector as generate_connector
+
+
+def test_scaffold_provider_and_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Scaffolding should create three provider modules and register them."""
+    providers = tmp_path / "providers"
+    providers.mkdir()
+    registry = providers / "registry_generated.py"
+    registry.write_text(generate_connector.render_registry([]), encoding="utf-8")
+    monkeypatch.setattr(generate_connector, "_FRAMEWORK_DIR", tmp_path)
+    monkeypatch.setattr(generate_connector, "_PROVIDERS_DIR", providers)
+    monkeypatch.setattr(generate_connector, "_REGISTRY_PATH", registry)
+
+    generate_connector.scaffold_provider("example", "Example")
+    generate_connector.update_registry()
+
+    assert {path.name for path in (providers / "example").iterdir()} == {
+        "__init__.py",
+        "actions.py",
+        "definition.py",
+        "executors.py",
+    }
+    assert "access=ActionAccess.READ" in (providers / "example/actions.py").read_text(
+        encoding="utf-8"
+    )
+    assert "providers.example" in registry.read_text(encoding="utf-8")
+    generate_connector.update_registry(check=True)
+
+
+def test_scaffold_rejects_invalid_provider() -> None:
+    """Scaffolding should reject invalid provider package names."""
+    with pytest.raises(ValueError, match="lowercase snake-case"):
+        generate_connector._validate_identifier("Notion")

--- a/framework/dev/test.sh
+++ b/framework/dev/test.sh
@@ -13,6 +13,10 @@ echo "RUN_PYTEST: $RUN_PYTEST"
 
 echo "- Start Python checks"
 
+echo "- connector registry: start"
+python -m dev.generate_connector --check
+echo "- connector registry: done"
+
 echo "- clang-format:  start"
 clang-format --Werror --dry-run proto/flwr/proto/*
 echo "- clang-format:  done"

--- a/framework/py/flwr/supercore/task_process/connector/definition.py
+++ b/framework/py/flwr/supercore/task_process/connector/definition.py
@@ -12,46 +12,143 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Definition of one account-scoped connector."""
+"""Declarative definitions for account-scoped connector providers."""
+
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import dataclass, field
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Literal
+
+from flwr.supercore.typing import JSONObject
 
 
-from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+class ActionAccess(StrEnum):
+    """Provider-independent classification of an action's side effects."""
 
-from flwr.supercore.typing import JSONObject, JSONValue
-
-from .oauth import OAuthConnectorProvider
-
-ConnectorHandler = Callable[..., JSONValue]
+    READ = "read"
+    WRITE = "write"
 
 
 @dataclass(frozen=True)
-class ConnectorDefinition:
-    """Describe all runtime components of one account-scoped connector."""
+class ActionDefinition:
+    """Describe one provider action independently of its executor."""
 
-    ref: str
-    tools: tuple[JSONObject, ...]
-    handlers: Mapping[str, ConnectorHandler]
-    oauth_provider: OAuthConnectorProvider | None = None
+    name: str
+    description: str
+    access: ActionAccess
+    input_schema: JSONObject
+    output_schema: JSONObject | None = None
+    required_scopes: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
-        """Reject incomplete definitions when the connector is imported."""
-        if not self.ref:
-            raise ValueError("Connector reference must not be empty.")
-        tool_names = [tool.get("name") for tool in self.tools]
-        if not all(isinstance(name, str) and name for name in tool_names):
-            raise ValueError(f"Connector '{self.ref}' has an invalid tool name.")
-        if len(tool_names) != len(set(tool_names)):
-            raise ValueError(f"Connector '{self.ref}' has duplicate tool names.")
-        if set(tool_names) != set(self.handlers):
-            raise ValueError(
-                f"Connector '{self.ref}' tool schemas and handlers do not match."
-            )
-        if (
-            self.oauth_provider is not None
-            and self.oauth_provider.connector_ref != self.ref
-        ):
-            raise ValueError(
-                f"Connector '{self.ref}' has an OAuth provider for "
-                f"'{self.oauth_provider.connector_ref}'."
-            )
+        """Reject invalid action definitions when a provider is imported."""
+        _validate_identifier(self.name, "Action name")
+        if not self.description.strip():
+            raise ValueError(f"Action '{self.name}' description must not be empty.")
+        if not isinstance(self.access, ActionAccess):
+            raise ValueError(f"Action '{self.name}' has an invalid access class.")
+        if self.input_schema.get("type") != "object":
+            raise ValueError(f"Action '{self.name}' input schema must be an object.")
+        if len(self.required_scopes) != len(set(self.required_scopes)):
+            raise ValueError(f"Action '{self.name}' has duplicate OAuth scopes.")
+
+    def tool(self, provider_ref: str) -> JSONObject:
+        """Return the model-facing function tool for this action."""
+        return {
+            "type": "function",
+            "name": self.tool_name(provider_ref),
+            "description": self.description,
+            "parameters": deepcopy(self.input_schema),
+        }
+
+    def tool_name(self, provider_ref: str) -> str:
+        """Return this action's globally unique model-facing name."""
+        return f"{provider_ref}_{self.name}"
+
+
+@dataclass(frozen=True)
+# pylint: disable-next=too-many-instance-attributes
+class OAuth2Definition:
+    """Describe a standard OAuth 2 authorization-code integration."""
+
+    authorization_url: str
+    token_url: str
+    client_id_env: str
+    client_secret_env: str | None
+    redirect_uri_env: str
+    scopes: tuple[str, ...] = ()
+    scope_separator: Literal[" ", ","] = " "
+    token_auth_method: Literal["client_secret_basic", "client_secret_post", "none"] = (
+        "client_secret_basic"
+    )
+    token_request_format: Literal["form", "json"] = "form"
+    use_pkce: bool = False
+    authorization_params: JSONObject = field(default_factory=dict)
+    token_params: JSONObject = field(default_factory=dict)
+    token_response_path: tuple[str, ...] = ()
+    config_fields: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Reject incomplete OAuth definitions."""
+        required = (
+            self.authorization_url,
+            self.token_url,
+            self.client_id_env,
+            self.redirect_uri_env,
+        )
+        if not all(value.strip() for value in required):
+            raise ValueError("OAuth definition fields must not be empty.")
+        if self.token_auth_method != "none" and not self.client_secret_env:
+            raise ValueError("Confidential OAuth clients require a client secret.")
+        if len(self.scopes) != len(set(self.scopes)):
+            raise ValueError("OAuth definition has duplicate scopes.")
+        object.__setattr__(
+            self, "authorization_params", MappingProxyType(self.authorization_params)
+        )
+        object.__setattr__(self, "token_params", MappingProxyType(self.token_params))
+
+
+@dataclass(frozen=True)
+class ProviderDefinition:
+    """Describe one account-scoped connector provider."""
+
+    ref: str
+    display_name: str
+    description: str
+    actions: tuple[ActionDefinition, ...]
+    oauth: OAuth2Definition | None = None
+    api_base_url: str | None = None
+    api_headers: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Reject inconsistent provider packages when imported."""
+        _validate_identifier(self.ref, "Provider reference")
+        if not self.display_name.strip() or not self.description.strip():
+            raise ValueError(f"Provider '{self.ref}' metadata must not be empty.")
+        if not self.actions:
+            raise ValueError(f"Provider '{self.ref}' must define at least one action.")
+        names = [action.name for action in self.actions]
+        if len(names) != len(set(names)):
+            raise ValueError(f"Provider '{self.ref}' has duplicate action names.")
+        if self.oauth is not None:
+            missing_scopes = {
+                scope
+                for action in self.actions
+                for scope in action.required_scopes
+                if scope not in self.oauth.scopes
+            }
+            if missing_scopes:
+                raise ValueError(
+                    f"Provider '{self.ref}' actions require undeclared OAuth scopes: "
+                    + ", ".join(sorted(missing_scopes))
+                    + "."
+                )
+        object.__setattr__(self, "api_headers", MappingProxyType(self.api_headers))
+
+
+def _validate_identifier(value: str, label: str) -> None:
+    """Require a stable lowercase snake-case identifier."""
+    if not value or not value.isidentifier() or value.lower() != value:
+        raise ValueError(f"{label} must be a lowercase snake-case identifier.")

--- a/framework/py/flwr/supercore/task_process/connector/definition_test.py
+++ b/framework/py/flwr/supercore/task_process/connector/definition_test.py
@@ -12,27 +12,73 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Tests for connector definitions."""
-
+"""Tests for declarative connector definitions."""
 
 import pytest
 
-from flwr.supercore.typing import JSONObject
+from .definition import (
+    ActionAccess,
+    ActionDefinition,
+    OAuth2Definition,
+    ProviderDefinition,
+)
+from .runtime import ConnectorDefinition
 
-from .definition import ConnectorDefinition
-from .tool_schema import function_tool
 
-
-def _handler() -> JSONObject:
-    return {}
-
-
-def test_connector_definition_rejects_handler_drift() -> None:
-    """Every tool should have exactly one matching handler."""
-    tool = function_tool("example_read", "Read an example.", properties={})
-    ConnectorDefinition(
-        ref="example", tools=(tool,), handlers={"example_read": _handler}
+def _action(*, scopes: tuple[str, ...] = ()) -> ActionDefinition:
+    return ActionDefinition(
+        name="read",
+        description="Read an example.",
+        access=ActionAccess.READ,
+        input_schema={"type": "object", "properties": {}},
+        required_scopes=scopes,
     )
 
-    with pytest.raises(ValueError, match="schemas and handlers do not match"):
-        ConnectorDefinition(ref="example", tools=(tool,), handlers={})
+
+def _provider(*, scopes: tuple[str, ...] = ()) -> ProviderDefinition:
+    return ProviderDefinition(
+        ref="example",
+        display_name="Example",
+        description="Example provider.",
+        actions=(_action(scopes=scopes),),
+        oauth=OAuth2Definition(
+            authorization_url="https://example.com/authorize",
+            token_url="https://example.com/token",
+            client_id_env="EXAMPLE_CLIENT_ID",
+            client_secret_env="EXAMPLE_CLIENT_SECRET",
+            redirect_uri_env="EXAMPLE_REDIRECT_URI",
+            scopes=scopes,
+        ),
+    )
+
+
+def test_provider_definition_builds_tools() -> None:
+    """Provider actions should generate globally unique function tools."""
+    connector = ConnectorDefinition(
+        provider=_provider(scopes=("read:items",)),
+        executors={"read": lambda arguments, context: {}},
+    )
+
+    assert connector.tools == (
+        {
+            "type": "function",
+            "name": "example_read",
+            "description": "Read an example.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    )
+    assert connector.provider.actions[0].access is ActionAccess.READ
+
+
+def test_definitions_reject_drift() -> None:
+    """Definitions should reject undeclared scopes and missing executors."""
+    with pytest.raises(ValueError, match="undeclared OAuth scopes"):
+        _provider(scopes=("read:items",)).__class__(
+            ref="example",
+            display_name="Example",
+            description="Example provider.",
+            actions=(_action(scopes=("write:items",)),),
+            oauth=_provider(scopes=("read:items",)).oauth,
+        )
+    with pytest.raises(ValueError, match="actions and executors do not match"):
+        ConnectorDefinition(provider=_provider(), executors={})

--- a/framework/py/flwr/supercore/task_process/connector/http.py
+++ b/framework/py/flwr/supercore/task_process/connector/http.py
@@ -29,13 +29,67 @@ HttpErrorCode = Callable[[requests.Response], str]
 class ConnectorApiError(RuntimeError):
     """Base class for secret-safe connector API failures."""
 
-    provider: str
+    provider = "Connector"
 
-    def __init__(self, code: str, status_code: int | None = None) -> None:
+    def __init__(
+        self,
+        code: str,
+        status_code: int | None = None,
+        *,
+        provider: str | None = None,
+    ) -> None:
         self.code = code
         self.status_code = status_code
         detail = code if status_code is None else f"{code} ({status_code})"
-        super().__init__(f"{self.provider} API request failed: {detail}.")
+        super().__init__(f"{provider or self.provider} API request failed: {detail}.")
+
+
+class ConnectorHttpClient:
+    """Make authenticated, secret-safe requests to one provider API."""
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        base_url: str,
+        credentials: JSONObject,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        if not base_url.startswith("https://"):
+            raise ValueError("Connector API base URL must use HTTPS.")
+        token = credentials.get("access_token")
+        if not isinstance(token, str) or not token:
+            raise ConnectorApiError("invalid_credentials", provider=provider)
+        self._provider = provider
+        self._base_url = base_url.rstrip("/")
+        self._headers = {
+            "Authorization": f"Bearer {token}",
+            **dict(headers or {}),
+        }
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Mapping[str, str] | None = None,
+        json: JSONObject | None = None,
+    ) -> JSONObject:
+        """Request one provider-relative JSON object endpoint."""
+        if not path.startswith("/") or path.startswith("//"):
+            raise ValueError("Connector API path must be provider-relative.")
+        return request_json_object(
+            method,
+            f"{self._base_url}{path}",
+            error=self._error,
+            headers=self._headers,
+            params=params,
+            json=json,
+        )
+
+    def _error(self, code: str, status_code: int | None) -> ConnectorApiError:
+        """Build a provider-labelled, secret-safe error."""
+        return ConnectorApiError(code, status_code, provider=self._provider)
 
 
 # pylint: disable-next=too-many-arguments

--- a/framework/py/flwr/supercore/task_process/connector/infrastructure_test.py
+++ b/framework/py/flwr/supercore/task_process/connector/infrastructure_test.py
@@ -23,8 +23,19 @@ import requests
 
 from flwr.supercore.typing import JSONObject
 
-from .http import ConnectorApiError, request_json_object
-from .oauth import BaseOAuthProvider, load_oauth_provider
+from .definition import (
+    ActionAccess,
+    ActionDefinition,
+    OAuth2Definition,
+    ProviderDefinition,
+)
+from .http import ConnectorApiError, ConnectorHttpClient, request_json_object
+from .oauth import (
+    BaseOAuthProvider,
+    DeclarativeOAuthProvider,
+    load_declarative_oauth_provider,
+    load_oauth_provider,
+)
 
 
 class ExampleApiError(ConnectorApiError):
@@ -47,6 +58,29 @@ def test_json_request_failure_is_secret_safe() -> None:
 
     assert exc_info.value.code == "request_failed"
     assert "secret" not in str(exc_info.value)
+
+
+def test_connector_http_client_adds_credentials() -> None:
+    """Provider executors should receive a configured HTTP client."""
+    response = Mock(status_code=200)
+    response.json.return_value = {"items": []}
+    client = ConnectorHttpClient(
+        provider="Example",
+        base_url="https://api.example.com/v1",
+        credentials={"access_token": "secret"},
+        headers={"X-Api-Version": "1"},
+    )
+    with patch(
+        "flwr.supercore.task_process.connector.http.requests.request",
+        return_value=response,
+    ) as request:
+        assert client.request("GET", "/items") == {"items": []}
+
+    assert request.call_args.args == ("GET", "https://api.example.com/v1/items")
+    assert request.call_args.kwargs["headers"] == {
+        "Authorization": "Bearer secret",
+        "X-Api-Version": "1",
+    }
 
 
 class ExampleOAuthProvider(BaseOAuthProvider):
@@ -115,3 +149,60 @@ def test_oauth_flow_and_environment(monkeypatch: pytest.MonkeyPatch) -> None:
             client_secret_env="EXAMPLE_CLIENT_SECRET",
             redirect_uri_env="EXAMPLE_REDIRECT_URI",
         )
+
+
+def test_declarative_oauth_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Standard providers should configure OAuth without a custom subclass."""
+    provider = ProviderDefinition(
+        ref="example",
+        display_name="Example",
+        description="Example provider.",
+        actions=(
+            ActionDefinition(
+                name="read",
+                description="Read an example.",
+                access=ActionAccess.READ,
+                input_schema={"type": "object", "properties": {}},
+                required_scopes=("items:read",),
+            ),
+        ),
+        oauth=OAuth2Definition(
+            authorization_url="https://example.com/authorize",
+            token_url="https://example.com/token",
+            client_id_env="EXAMPLE_CLIENT_ID",
+            client_secret_env="EXAMPLE_CLIENT_SECRET",
+            redirect_uri_env="EXAMPLE_REDIRECT_URI",
+            scopes=("items:read",),
+            token_auth_method="client_secret_post",
+            config_fields=("account_id",),
+        ),
+    )
+    monkeypatch.setenv("EXAMPLE_CLIENT_ID", "client")
+    monkeypatch.setenv("EXAMPLE_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("EXAMPLE_REDIRECT_URI", "https://example.com/callback")
+    oauth = load_declarative_oauth_provider(provider)
+    assert isinstance(oauth, DeclarativeOAuthProvider)
+    assert "scope=items%3Aread" in oauth.build_authorization_url(
+        redirect_uri="https://example.com/callback",
+        state="state",
+        pkce_challenge=None,
+    )
+    response = Mock(status_code=200)
+    response.json.return_value = {
+        "access_token": "access",
+        "refresh_token": "refresh",
+        "account_id": "account",
+    }
+    with patch(
+        "flwr.supercore.task_process.connector.oauth.requests.post",
+        return_value=response,
+    ) as post:
+        credentials, config = oauth.exchange_code(
+            code="code",
+            redirect_uri="https://example.com/callback",
+            pkce_verifier=None,
+        )
+
+    assert post.call_args.kwargs["data"]["client_id"] == "client"
+    assert credentials == {"access_token": "access", "refresh_token": "refresh"}
+    assert config == {"account_id": "account"}

--- a/framework/py/flwr/supercore/task_process/connector/oauth.py
+++ b/framework/py/flwr/supercore/task_process/connector/oauth.py
@@ -17,13 +17,15 @@
 
 import os
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import Protocol, TypeVar, cast
 from urllib.parse import urlencode
 
 import requests
 
 from flwr.supercore.typing import JSONObject
+
+from .definition import ProviderDefinition
 
 
 class OAuthConnectorProvider(Protocol):
@@ -166,3 +168,197 @@ class BaseOAuthProvider(ABC):
         self, payload: JSONObject
     ) -> tuple[JSONObject, JSONObject]:
         """Parse provider-specific credentials and configuration."""
+
+
+class DeclarativeOAuthProvider:
+    """Implement a standard OAuth flow from a provider definition."""
+
+    def __init__(
+        self,
+        provider: ProviderDefinition,
+        *,
+        client_id: str,
+        client_secret: str,
+        redirect_uri: str,
+    ) -> None:
+        if provider.oauth is None:
+            raise ValueError(f"Provider '{provider.ref}' does not define OAuth.")
+        values = (client_id.strip(), client_secret.strip(), redirect_uri.strip())
+        if (
+            not values[0]
+            or not values[2]
+            or (provider.oauth.token_auth_method != "none" and not values[1])
+        ):
+            raise ValueError(
+                f"{provider.display_name} OAuth configuration is incomplete."
+            )
+        self.connector_ref = provider.ref
+        self.display_name = provider.display_name
+        self.description = provider.description
+        self._oauth = provider.oauth
+        self._client_id, self._client_secret, self._redirect_uri = values
+
+    def resolve_redirect_uri(self, requested_redirect_uri: str) -> str:
+        """Require the redirect URI configured for the provider application."""
+        if requested_redirect_uri.strip() != self._redirect_uri:
+            raise ValueError(f"{self.display_name} redirect URI is not allowed.")
+        return self._redirect_uri
+
+    def build_authorization_url(
+        self,
+        *,
+        redirect_uri: str,
+        state: str,
+        pkce_challenge: str | None,
+    ) -> str:
+        """Build an authorization URL from declarative OAuth settings."""
+        params = _string_mapping(self._oauth.authorization_params)
+        params.update(
+            {
+                "client_id": self._client_id,
+                "redirect_uri": redirect_uri,
+                "response_type": "code",
+                "state": state,
+            }
+        )
+        if self._oauth.scopes:
+            params["scope"] = self._oauth.scope_separator.join(self._oauth.scopes)
+        if self._oauth.use_pkce:
+            if not pkce_challenge:
+                raise ValueError(f"{self.display_name} OAuth requires PKCE.")
+            params.update(
+                {"code_challenge": pkce_challenge, "code_challenge_method": "S256"}
+            )
+        return f"{self._oauth.authorization_url}?{urlencode(params)}"
+
+    def exchange_code(
+        self,
+        *,
+        code: str,
+        redirect_uri: str,
+        pkce_verifier: str | None,
+    ) -> tuple[JSONObject, JSONObject]:
+        """Exchange an authorization code and extract standard token fields."""
+        if not code:
+            raise self._error("exchange failed")
+        body: JSONObject = {
+            **self._oauth.token_params,
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+        }
+        if self._oauth.use_pkce:
+            if not pkce_verifier:
+                raise self._error("exchange failed")
+            body["code_verifier"] = pkce_verifier
+        auth: tuple[str, str] | None = None
+        if self._oauth.token_auth_method == "client_secret_basic":
+            auth = (self._client_id, self._client_secret)
+        elif self._oauth.token_auth_method == "client_secret_post":
+            body.update(
+                {"client_id": self._client_id, "client_secret": self._client_secret}
+            )
+        else:
+            body["client_id"] = self._client_id
+        response = self._request_token(body, auth)
+        token_payload = self._read_token_payload(response)
+        return self._extract_token_fields(token_payload)
+
+    def _request_token(
+        self, body: JSONObject, auth: tuple[str, str] | None
+    ) -> requests.Response:
+        """Send one token request using the configured encoding."""
+        try:
+            if self._oauth.token_request_format == "json":
+                return requests.post(
+                    self._oauth.token_url, auth=auth, json=body, timeout=30.0
+                )
+            return requests.post(
+                self._oauth.token_url, auth=auth, data=body, timeout=30.0
+            )
+        except requests.RequestException:
+            raise self._error("exchange failed") from None
+
+    def _read_token_payload(self, response: requests.Response) -> JSONObject:
+        """Validate and unwrap one token response."""
+        if response.status_code >= 400:
+            raise self._error("exchange failed")
+        try:
+            payload = response.json()
+        except ValueError:
+            raise self._error("returned an invalid response") from None
+        if not isinstance(payload, dict):
+            raise self._error("returned an invalid response")
+        token_payload = _nested_object(
+            cast(JSONObject, payload), self._oauth.token_response_path, self._error
+        )
+        if "error" in token_payload:
+            raise self._error("exchange failed")
+        return token_payload
+
+    def _extract_token_fields(
+        self, token_payload: JSONObject
+    ) -> tuple[JSONObject, JSONObject]:
+        """Separate credentials from non-secret provider configuration."""
+        access_token = token_payload.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            raise self._error("returned an invalid response")
+        credentials: JSONObject = {"access_token": access_token}
+        for key in ("refresh_token", "expires_in", "token_type"):
+            value = token_payload.get(key)
+            if isinstance(value, (str, int)) and not isinstance(value, bool):
+                credentials[key] = value
+        config: JSONObject = {}
+        for key in self._oauth.config_fields:
+            value = token_payload.get(key)
+            if isinstance(value, (str, int, float, bool)) or value is None:
+                config[key] = value
+        return credentials, config
+
+    def _error(self, detail: str) -> RuntimeError:
+        """Build a provider-labelled, secret-safe OAuth error."""
+        return RuntimeError(f"{self.display_name} OAuth {detail}.")
+
+
+def load_declarative_oauth_provider(
+    provider: ProviderDefinition,
+) -> DeclarativeOAuthProvider | None:
+    """Load a provider's OAuth app from its declared environment variables."""
+    if provider.oauth is None:
+        return None
+    oauth = provider.oauth
+    values = (
+        os.getenv(oauth.client_id_env, ""),
+        os.getenv(oauth.client_secret_env, "") if oauth.client_secret_env else "",
+        os.getenv(oauth.redirect_uri_env, ""),
+    )
+    if not any(value.strip() for value in values):
+        return None
+    return DeclarativeOAuthProvider(
+        provider,
+        client_id=values[0],
+        client_secret=values[1],
+        redirect_uri=values[2],
+    )
+
+
+def _string_mapping(value: Mapping[str, object]) -> dict[str, str]:
+    """Validate provider-defined static request parameters."""
+    if not all(isinstance(item, str) for item in value.values()):
+        raise ValueError("OAuth static parameters must be strings.")
+    return {key: cast(str, item) for key, item in value.items()}
+
+
+def _nested_object(
+    payload: JSONObject,
+    path: tuple[str, ...],
+    error: Callable[[str], RuntimeError],
+) -> JSONObject:
+    """Read a configured object envelope from an OAuth response."""
+    current = payload
+    for key in path:
+        value = current.get(key)
+        if not isinstance(value, dict):
+            raise error("returned an invalid response")
+        current = value
+    return current

--- a/framework/py/flwr/supercore/task_process/connector/providers/README.md
+++ b/framework/py/flwr/supercore/task_process/connector/providers/README.md
@@ -1,0 +1,36 @@
+# Connector providers
+
+Create a standard OAuth connector from `framework/`:
+
+```bash
+uv run --no-sync --python=3.11.14 \
+  python -m dev.generate_connector <provider_ref> --display-name "Provider Name"
+```
+
+The command creates one package with:
+
+- `definition.py`: provider metadata, OAuth configuration, and API settings;
+- `actions.py`: model-facing action schemas and required OAuth scopes;
+- `executors.py`: provider API calls using `ConnectorContext`;
+- `__init__.py`: package marker.
+
+It also regenerates `registry_generated.py`. Do not edit that file or the central
+connector registry manually.
+
+Provider definitions are imported at startup. Executor modules are imported only
+when one of their actions runs. The shared runtime validates action/executor
+correspondence, constructs OAuth flows, supplies credentials, configures the HTTP
+client, maps provider errors, and records usage.
+
+Every action must declare `ActionAccess.READ` or `ActionAccess.WRITE`. This
+classification is provider-independent; `required_scopes` remains the source of
+provider-native OAuth permissions.
+
+After implementing a provider, run:
+
+```bash
+uv run --no-sync --python=3.11.14 \
+  python -m dev.generate_connector --check
+uv run --no-sync --python=3.11.14 \
+  python -m pytest py/flwr/supercore/task_process/connector
+```

--- a/framework/py/flwr/supercore/task_process/connector/providers/__init__.py
+++ b/framework/py/flwr/supercore/task_process/connector/providers/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Account-scoped connector provider packages."""

--- a/framework/py/flwr/supercore/task_process/connector/providers/loader.py
+++ b/framework/py/flwr/supercore/task_process/connector/providers/loader.py
@@ -1,0 +1,107 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Load generated provider definitions and lazy action executors."""
+
+from collections.abc import Mapping
+from importlib import import_module
+from types import ModuleType
+from typing import cast
+
+from flwr.supercore.typing import JSONObject, JSONValue
+
+from ..definition import ProviderDefinition
+from ..oauth import load_declarative_oauth_provider
+from ..runtime import ConnectorContext, ConnectorDefinition, ConnectorExecutor
+from .registry_generated import PROVIDER_PACKAGES
+
+
+def load_connectors() -> tuple[ConnectorDefinition, ...]:
+    """Load provider definitions while keeping executor modules lazy."""
+    connectors: list[ConnectorDefinition] = []
+    for package in PROVIDER_PACKAGES:
+        provider = _load_provider(package)
+        executors = {
+            action.name: _lazy_executor(package, action.name)
+            for action in provider.actions
+        }
+        connectors.append(
+            ConnectorDefinition(
+                provider=provider,
+                executors=executors,
+                oauth_provider=load_declarative_oauth_provider(provider),
+            )
+        )
+    return tuple(connectors)
+
+
+def validate_provider_packages() -> None:
+    """Import every provider package and validate executor correspondence."""
+    definitions = [_load_provider(package) for package in PROVIDER_PACKAGES]
+    refs = [provider.ref for provider in definitions]
+    if len(refs) != len(set(refs)):
+        raise ValueError("Provider references must be globally unique.")
+    tool_names = [
+        action.tool_name(provider.ref)
+        for provider in definitions
+        for action in provider.actions
+    ]
+    if len(tool_names) != len(set(tool_names)):
+        raise ValueError("Provider action tool names must be globally unique.")
+    for package, provider in zip(PROVIDER_PACKAGES, definitions, strict=True):
+        executors = _load_executors(package)
+        if set(executors) != {action.name for action in provider.actions}:
+            raise ValueError(
+                f"Provider '{provider.ref}' actions and executors do not match."
+            )
+
+
+def _load_provider(package: str) -> ProviderDefinition:
+    """Load and validate one provider's definition module."""
+    module = import_module(f"{package}.definition")
+    provider = getattr(module, "PROVIDER", None)
+    if not isinstance(provider, ProviderDefinition):
+        raise TypeError(f"Provider package '{package}' does not export PROVIDER.")
+    if package.rsplit(".", maxsplit=1)[-1] != provider.ref:
+        raise ValueError(
+            f"Provider package '{package}' must match reference '{provider.ref}'."
+        )
+    return provider
+
+
+def _load_executors(package: str) -> Mapping[str, ConnectorExecutor]:
+    """Load and validate one provider's executor mapping."""
+    module: ModuleType = import_module(f"{package}.executors")
+    executors = getattr(module, "EXECUTORS", None)
+    if not isinstance(executors, Mapping):
+        raise TypeError(f"Provider package '{package}' does not export EXECUTORS.")
+    if not all(
+        isinstance(name, str) and callable(value) for name, value in executors.items()
+    ):
+        raise TypeError(f"Provider package '{package}' has invalid executors.")
+    return cast(Mapping[str, ConnectorExecutor], executors)
+
+
+def _lazy_executor(package: str, action_name: str) -> ConnectorExecutor:
+    """Return an executor which imports provider implementation on first use."""
+
+    def execute(arguments: JSONObject, context: ConnectorContext) -> JSONValue:
+        executor = _load_executors(package).get(action_name)
+        if executor is None:
+            raise RuntimeError(
+                f"Provider action '{package}.{action_name}' has no executor."
+            )
+        return executor(arguments, context)
+
+    return execute

--- a/framework/py/flwr/supercore/task_process/connector/providers/loader_test.py
+++ b/framework/py/flwr/supercore/task_process/connector/providers/loader_test.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for generated provider package loading."""
+
+import sys
+from types import ModuleType
+from unittest.mock import Mock
+
+import pytest
+
+from flwr.supercore.typing import JSONObject
+
+from ..definition import ActionAccess, ActionDefinition, ProviderDefinition
+from . import loader
+
+_PACKAGE = "flwr.supercore.task_process.connector.providers.example"
+
+
+def test_provider_executors_are_lazy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Loading definitions should not import provider executor modules."""
+    definition_module = ModuleType(f"{_PACKAGE}.definition")
+    definition_module.__dict__["PROVIDER"] = ProviderDefinition(
+        ref="example",
+        display_name="Example",
+        description="Example provider.",
+        actions=(
+            ActionDefinition(
+                name="read",
+                description="Read an example.",
+                access=ActionAccess.READ,
+                input_schema={"type": "object", "properties": {}},
+            ),
+        ),
+    )
+    executor_module = ModuleType(f"{_PACKAGE}.executors")
+
+    def read(arguments: JSONObject, context: object) -> JSONObject:
+        return {"arguments": arguments}
+
+    executor_module.__dict__["EXECUTORS"] = {"read": read}
+    monkeypatch.setattr(loader, "PROVIDER_PACKAGES", (_PACKAGE,))
+    monkeypatch.setitem(sys.modules, f"{_PACKAGE}.definition", definition_module)
+    connectors = loader.load_connectors()
+    assert f"{_PACKAGE}.executors" not in sys.modules
+
+    monkeypatch.setitem(sys.modules, f"{_PACKAGE}.executors", executor_module)
+    result = connectors[0].handlers["example_read"]({"id": "1"}, Mock())
+    assert result == {"arguments": {"id": "1"}}
+    loader.validate_provider_packages()
+
+
+def test_package_validation_rejects_executor_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Contract validation should reject undeclared or missing executors."""
+    definition_module = ModuleType(f"{_PACKAGE}.definition")
+    definition_module.__dict__["PROVIDER"] = ProviderDefinition(
+        ref="example",
+        display_name="Example",
+        description="Example provider.",
+        actions=(
+            ActionDefinition(
+                name="read",
+                description="Read an example.",
+                access=ActionAccess.READ,
+                input_schema={"type": "object", "properties": {}},
+            ),
+        ),
+    )
+    executor_module = ModuleType(f"{_PACKAGE}.executors")
+    executor_module.__dict__["EXECUTORS"] = {}
+    monkeypatch.setattr(loader, "PROVIDER_PACKAGES", (_PACKAGE,))
+    monkeypatch.setitem(sys.modules, f"{_PACKAGE}.definition", definition_module)
+    monkeypatch.setitem(sys.modules, f"{_PACKAGE}.executors", executor_module)
+
+    with pytest.raises(ValueError, match="actions and executors do not match"):
+        loader.validate_provider_packages()

--- a/framework/py/flwr/supercore/task_process/connector/providers/registry_generated.py
+++ b/framework/py/flwr/supercore/task_process/connector/providers/registry_generated.py
@@ -1,0 +1,17 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Generated connector provider package registry. Do not edit."""
+
+PROVIDER_PACKAGES: tuple[str, ...] = ()

--- a/framework/py/flwr/supercore/task_process/connector/registry.py
+++ b/framework/py/flwr/supercore/task_process/connector/registry.py
@@ -21,13 +21,15 @@ from flwr.supercore.task_process.usage import TaskUsageRecorder
 from flwr.supercore.typing import JSONObject, JSONValue
 
 from . import automation, browser_use, web_fetch, web_search
-from .definition import ConnectorDefinition, ConnectorHandler
+from .http import ConnectorHttpClient
 from .oauth import OAuthConnectorProvider
+from .providers.loader import load_connectors
+from .runtime import ConnectorContext, ConnectorDefinition, ConnectorExecutor
 
 ConnectorToolFactory = Callable[[], JSONObject]
 
 
-CONNECTORS: tuple[ConnectorDefinition, ...] = ()
+CONNECTORS: tuple[ConnectorDefinition, ...] = load_connectors()
 _CONNECTORS_BY_REF = {connector.ref: connector for connector in CONNECTORS}
 
 OAUTH_CONNECTOR_PROVIDERS: tuple[OAuthConnectorProvider, ...] = tuple(
@@ -35,18 +37,21 @@ OAUTH_CONNECTOR_PROVIDERS: tuple[OAuthConnectorProvider, ...] = tuple(
     for connector in CONNECTORS
     if connector.oauth_provider is not None
 )
-_CONNECTOR_HANDLERS: dict[str, ConnectorHandler] = {
+_CONNECTOR_HANDLERS: dict[str, Callable[..., JSONValue]] = {
     web_search.WEB_SEARCH_CONNECTOR_NAME: web_search.search,
     web_fetch.WEB_FETCH_CONNECTOR_NAME: web_fetch.invoke_web_fetch_provider,
     browser_use.BROWSER_USE_CONNECTOR_NAME: browser_use.invoke_browser_use_provider,
 }
-_CREDENTIAL_CONNECTOR_HANDLERS: dict[str, ConnectorHandler] = {
+_CREDENTIAL_CONNECTOR_HANDLERS: dict[str, ConnectorExecutor] = {
     name: handler
     for connector in CONNECTORS
     for name, handler in connector.handlers.items()
 }
 _CREDENTIAL_CONNECTOR_REFS: dict[str, str] = {
     name: connector.ref for connector in CONNECTORS for name in connector.handlers
+}
+_CREDENTIAL_CONNECTORS = {
+    name: connector for connector in CONNECTORS for name in connector.handlers
 }
 _BUILTIN_CONNECTOR_TOOL_FACTORIES: dict[str, ConnectorToolFactory] = {
     automation.START_AUTOMATION_TOOL_NAME: automation.make_start_automation_tool,
@@ -73,11 +78,23 @@ def invoke_connector(
         raise ValueError(f"Unsupported connector '{name}'.")
     if credentials is None or config is None:
         raise RuntimeError("Connector credentials are required.")
+    connector = _CREDENTIAL_CONNECTORS.get(name)
+    http = None
+    if connector is not None and connector.provider.api_base_url is not None:
+        http = ConnectorHttpClient(
+            provider=connector.provider.display_name,
+            base_url=connector.provider.api_base_url,
+            credentials=credentials,
+            headers=connector.provider.api_headers,
+        )
     return handler(
-        **arguments,
-        credentials=credentials,
-        config=config,
-        usage_recorder=usage_recorder,
+        arguments,
+        ConnectorContext(
+            credentials=credentials,
+            config=config,
+            usage_recorder=usage_recorder,
+            http=http,
+        ),
     )
 
 

--- a/framework/py/flwr/supercore/task_process/connector/registry_test.py
+++ b/framework/py/flwr/supercore/task_process/connector/registry_test.py
@@ -16,6 +16,12 @@
 
 
 from .registry import CONNECTORS
+from .providers.loader import validate_provider_packages
+
+
+def test_provider_packages_satisfy_contract() -> None:
+    """Every generated provider should have valid actions and executors."""
+    validate_provider_packages()
 
 
 def test_connector_references_are_unique() -> None:

--- a/framework/py/flwr/supercore/task_process/connector/runtime.py
+++ b/framework/py/flwr/supercore/task_process/connector/runtime.py
@@ -1,0 +1,81 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Runtime types for executing declarative provider actions."""
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+from flwr.supercore.task_process.usage import TaskUsageRecorder
+from flwr.supercore.typing import JSONObject, JSONValue
+
+from .definition import ProviderDefinition
+from .http import ConnectorHttpClient
+from .oauth import OAuthConnectorProvider
+
+
+@dataclass(frozen=True)
+class ConnectorContext:
+    """Infrastructure supplied to one account-scoped action executor."""
+
+    credentials: JSONObject
+    config: JSONObject
+    usage_recorder: TaskUsageRecorder
+    http: ConnectorHttpClient | None
+
+
+ConnectorExecutor = Callable[[JSONObject, ConnectorContext], JSONValue]
+
+
+@dataclass(frozen=True)
+class ConnectorDefinition:
+    """Combine one provider definition with its runtime executors."""
+
+    provider: ProviderDefinition
+    executors: Mapping[str, ConnectorExecutor]
+    oauth_provider: OAuthConnectorProvider | None = None
+
+    def __post_init__(self) -> None:
+        """Reject action/executor drift when a provider is loaded."""
+        action_names = {action.name for action in self.provider.actions}
+        if action_names != set(self.executors):
+            raise ValueError(
+                f"Provider '{self.ref}' actions and executors do not match."
+            )
+        if (
+            self.oauth_provider is not None
+            and self.oauth_provider.connector_ref != self.ref
+        ):
+            raise ValueError(
+                f"Provider '{self.ref}' has OAuth configuration for "
+                f"'{self.oauth_provider.connector_ref}'."
+            )
+
+    @property
+    def ref(self) -> str:
+        """Return the provider reference."""
+        return self.provider.ref
+
+    @property
+    def tools(self) -> tuple[JSONObject, ...]:
+        """Return model-facing tools for this provider."""
+        return tuple(action.tool(self.ref) for action in self.provider.actions)
+
+    @property
+    def handlers(self) -> Mapping[str, ConnectorExecutor]:
+        """Return executors keyed by globally unique tool name."""
+        return {
+            action.tool_name(self.ref): self.executors[action.name]
+            for action in self.provider.actions
+        }

--- a/framework/py/flwr/supercore/task_process/connector/task_test.py
+++ b/framework/py/flwr/supercore/task_process/connector/task_test.py
@@ -97,12 +97,11 @@ class TestHandleTask(unittest.TestCase):
         handle_task(stub=self.stub, task_id=22, run_id=7)
 
         self.stub.GetConnector.assert_called_once_with(GetConnectorRequest())
-        self.provider.assert_called_once_with(
-            query="release notes",
-            credentials={"token": "secret"},
-            config={"workspace": "primary"},
-            usage_recorder=ANY,
-        )
+        self.provider.assert_called_once_with({"query": "release notes"}, ANY)
+        context = self.provider.call_args.args[1]
+        assert context.credentials == {"token": "secret"}
+        assert context.config == {"workspace": "primary"}
+        assert context.usage_recorder is not None
         assert _pushed_response(self.stub).payload == {
             "name": tool_name,
             "call_id": "call-1",


### PR DESCRIPTION
## Summary

  Introduces a declarative OAuth connector framework that keeps each provider limited to definitions, actions, and
  executors.

  - Adds shared OAuth, HTTP, execution-context, and registry infrastructure
  - Adds mandatory READ/WRITE metadata per action
  - Adds a generator for scaffolding providers and maintaining the provider registry
  - Adds registry freshness checks to development tooling
  - Adds focused validation and runtime tests

  New connectors can reuse the shared infrastructure without implementing OAuth, HTTP transport, registration, or credential handling.