### PR TITLE
ci(framework:skip): Reduce scikit-learn E2E workload

### DIFF
--- a/framework/e2e/e2e-scikit-learn/e2e_scikit_learn/server_app.py
+++ b/framework/e2e/e2e-scikit-learn/e2e_scikit_learn/server_app.py
@@ -39,7 +39,7 @@ def main(grid, context):
     # Construct the LegacyContext
     context = fl.server.LegacyContext(
         context=context,
-        config=fl.server.ServerConfig(num_rounds=3),
+        config=fl.server.ServerConfig(num_rounds=2),
     )
 
     # Create the workflow
@@ -62,7 +62,7 @@ if __name__ == "__main__":
 
     hist = fl.server.start_server(
         server_address="127.0.0.1:8080",
-        config=fl.server.ServerConfig(num_rounds=3),
+        config=fl.server.ServerConfig(num_rounds=2),
         strategy=strategy,
     )
 

--- a/framework/e2e/e2e-scikit-learn/e2e_scikit_learn/utils.py
+++ b/framework/e2e/e2e-scikit-learn/e2e_scikit_learn/utils.py
@@ -10,6 +10,8 @@ Dataset = Tuple[XY, XY]
 LogRegParams = Union[XY, Tuple[np.ndarray]]
 XYList = List[XY]
 MAX_PARTITION_SAMPLES = 100
+IMAGE_STRIDE = 2
+NUM_FEATURES = (28 // IMAGE_STRIDE) ** 2
 
 
 def get_model_parameters(model: LogisticRegression) -> LogRegParams:
@@ -44,7 +46,7 @@ def set_initial_params(model: LogisticRegression):
     sklearn.linear_model.LogisticRegression documentation for more information.
     """
     n_classes = 10  # MNIST has 10 classes
-    n_features = 784  # Number of features in dataset
+    n_features = NUM_FEATURES  # Number of features in downsampled images
     model.classes_ = np.array([i for i in range(10)])
 
     model.coef_ = np.zeros((n_classes, n_features))
@@ -86,7 +88,7 @@ def load_data(partition_id: int, num_partitions: int):
     dataset = dataset.with_format("numpy")
 
     batch = dataset[:]
-    X = batch["image"].reshape((len(dataset), -1))
+    X = batch["image"][:, ::IMAGE_STRIDE, ::IMAGE_STRIDE].reshape((len(dataset), -1))
     y = batch["label"]
 
     # Split the on edge data: 80% train, 20% test

--- a/framework/e2e/e2e-scikit-learn/e2e_scikit_learn/utils.py
+++ b/framework/e2e/e2e-scikit-learn/e2e_scikit_learn/utils.py
@@ -9,6 +9,7 @@ XY = Tuple[np.ndarray, np.ndarray]
 Dataset = Tuple[XY, XY]
 LogRegParams = Union[XY, Tuple[np.ndarray]]
 XYList = List[XY]
+MAX_PARTITION_SAMPLES = 100
 
 
 def get_model_parameters(model: LogisticRegression) -> LogRegParams:
@@ -65,7 +66,9 @@ def load_data(partition_id: int, num_partitions: int):
             partitioners={"train": partitioner},
         )
 
-    dataset = fds.load_partition(partition_id, "train").with_format("numpy")
+    dataset = fds.load_partition(partition_id, "train")
+    dataset = dataset.select(range(min(MAX_PARTITION_SAMPLES, len(dataset))))
+    dataset = dataset.with_format("numpy")
 
     batch = dataset[:]
     X = batch["image"].reshape((len(dataset), -1))

--- a/framework/e2e/e2e-scikit-learn/e2e_scikit_learn/utils.py
+++ b/framework/e2e/e2e-scikit-learn/e2e_scikit_learn/utils.py
@@ -9,7 +9,7 @@ XY = Tuple[np.ndarray, np.ndarray]
 Dataset = Tuple[XY, XY]
 LogRegParams = Union[XY, Tuple[np.ndarray]]
 XYList = List[XY]
-MAX_PARTITION_SAMPLES = 100
+MAX_PARTITION_SAMPLES = 50
 IMAGE_STRIDE = 2
 NUM_FEATURES = (28 // IMAGE_STRIDE) ** 2
 

--- a/framework/e2e/e2e-scikit-learn/e2e_scikit_learn/utils.py
+++ b/framework/e2e/e2e-scikit-learn/e2e_scikit_learn/utils.py
@@ -67,7 +67,22 @@ def load_data(partition_id: int, num_partitions: int):
         )
 
     dataset = fds.load_partition(partition_id, "train")
-    dataset = dataset.select(range(min(MAX_PARTITION_SAMPLES, len(dataset))))
+    num_samples = min(MAX_PARTITION_SAMPLES, len(dataset))
+    labels = np.asarray(dataset["label"])
+    unique_labels = np.unique(labels)
+    samples_per_label = num_samples // len(unique_labels)
+    selected_indices = (
+        np.stack(
+            [
+                np.flatnonzero(labels == label)[:samples_per_label]
+                for label in unique_labels
+            ],
+            axis=1,
+        )
+        .reshape(-1)
+        .tolist()
+    )
+    dataset = dataset.select(selected_indices)
     dataset = dataset.with_format("numpy")
 
     batch = dataset[:]

--- a/framework/e2e/e2e-scikit-learn/e2e_scikit_learn/utils.py
+++ b/framework/e2e/e2e-scikit-learn/e2e_scikit_learn/utils.py
@@ -9,7 +9,7 @@ XY = Tuple[np.ndarray, np.ndarray]
 Dataset = Tuple[XY, XY]
 LogRegParams = Union[XY, Tuple[np.ndarray]]
 XYList = List[XY]
-MAX_PARTITION_SAMPLES = 50
+MAX_PARTITION_SAMPLES = 100
 IMAGE_STRIDE = 2
 NUM_FEATURES = (28 // IMAGE_STRIDE) ** 2
 

--- a/framework/e2e/e2e-scikit-learn/simulation.py
+++ b/framework/e2e/e2e-scikit-learn/simulation.py
@@ -5,7 +5,7 @@ import flwr as fl
 hist = fl.simulation.start_simulation(
     client_fn=client_fn,
     num_clients=2,
-    config=fl.server.ServerConfig(num_rounds=3),
+    config=fl.server.ServerConfig(num_rounds=2),
 )
 
 assert (


### PR DESCRIPTION
## Summary

- Limit each federated MNIST partition to 100 class-balanced examples.
- Downsample each image from 28×28 to 14×14 features before LogisticRegression.
- Reduce federation from three rounds to two while keeping multi-round state exchange.
- Preserve the LogisticRegression parameter exchange, fit, evaluation, and federated workflow.

## Why

The Framework / e2e-scikit-learn job spent 171 seconds in the baseline run. The E2E validates scikit-learn/Flower integration, parameter exchange, fitting, evaluation, and the existing convergence assertion; the stable class-balanced fixture and lower-dimensional image representation preserve that coverage with less CPU work.

## Performance impact

Baseline from GitHub Actions run 31481576935:

- Framework / e2e-scikit-learn: 171s
- Driver test: 83s
- Virtual-client test: 19s

Measured on GitHub Actions run 31498395664:

- Framework / e2e-scikit-learn: 171s → 163s (8s, ~5% faster)

## Validation

- python3 -m py_compile framework/e2e/e2e-scikit-learn/e2e_scikit_learn/utils.py
- git diff --check