### PR TITLE
fix(framework): Handle PostgreSQL automation timestamps

### DIFF
--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -2449,7 +2449,7 @@ class SqlInMemoryStateTest(StateTest, unittest.TestCase):
             """,
             {"automation_id": uint64_to_int64(legacy.automation_id)},
         )
-        self.assertNotIn("T", rows[0]["next_run_at"])
+        self.assertNotIn("T", str(rows[0]["next_run_at"]))
 
     def test_legacy_automation_normalization_flag_waits_for_commit(self) -> None:
         """Rolled-back timestamp normalization does not poison later reads."""


### PR DESCRIPTION
## Description

The automation timestamp ordering test assumes that a raw SQL query returns `next_run_at` as a string.

SQLAlchemy returns the same value as a native `datetime` for PostgreSQL, so the assertion raises a `TypeError` when checking for the legacy ISO timestamp separator. Converting the queried value to `str` keeps the assertion database-independent while preserving the original behavior being tested.

## Validation

- `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 uv run --no-sync --python=3.11.14 python -m pytest py/flwr/server/superlink/linkstate/linkstate_test.py -k "legacy_automation_timestamp_ordering_is_chronological"`
- `uv run --no-sync --python=3.11.14 python -m ruff check py/flwr/server/superlink/linkstate/linkstate_test.py`
- `uv run --no-sync --python=3.11.14 python -m black --check py/flwr/server/superlink/linkstate/linkstate_test.py`
