### PR TITLE
ci(framework:skip): Reduce JAX E2E training time

### DIFF
--- a/framework/e2e/e2e-jax/e2e_jax/client_app.py
+++ b/framework/e2e/e2e-jax/e2e_jax/client_app.py
@@ -12,7 +12,7 @@ from flwr.clientapp import ClientApp
 
 # Load data and determine model shape
 train_x, train_y, test_x, test_y = jax_training.load_data()
-grad_fn = jax.grad(jax_training.loss_fn)
+grad_fn = jax.jit(jax.grad(jax_training.loss_fn))
 model_shape = train_x.shape[1:]
 
 

--- a/framework/e2e/e2e-jax/e2e_jax/jax_training.py
+++ b/framework/e2e/e2e-jax/e2e_jax/jax_training.py
@@ -16,7 +16,7 @@ from sklearn.datasets import make_regression
 from sklearn.model_selection import train_test_split
 
 key = jax.random.PRNGKey(0)
-NUM_EPOCHS = 10
+NUM_EPOCHS = 5
 
 
 def load_data() -> (

--- a/framework/e2e/e2e-jax/e2e_jax/jax_training.py
+++ b/framework/e2e/e2e-jax/e2e_jax/jax_training.py
@@ -16,6 +16,7 @@ from sklearn.datasets import make_regression
 from sklearn.model_selection import train_test_split
 
 key = jax.random.PRNGKey(0)
+NUM_EPOCHS = 10
 
 
 def load_data() -> (
@@ -41,7 +42,7 @@ def loss_fn(params, X, y) -> Callable:
 
 def train(params, grad_fn, X, y) -> Tuple[np.array, float, int]:
     num_examples = X.shape[0]
-    for epochs in range(50):
+    for epochs in range(NUM_EPOCHS):
         grads = grad_fn(params, X, y)
         params = jax.tree_util.tree_map(lambda p, g: p - 0.05 * g, params, grads)
         loss = loss_fn(params, X, y)

--- a/framework/e2e/e2e-jax/e2e_jax/server_app.py
+++ b/framework/e2e/e2e-jax/e2e_jax/server_app.py
@@ -39,7 +39,7 @@ def main(grid, context):
     # Construct the LegacyContext
     context = fl.server.LegacyContext(
         context=context,
-        config=fl.server.ServerConfig(num_rounds=3),
+        config=fl.server.ServerConfig(num_rounds=2),
     )
 
     # Create the workflow
@@ -62,7 +62,7 @@ if __name__ == "__main__":
 
     hist = fl.server.start_server(
         server_address="127.0.0.1:8080",
-        config=fl.server.ServerConfig(num_rounds=3),
+        config=fl.server.ServerConfig(num_rounds=2),
         strategy=strategy,
     )
 

--- a/framework/e2e/e2e-jax/simulation.py
+++ b/framework/e2e/e2e-jax/simulation.py
@@ -5,7 +5,7 @@ import flwr as fl
 hist = fl.simulation.start_simulation(
     client_fn=client_fn,
     num_clients=2,
-    config=fl.server.ServerConfig(num_rounds=3),
+    config=fl.server.ServerConfig(num_rounds=2),
 )
 
 assert (


### PR DESCRIPTION
## Summary

- JIT-compile the JAX gradient function used by the client.
- Reduce the linear-regression smoke test from 50 to 5 epochs.
- Reduce federation from three rounds to two while keeping multi-round state exchange.

## Why

The Framework / e2e-jax job spent 160 seconds in the baseline run. JAX compilation and repeated gradient work are disproportionate for this tiny regression fixture; JIT plus fewer epochs and rounds preserve the Flower/JAX training path and state exchange with less CPU work.

## Performance impact

Baseline from GitHub Actions run 31481576935:

- Framework / e2e-jax: 160s
- Driver test: 71s
- Virtual-client test: 17s

Measured on GitHub Actions run 31497122941:

- Framework / e2e-jax: 160s → 140s (20s, ~13% faster)

## Validation

- python3 -m py_compile framework/e2e/e2e-jax/e2e_jax/client_app.py framework/e2e/e2e-jax/e2e_jax/jax_training.py
- git diff --check