### PR TITLE
fix(framework:skip): Add PostgreSQL automation query regression coverage

### DIFF
--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -2374,7 +2374,9 @@ class SqlInMemoryStateTest(StateTest, unittest.TestCase):
             next_run_at="2026-08-07T00:01:00+00:00",
         )
 
-        self.assertEqual(len(captured_queries), 2)
+        self.assertTrue(captured_queries)
+        self.assertTrue(any("SELECT start_run_request" in q for q in captured_queries))
+        self.assertTrue(any("UPDATE automation" in q for q in captured_queries))
         for query in captured_queries:
             self.assertNotIn(":next_run_at IS NOT NULL", query)
 

--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -2352,6 +2352,32 @@ class SqlInMemoryStateTest(StateTest, unittest.TestCase):
         state.initialize()
         return state
 
+    def test_automation_queries_avoid_untyped_bind_null_checks(self) -> None:
+        """Automation SQL should avoid bind null checks unsupported by PostgreSQL."""
+        state = self.state_factory()
+        captured_queries: list[str] = []
+
+        # pylint: disable-next=unused-argument
+        def fake_query(query: str, data: Any = None) -> list[dict[str, Any]]:
+            captured_queries.append(query)
+            return []
+
+        state.query = fake_query  # type: ignore[method-assign]
+        state.claim_automation(
+            1,
+            previous_next_run_at="2026-08-07T00:00:00+00:00",
+            next_run_at="2026-08-07T00:01:00+00:00",
+        )
+        state.advance_automation(
+            1,
+            previous_next_run_at="2026-08-07T00:00:00+00:00",
+            next_run_at="2026-08-07T00:01:00+00:00",
+        )
+
+        self.assertEqual(len(captured_queries), 2)
+        for query in captured_queries:
+            self.assertNotIn(":next_run_at IS NOT NULL", query)
+
     def test_get_fab_refreshes_cached_row_in_shared_session(self) -> None:
         """Test get_fab observes raw SQL updates in a shared session."""
         state = self.state_factory()


### PR DESCRIPTION
## Issue

### Description

PostgreSQL cannot infer a bind parameter type from a standalone `:next_run_at IS NOT NULL` predicate. The automation claim queries were fixed in #7771 and #7773, but the existing behavioral tests run against SQLite and did not guard the generated SQL. That allowed the first fix to cover the `SELECT` while leaving the same unsupported predicate in the `UPDATE`.

### Related issues/PRs

Follow-up to #7771 and #7773.

## Proposal

### Explanation

Add a SQL-specific regression test that captures the queries emitted by `claim_automation` and `advance_automation` and verifies that neither reintroduces the untyped bind null check. The test would fail on both the original implementation and the partially fixed revision.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [ ] Update documentation (not applicable; test-only change)
- [ ] Address LLM-reviewer comments, if applicable
- [ ] Make CI checks pass
- [ ] Ping maintainers on Slack

### Any other comments?

No production code or public API behavior changes.