### PR TITLE
ci(framework:skip): Reduce PyTorch E2E workload

### DIFF
--- a/framework/e2e/e2e-pytorch/e2e_pytorch/client_app.py
+++ b/framework/e2e/e2e-pytorch/e2e_pytorch/client_app.py
@@ -44,17 +44,17 @@ class Net(nn.Module):
 
     def __init__(self) -> None:
         super(Net, self).__init__()
-        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.conv1 = nn.Conv2d(3, 4, 5)
         self.pool = nn.MaxPool2d(2, 2)
-        self.conv2 = nn.Conv2d(6, 16, 5)
-        self.fc1 = nn.Linear(16 * 5 * 5, 120)
-        self.fc2 = nn.Linear(120, 84)
-        self.fc3 = nn.Linear(84, 10)
+        self.conv2 = nn.Conv2d(4, 8, 5)
+        self.fc1 = nn.Linear(8 * 5 * 5, 32)
+        self.fc2 = nn.Linear(32, 16)
+        self.fc3 = nn.Linear(16, 10)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
-        x = x.view(-1, 16 * 5 * 5)
+        x = x.view(-1, 8 * 5 * 5)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         return self.fc3(x)

--- a/framework/e2e/e2e-pytorch/e2e_pytorch/client_app.py
+++ b/framework/e2e/e2e-pytorch/e2e_pytorch/client_app.py
@@ -20,7 +20,7 @@ from flwr.clientapp import ClientApp
 
 warnings.filterwarnings("ignore", category=UserWarning)
 DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-SUBSET_SIZE = 1000
+SUBSET_SIZE = 100
 STATE_VAR = "timestamp"
 
 
@@ -100,6 +100,7 @@ def load_data():
 # #############################################################################
 
 # Load model and data (simple CNN, CIFAR-10)
+torch.manual_seed(42)
 net = Net().to(DEVICE)
 trainloader, testloader = load_data()
 

--- a/framework/e2e/e2e-pytorch/e2e_pytorch/server_app.py
+++ b/framework/e2e/e2e-pytorch/e2e_pytorch/server_app.py
@@ -39,7 +39,7 @@ def main(grid, context):
     # Construct the LegacyContext
     context = fl.server.LegacyContext(
         context=context,
-        config=fl.server.ServerConfig(num_rounds=3),
+        config=fl.server.ServerConfig(num_rounds=2),
     )
 
     # Create the workflow
@@ -62,7 +62,7 @@ if __name__ == "__main__":
 
     hist = fl.server.start_server(
         server_address="127.0.0.1:8080",
-        config=fl.server.ServerConfig(num_rounds=3),
+        config=fl.server.ServerConfig(num_rounds=2),
         strategy=strategy,
     )
 

--- a/framework/e2e/e2e-pytorch/simulation.py
+++ b/framework/e2e/e2e-pytorch/simulation.py
@@ -35,7 +35,7 @@ strategy = fl.server.strategy.FedAvg(
 hist = fl.simulation.start_simulation(
     client_fn=client_fn,
     num_clients=2,
-    config=fl.server.ServerConfig(num_rounds=3),
+    config=fl.server.ServerConfig(num_rounds=2),
     strategy=strategy,
 )
 

--- a/framework/e2e/e2e-pytorch/simulation_next.py
+++ b/framework/e2e/e2e-pytorch/simulation_next.py
@@ -4,7 +4,7 @@ import flwr as fl
 
 # Define ServerAppp
 server_app = fl.serverapp.ServerApp(
-    config=fl.server.ServerConfig(num_rounds=3),
+    config=fl.server.ServerConfig(num_rounds=2),
 )
 
 


### PR DESCRIPTION
## Summary

- Reduce the CIFAR-10 client fixture from 1,000 to 100 training examples.
- Shrink the CNN channel and dense-layer widths for the integration fixture.
- Reduce federation from three rounds to two while keeping multi-round state exchange.
- Seed PyTorch initialization so the smoke test remains reproducible.

## Why

The Framework / e2e-pytorch job spent 255 seconds in the baseline run. This E2E validates the PyTorch/Flower integration, client fit/evaluate flow, parameter exchange, and server lifecycle; a smaller deterministic fixture and model preserve that coverage without production-scale compute.

## Performance impact

Baseline from GitHub Actions run 31481576935:

- Framework / e2e-pytorch: 255s
- Driver test: 91s
- Virtual-client test: 31s
- Simulation-engine test: 24s

Measured on GitHub Actions run 31497169835:

- Framework / e2e-pytorch: 255s → 186s (69s, ~27% faster)

## Validation

- python3 -m py_compile framework/e2e/e2e-pytorch/e2e_pytorch/client_app.py
- git diff --check