### PR TITLE
ci(framework:skip): Reduce Opacus E2E workload

### DIFF
--- a/framework/e2e/e2e-opacus/e2e_opacus/client_app.py
+++ b/framework/e2e/e2e-opacus/e2e_opacus/client_app.py
@@ -16,6 +16,7 @@ from flwr.clientapp import ClientApp
 # Define parameters.
 PARAMS = {
     "batch_size": 32,
+    "dataset_size": 200,
     "train_split": 0.7,
     "local_epochs": 1,
 }
@@ -96,10 +97,10 @@ def load_data():
         [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
     )
     data = Cifar10Dataset("train", transform=transform)
-    split = math.floor(len(data) * 0.01 * PARAMS["train_split"])
+    split = math.floor(PARAMS["dataset_size"] * PARAMS["train_split"])
     trainset = torch.utils.data.Subset(data, list(range(0, split)))
     testset = torch.utils.data.Subset(
-        data, list(range(split, math.floor(len(data) * 0.01)))
+        data, list(range(split, PARAMS["dataset_size"]))
     )
     trainloader = DataLoader(trainset, PARAMS["batch_size"])
     testloader = DataLoader(testset, PARAMS["batch_size"])

--- a/framework/e2e/e2e-opacus/e2e_opacus/client_app.py
+++ b/framework/e2e/e2e-opacus/e2e_opacus/client_app.py
@@ -99,9 +99,7 @@ def load_data():
     data = Cifar10Dataset("train", transform=transform)
     split = math.floor(PARAMS["dataset_size"] * PARAMS["train_split"])
     trainset = torch.utils.data.Subset(data, list(range(0, split)))
-    testset = torch.utils.data.Subset(
-        data, list(range(split, PARAMS["dataset_size"]))
-    )
+    testset = torch.utils.data.Subset(data, list(range(split, PARAMS["dataset_size"])))
     trainloader = DataLoader(trainset, PARAMS["batch_size"])
     testloader = DataLoader(testset, PARAMS["batch_size"])
     sample_rate = PARAMS["batch_size"] / len(trainset)

--- a/framework/e2e/e2e-opacus/e2e_opacus/client_app.py
+++ b/framework/e2e/e2e-opacus/e2e_opacus/client_app.py
@@ -48,17 +48,17 @@ class Cifar10Dataset(torch.utils.data.Dataset):
 class Net(nn.Module):
     def __init__(self) -> None:
         super(Net, self).__init__()
-        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.conv1 = nn.Conv2d(3, 4, 5)
         self.pool = nn.MaxPool2d(2, 2)
-        self.conv2 = nn.Conv2d(6, 16, 5)
-        self.fc1 = nn.Linear(16 * 5 * 5, 120)
-        self.fc2 = nn.Linear(120, 84)
-        self.fc3 = nn.Linear(84, 10)
+        self.conv2 = nn.Conv2d(4, 8, 5)
+        self.fc1 = nn.Linear(8 * 5 * 5, 32)
+        self.fc2 = nn.Linear(32, 16)
+        self.fc3 = nn.Linear(16, 10)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
-        x = x.view(-1, 16 * 5 * 5)
+        x = x.view(-1, 8 * 5 * 5)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)

--- a/framework/e2e/e2e-opacus/e2e_opacus/client_app.py
+++ b/framework/e2e/e2e-opacus/e2e_opacus/client_app.py
@@ -19,6 +19,7 @@ PARAMS = {
     "fixture_size": 200,
     "local_epochs": 1,
 }
+TRAIN_SPLIT = 0.7
 PRIVACY_PARAMS = {
     # 'target_epsilon': 5.0,
     "target_delta": 1e-5,
@@ -96,9 +97,9 @@ def load_data():
         [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
     )
     data = Cifar10Dataset("train", transform=transform)
-    split = math.floor(PARAMS["dataset_size"] * PARAMS["train_split"])
+    split = math.floor(PARAMS["fixture_size"] * TRAIN_SPLIT)
     trainset = torch.utils.data.Subset(data, list(range(0, split)))
-    testset = torch.utils.data.Subset(data, list(range(split, PARAMS["dataset_size"])))
+    testset = torch.utils.data.Subset(data, list(range(split, PARAMS["fixture_size"])))
     trainloader = DataLoader(trainset, PARAMS["batch_size"])
     testloader = DataLoader(testset, PARAMS["batch_size"])
     sample_rate = PARAMS["batch_size"] / len(trainset)

--- a/framework/e2e/e2e-opacus/e2e_opacus/client_app.py
+++ b/framework/e2e/e2e-opacus/e2e_opacus/client_app.py
@@ -16,8 +16,7 @@ from flwr.clientapp import ClientApp
 # Define parameters.
 PARAMS = {
     "batch_size": 32,
-    "dataset_size": 200,
-    "train_split": 0.7,
+    "fixture_size": 200,
     "local_epochs": 1,
 }
 PRIVACY_PARAMS = {

--- a/framework/e2e/e2e-opacus/e2e_opacus/server_app.py
+++ b/framework/e2e/e2e-opacus/e2e_opacus/server_app.py
@@ -39,7 +39,7 @@ def main(grid, context):
     # Construct the LegacyContext
     context = fl.server.LegacyContext(
         context=context,
-        config=fl.server.ServerConfig(num_rounds=3),
+        config=fl.server.ServerConfig(num_rounds=2),
     )
 
     # Create the workflow
@@ -62,7 +62,7 @@ if __name__ == "__main__":
 
     hist = fl.server.start_server(
         server_address="127.0.0.1:8080",
-        config=fl.server.ServerConfig(num_rounds=3),
+        config=fl.server.ServerConfig(num_rounds=2),
         strategy=strategy,
     )
 

--- a/framework/e2e/e2e-opacus/simulation.py
+++ b/framework/e2e/e2e-opacus/simulation.py
@@ -5,7 +5,7 @@ import flwr as fl
 hist = fl.simulation.start_simulation(
     client_fn=client_fn,
     num_clients=2,
-    config=fl.server.ServerConfig(num_rounds=3),
+    config=fl.server.ServerConfig(num_rounds=2),
 )
 
 assert (


### PR DESCRIPTION
## Summary

- Make the Opacus CIFAR-10 fixture size explicit at 200 total examples.
- Shrink the CNN channel and dense-layer widths while preserving the DP training path.
- Reduce federation from three rounds to two while keeping multi-round state exchange.

## Why

The Framework / e2e-opacus job spent 236 seconds in the baseline run. This E2E validates Flower/Opacus integration, privacy-engine setup, training, evaluation, parameter exchange, and the server lifecycle; a smaller deterministic fixture and model preserve that coverage without unnecessary CPU work.

## Performance impact

Baseline from GitHub Actions run 31481576935:

- Framework / e2e-opacus: 236s
- Driver test: 101s
- Virtual-client test: 32s

Measured on GitHub Actions run 31497123925:

- Framework / e2e-opacus: 236s → 193s (43s, ~18% faster)

## Validation

- python3 -m py_compile framework/e2e/e2e-opacus/e2e_opacus/client_app.py
- git diff --check