### PR TITLE
refactor(framework): Annotate dialect insert return types

### DIFF
--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -123,7 +123,7 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         self._object_store = object_store
 
     def dialect_insert(self, table: Any) -> SQLiteInsert | PostgresInsert:
-        """Return a SQLite insert statement for CoreState upserts."""
+        """Return a dialect-specific insert statement for CoreState upserts."""
         if self.database_backend == "sqlite":
             return sqlite_insert(table)
 

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -25,6 +25,7 @@ from typing import Any, Literal, cast
 from uuid import uuid4
 
 from sqlalchemy import MetaData, delete, func, insert, literal, or_, select, update
+from sqlalchemy.dialects.postgresql import Insert as PostgresInsert
 from sqlalchemy.dialects.sqlite import Insert as SQLiteInsert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
@@ -121,7 +122,7 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         super().__init__(database_path)
         self._object_store = object_store
 
-    def dialect_insert(self, table: Any) -> SQLiteInsert:
+    def dialect_insert(self, table: Any) -> SQLiteInsert | PostgresInsert:
         """Return a SQLite insert statement for CoreState upserts."""
         if self.database_backend == "sqlite":
             return sqlite_insert(table)


### PR DESCRIPTION
## What changed

- Import the PostgreSQL dialect-specific `Insert` type in `sql_corestate.py`.
- Annotate `SqlCoreState.dialect_insert` as returning either `SQLiteInsert` or `PostgresInsert`.
- Leave `sql_linkstate.py` and `sql_object_store.py` unchanged because neither defines its own `dialect_insert` method.

## Why

The method can be overridden for PostgreSQL-backed state implementations, so its return annotation should represent both supported dialect-specific insert statement types. This improves type-checking for PostgreSQL implementations without changing runtime behavior.

## Validation

- `uv run --no-sync --python=3.11.14 python -m ruff check py/flwr/supercore/corestate/sql_corestate.py`
- `uv run --no-sync --python=3.11.14 python -m mypy py/flwr/supercore/corestate/sql_corestate.py`

No unit tests were added, as requested.