### PR TITLE
ci(framework:skip): Use a tiny model for FastAI E2E

### DIFF
--- a/framework/e2e/e2e-fastai/e2e_fastai/client_app.py
+++ b/framework/e2e/e2e-fastai/e2e_fastai/client_app.py
@@ -20,7 +20,7 @@ dls = ImageDataLoaders.from_folder(
     path, valid_pct=0.5, train="training", valid="testing", num_workers=0
 )
 
-subset_size = 100  # Or whatever
+subset_size = 50  # Enough examples to exercise fit and evaluation.
 selected_train = np.random.choice(dls.train_ds.items, subset_size, replace=False)
 selected_valid = np.random.choice(dls.valid_ds.items, subset_size, replace=False)
 # Swap in the subset for the whole thing (Note: this mutates dls, so re-initialize before full training!)

--- a/framework/e2e/e2e-fastai/e2e_fastai/client_app.py
+++ b/framework/e2e/e2e-fastai/e2e_fastai/client_app.py
@@ -31,7 +31,7 @@ dls.valid = dls.test_dl(selected_valid, with_labels=True)
 # so a production-sized pretrained model only adds CPU time.
 learn = Learner(
     dls,
-    nn.Sequential(nn.Flatten(), nn.Linear(28 * 28, 10)),
+    nn.Sequential(nn.Flatten(), nn.Linear(3 * 28 * 28, 10)),
     metrics=error_rate,
 )
 

--- a/framework/e2e/e2e-fastai/e2e_fastai/client_app.py
+++ b/framework/e2e/e2e-fastai/e2e_fastai/client_app.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 
 import numpy as np
 import torch
+import torch.nn as nn
 from fastai.vision.all import *
 
 from flwr.app import Context
@@ -26,8 +27,13 @@ selected_valid = np.random.choice(dls.valid_ds.items, subset_size, replace=False
 dls.train = dls.test_dl(selected_train, with_labels=True)
 dls.valid = dls.test_dl(selected_valid, with_labels=True)
 
-# Define model
-learn = vision_learner(dls, squeezenet1_1, metrics=error_rate)
+# Define a small model. The E2E test exercises the FastAI/Flower integration,
+# so a production-sized pretrained model only adds CPU time.
+learn = Learner(
+    dls,
+    nn.Sequential(nn.Flatten(), nn.Linear(28 * 28, 10)),
+    metrics=error_rate,
+)
 
 
 # Define Flower client

--- a/framework/e2e/e2e-fastai/e2e_fastai/server_app.py
+++ b/framework/e2e/e2e-fastai/e2e_fastai/server_app.py
@@ -39,7 +39,7 @@ def main(grid, context):
     # Construct the LegacyContext
     context = fl.server.LegacyContext(
         context=context,
-        config=fl.server.ServerConfig(num_rounds=3),
+        config=fl.server.ServerConfig(num_rounds=2),
     )
 
     # Create the workflow
@@ -62,7 +62,7 @@ if __name__ == "__main__":
 
     hist = fl.server.start_server(
         server_address="127.0.0.1:8080",
-        config=fl.server.ServerConfig(num_rounds=3),
+        config=fl.server.ServerConfig(num_rounds=2),
         strategy=strategy,
     )
 

--- a/framework/e2e/e2e-fastai/simulation.py
+++ b/framework/e2e/e2e-fastai/simulation.py
@@ -5,7 +5,7 @@ import flwr as fl
 hist = fl.simulation.start_simulation(
     client_fn=client_fn,
     num_clients=2,
-    config=fl.server.ServerConfig(num_rounds=3),
+    config=fl.server.ServerConfig(num_rounds=2),
 )
 
 assert (


### PR DESCRIPTION
## Summary

- Replace the SqueezeNet model with a small linear classifier for the FastAI smoke test.
- Reduce the fixture from 100 to 50 examples.
- Reduce federation from three rounds to two while keeping multi-round state exchange.
- Keep the FastAI learner, Flower client, fit, evaluation, and federated workflow unchanged.

## Why

The Framework / e2e-fastai job spent 257 seconds in the baseline run. The E2E verifies FastAI/Flower integration rather than production-model throughput, so a tiny model and fixture preserve the learner/client workflow without SqueezeNet's unnecessary CPU cost.

## Performance impact

Baseline from GitHub Actions run 31481576935:

- Framework / e2e-fastai: 257s
- Driver test: 100s
- Virtual-client test: 32s

Measured on GitHub Actions run 31497121806:

- Framework / e2e-fastai: 257s → 195s (62s, ~24% faster)

## Validation

- python3 -m py_compile framework/e2e/e2e-fastai/e2e_fastai/client_app.py
- git diff --check