### PR TITLE
refactor(framework): Use ORM for run-series writes

### DIFF
--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -679,51 +679,43 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         description: str | None = None,
     ) -> int | None:
         """Store a run in a run series and return the series ID."""
-        insert_query = """
-            INSERT INTO run_series
-            (series_id, federation_id, description, created_at, updated_at)
-            VALUES
-            (:series_id, :federation_id, :description, :created_at, :updated_at)
-            ON CONFLICT(series_id) DO NOTHING
-            RETURNING series_id
-        """
-
         try:
-            with self.session():
+            with self.session() as session:
                 if series_id is None:
                     # No series was provided, so create one before linking the run.
                     candidate = generate_rand_int_from_bytes(SERIES_ID_NUM_BYTES)
                     timestamp = now()
-                    rows = self.query(
-                        insert_query,
-                        {
-                            "series_id": uint64_to_int64(candidate),
-                            "federation_id": federation_id,
-                            "description": description,
-                            "created_at": timestamp,
-                            "updated_at": timestamp,
-                        },
+                    stmt = (
+                        self.dialect_insert(RunSeriesModel)
+                        .values(
+                            series_id=uint64_to_int64(candidate),
+                            federation_id=federation_id,
+                            description=description,
+                            created_at=timestamp,
+                            updated_at=timestamp,
+                        )
+                        .on_conflict_do_nothing(
+                            index_elements=[RunSeriesModel.series_id]
+                        )
+                        .returning(RunSeriesModel.series_id)
                     )
-                    if rows:
-                        resolved_series_id = candidate
-                    else:
+                    resolved_series_id = (
+                        candidate if session.scalar(stmt) is not None else None
+                    )
+                    if resolved_series_id is None:
                         return None
 
                 else:
-                    rows = self.query(
-                        """
-                        UPDATE run_series
-                        SET updated_at = :updated_at
-                        WHERE series_id = :series_id AND federation_id = :federation_id
-                        RETURNING series_id
-                        """,
-                        {
-                            "series_id": uint64_to_int64(series_id),
-                            "federation_id": federation_id,
-                            "updated_at": now(),
-                        },
+                    updated_series_id = session.scalar(
+                        update(RunSeriesModel)
+                        .where(
+                            RunSeriesModel.series_id == uint64_to_int64(series_id),
+                            RunSeriesModel.federation_id == federation_id,
+                        )
+                        .values(updated_at=now())
+                        .returning(RunSeriesModel.series_id)
                     )
-                    if not rows:
+                    if updated_series_id is None:
                         log(
                             ERROR,
                             "Run series %d not found in federation %r",
@@ -734,16 +726,13 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
                     resolved_series_id = series_id
 
                 # Store the membership last so callers only receive linked series IDs.
-                self.query(
-                    """
-                    INSERT INTO series_runs (series_id, run_id)
-                    VALUES (:series_id, :run_id)
-                    """,
-                    {
-                        "series_id": uint64_to_int64(resolved_series_id),
-                        "run_id": uint64_to_int64(run_id),
-                    },
+                session.add(
+                    SeriesRunsModel(
+                        series_id=uint64_to_int64(resolved_series_id),
+                        run_id=uint64_to_int64(run_id),
+                    )
                 )
+                session.flush()
                 return resolved_series_id
         except IntegrityError:
             return None


### PR DESCRIPTION
## Issue

### Description

`SqlCoreState.store_run_in_series` still uses raw SQL for run-series creation, lookup/update, and run linking.

### Related issues/PRs

Follow-up to the CoreState ORM migration series.

## Proposal

### Explanation

This PR moves run-series creation/linking to SQLAlchemy model-backed statements while preserving the existing behavior: new series are inserted atomically, existing series update `updated_at`, unknown series IDs return `None`, and duplicate run links return `None`.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [x] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [x] Make CI checks pass
- [x] Ping maintainers on Slack (channel `#contributions`)

### Any other comments?

Validation:

```shell
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m pytest py/flwr/server/superlink/linkstate/linkstate_test.py -k 'store_run_in_series or get_run_series'
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m pytest py/flwr/server/superlink/linkstate/linkstate_test.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m mypy py/flwr/supercore/corestate/sql_corestate.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m pylint --ignore=py/flwr/proto py/flwr/supercore/corestate/sql_corestate.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m isort --check-only py/flwr/supercore/corestate/sql_corestate.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m black --check py/flwr/supercore/corestate/sql_corestate.py
PYENV_VERSION=3.11 pyenv exec uv run --no-sync python -m ruff check py/flwr/supercore/corestate/sql_corestate.py
git diff --check
```

`./dev/check-migrations.sh` was also run and currently reports pre-existing federation-table autogenerate operations unrelated to this CoreState code-only change.