### PR TITLE
ci(framework:skip): Fix E2E Python cache key

### DIFF
--- a/.github/workflows/framework-e2e.yml
+++ b/.github/workflows/framework-e2e.yml
@@ -258,7 +258,9 @@ jobs:
         if: ${{ needs.changes.outputs.framework == 'true' && github.ref_name == 'main' &&  !steps.cache-restore-python.outputs.cache-hit }}
         with:
           path: ${{ env.pythonLocation }}
-          key: pythonloc-${{ runner.os }}-${{ matrix.directory }}-${{ env.pythonLocation }}-${{ hashFiles(format('./framework/e2e/{0}/pyproject.toml', matrix.directory)) }}
+          # The E2E scripts mutate pyproject.toml while the tests run. Reuse the
+          # key computed during restore so the saved cache remains restorable.
+          key: ${{ steps.cache-restore-python.outputs.cache-primary-key }}
 
   strategies:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

- Reuse the cache key produced during Python-location restore when saving the cache.
- Keep the E2E dependency cache restorable after test scripts mutate their local `pyproject.toml`.

## Root cause

The workflow calculated the restore key before the E2E tests and recalculated a different save key after the tests. The test harness edits `pyproject.toml`, so the hash changed and the saved cache could not be restored.

## Performance impact

The referenced TensorFlow job spent about 52–62 seconds installing Python dependencies. On subsequent cache-hit runs, this fix keeps the saved cache key aligned with the restore key, allowing that setup work to be reused and avoiding most of the dependency-install cost. The first run still pays the normal installation cost.

## Validation

- `git diff --check`
- Workflow YAML parsed successfully
- Full GitHub Actions matrix passes