### PR TITLE
ci(framework:skip): Reduce PyTorch Lightning E2E workload

### DIFF
--- a/framework/e2e/e2e-pytorch-lightning/e2e_pytorch_lightning/mnist.py
+++ b/framework/e2e/e2e-pytorch-lightning/e2e_pytorch_lightning/mnist.py
@@ -14,6 +14,8 @@ from torch.nn import functional as F
 from torch.utils.data import DataLoader
 from torchvision import transforms
 
+MAX_PARTITION_SAMPLES = 100
+
 
 class LitAutoEncoder(pl.LightningModule):
     def __init__(self):
@@ -81,6 +83,7 @@ def load_data(partition_id, num_partitions):
             partitioners={"train": partitioner},
         )
     partition = fds.load_partition(partition_id, "train")
+    partition = partition.select(range(min(MAX_PARTITION_SAMPLES, len(partition))))
 
     partition = partition.with_transform(apply_transforms)
     # 20 % for on federated evaluation

--- a/framework/e2e/e2e-pytorch-lightning/e2e_pytorch_lightning/mnist.py
+++ b/framework/e2e/e2e-pytorch-lightning/e2e_pytorch_lightning/mnist.py
@@ -21,14 +21,14 @@ class LitAutoEncoder(pl.LightningModule):
     def __init__(self):
         super().__init__()
         self.encoder = nn.Sequential(
-            nn.Linear(28 * 28, 64),
+            nn.Linear(28 * 28, 16),
             nn.ReLU(),
-            nn.Linear(64, 3),
+            nn.Linear(16, 3),
         )
         self.decoder = nn.Sequential(
-            nn.Linear(3, 64),
+            nn.Linear(3, 16),
             nn.ReLU(),
-            nn.Linear(64, 28 * 28),
+            nn.Linear(16, 28 * 28),
         )
 
     def forward(self, x):

--- a/framework/e2e/e2e-pytorch-lightning/e2e_pytorch_lightning/server_app.py
+++ b/framework/e2e/e2e-pytorch-lightning/e2e_pytorch_lightning/server_app.py
@@ -39,7 +39,7 @@ def main(grid, context):
     # Construct the LegacyContext
     context = fl.server.LegacyContext(
         context=context,
-        config=fl.server.ServerConfig(num_rounds=3),
+        config=fl.server.ServerConfig(num_rounds=2),
     )
 
     # Create the workflow
@@ -62,7 +62,7 @@ if __name__ == "__main__":
 
     hist = fl.server.start_server(
         server_address="127.0.0.1:8080",
-        config=fl.server.ServerConfig(num_rounds=3),
+        config=fl.server.ServerConfig(num_rounds=2),
         strategy=strategy,
     )
 

--- a/framework/e2e/e2e-pytorch-lightning/simulation.py
+++ b/framework/e2e/e2e-pytorch-lightning/simulation.py
@@ -5,7 +5,7 @@ import flwr as fl
 hist = fl.simulation.start_simulation(
     client_fn=client_fn,
     num_clients=2,
-    config=fl.server.ServerConfig(num_rounds=3),
+    config=fl.server.ServerConfig(num_rounds=2),
 )
 
 assert (


### PR DESCRIPTION
## Summary

- Limit each federated MNIST partition to 100 examples before the existing train/validation/test split.
- Shrink the PyTorch Lightning autoencoder hidden layers from 64 to 16 units.
- Reduce federation from three rounds to two while keeping multi-round state exchange.
- Preserve the Lightning model and Flower client lifecycle.

## Why

The Framework / e2e-pytorch-lightning job spent 232 seconds in the baseline run. The E2E validates Lightning integration, federated data handling, parameter exchange, and the client lifecycle; a bounded fixture and smaller hidden layers preserve that coverage with less CPU work.

## Performance impact

Baseline from GitHub Actions run 31481576935:

- Framework / e2e-pytorch-lightning: 232s
- Driver test: 93s
- Virtual-client test: 40s

Measured on GitHub Actions run 31497122727:

- Framework / e2e-pytorch-lightning: 232s → 192s (40s, ~17% faster)

## Validation

- python3 -m py_compile framework/e2e/e2e-pytorch-lightning/e2e_pytorch_lightning/mnist.py
- git diff --check