### PR TITLE
fix(framework): Allow ClientAppIo PullMessages to return empty response

### DIFF
--- a/framework/py/flwr/supernode/runtime/run_clientapp.py
+++ b/framework/py/flwr/supernode/runtime/run_clientapp.py
@@ -244,6 +244,8 @@ def pull_task_input(stub: ClientAppIoStub) -> tuple[Message, Context, Run, Fab]:
 
     # Pull and inflate the message
     pull_msg_res: PullAppMessagesResponse = stub.PullMessages(PullAppMessagesRequest())
+    if not pull_msg_res.messages_list:
+        raise RuntimeError("No messages received from ClientAppIo")
     run_id = context.run_id
     node = Node(node_id=context.node_id)
     object_tree = pull_msg_res.message_object_trees[0]

--- a/framework/py/flwr/supernode/runtime/run_clientapp_test.py
+++ b/framework/py/flwr/supernode/runtime/run_clientapp_test.py
@@ -16,21 +16,44 @@
 
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import grpc
 
+from flwr.common.serde import fab_to_proto
+from flwr.proto.appio_pb2 import (  # pylint: disable=E0611
+    PullAppMessagesResponse,
+    PullTaskInputResponse,
+)
+from flwr.proto.message_pb2 import Context as ProtoContext  # pylint: disable=E0611
+from flwr.proto.run_pb2 import Run as ProtoRun  # pylint: disable=E0611
 from flwr.supercore.exit import ExitCode
+from flwr.supercore.fab import Fab
 from flwr.supercore.interceptors import (
     AppIoTokenClientInterceptor,
     RuntimeVersionClientInterceptor,
 )
 
-from .run_clientapp import run_clientapp
+from .run_clientapp import pull_task_input, run_clientapp
 
 
 class TestRunClientApp(unittest.TestCase):
     """Tests for `run_clientapp`."""
+
+    def test_pull_task_input_raises_when_no_message_received(self) -> None:
+        """`pull_task_input` should reject an empty PullMessages response."""
+        stub = Mock()
+        stub.PullTaskInput.return_value = PullTaskInputResponse(
+            context=ProtoContext(run_id=61016, node_id=123),
+            run=ProtoRun(run_id=61016),
+            fab=fab_to_proto(Fab("hash", b"content", {})),
+        )
+        stub.PullMessages.return_value = PullAppMessagesResponse()
+
+        with self.assertRaisesRegex(
+            RuntimeError, "No messages received from ClientAppIo"
+        ):
+            pull_task_input(stub)
 
     def test_run_clientapp_adds_client_interceptors(self) -> None:
         """`run_clientapp` should add client interceptors to gRPC channel creation."""

--- a/framework/py/flwr/supernode/servicer/clientappio/clientappio_servicer.py
+++ b/framework/py/flwr/supernode/servicer/clientappio/clientappio_servicer.py
@@ -203,13 +203,9 @@ class ClientAppIoServicer(AppIoServicer, clientappio_pb2_grpc.ClientAppIoService
         store = self.objectstore_factory.store()
 
         # Retrieve message for this run
-        messages = state.get_messages(run_ids=[run_id], is_reply=False)
+        messages = state.get_messages(run_ids=[run_id], is_reply=False, limit=1)
         if not messages:
-            context.abort(
-                grpc.StatusCode.NOT_FOUND,
-                f"No message found for run {run_id} in NodeState.",
-            )
-            raise RuntimeError("Unreachable code")  # for mypy
+            return PullAppMessagesResponse()
         message = messages[0]
 
         # Record message processing start time

--- a/framework/py/flwr/supernode/servicer/clientappio/clientappio_servicer_test.py
+++ b/framework/py/flwr/supernode/servicer/clientappio/clientappio_servicer_test.py
@@ -263,11 +263,10 @@ class TestClientAppIoServicer(unittest.TestCase):
         self.assertEqual(finish_task_kwargs["task_id"], task_id)
         self.assertEqual(finish_task_kwargs["sub_status"], request.sub_status)
 
-    def test_servicer_pull_messages_aborts_when_no_message_found(self) -> None:
-        """PullMessages should abort cleanly when no message is available."""
+    def test_servicer_pull_messages_returns_empty_response(self) -> None:
+        """PullMessages should return an empty response when no message is available."""
         run_id = 61016
         context = Mock()
-        context.abort.side_effect = grpc.RpcError()
         self.mock_state.get_messages.return_value = []
 
         with patch(
@@ -275,13 +274,11 @@ class TestClientAppIoServicer(unittest.TestCase):
             "get_authenticated_task",
             return_value=Mock(run_id=run_id),
         ):
-            with self.assertRaises(grpc.RpcError):
-                self.servicer.PullMessages(PullAppMessagesRequest(), context)
+            response = self.servicer.PullMessages(PullAppMessagesRequest(), context)
 
-        context.abort.assert_called_once_with(
-            grpc.StatusCode.NOT_FOUND,
-            f"No message found for run {run_id} in NodeState.",
-        )
+        self.assertEqual(list(response.messages_list), [])
+        self.assertEqual(list(response.message_object_trees), [])
+        context.abort.assert_not_called()
         self.mock_state.record_message_processing_start.assert_not_called()
 
     @parameterized.expand([(0, 0), (1, 0), (0, 1), (2, 1), (1, 2)])  # type: ignore


### PR DESCRIPTION
## What changed

- Return an empty `PullAppMessagesResponse` when ClientAppIo has no message available.
- Raise a clear runtime error in `flwr-clientapp` when `PullMessages` returns no messages.
- Add focused coverage for the servicer and client runtime behavior.

## Why

ClientAppIo previously converted an empty message result into a gRPC `NOT_FOUND` error, unlike ServerAppIo. This aligns the RPC behavior while keeping the ClientApp process responsible for treating the missing task message as fatal.

## Impact

ClientAppIo callers can now receive a valid empty response. `flwr-clientapp` exits through its existing task-process exception path instead of relying on a transport-level error.

## Validation

- `python -m isort` on the four changed files
- `python -m black` on the four changed files
- `python -m mypy` on the four changed files
- `python -m pylint` on the four changed files (10.00/10)
- Focused pytest modules (21 passed)
- `dev/devtool/check_pr_title.py`