### PR TITLE
refactor(framework): Unify OIDC config

### DIFF
--- a/framework/docs/source/helm/how-to-deploy-superlink-using-helm.md
+++ b/framework/docs/source/helm/how-to-deploy-superlink-using-helm.md
@@ -171,32 +171,32 @@ stringData:
 ## Enable Account Authentication
 
 Account authentication can be enabled if you're using the Flower Enterprise Edition (EE) Docker images.
-This is configured in the `global.userAuth` section of your `values.yml` file.
+This is configured in the `global.accountAuth` section of your `values.yml` file.
 
 ### Example: Enabling OpenID Connect (OIDC) Authentication
 
 ```yaml
 global:
-  userAuth:
+  accountAuth:
     enabled: true
     config:
-      authentication:
-        authn_type: oidc
-        authn_url: https://<domain>/auth/device
-        token_url: https://<domain>/token
-        validate_url: https://<domain>/userinfo
-        oidc_client_id: <client_id>
-        oidc_client_secret: <client_secret>
+      FLWR_OIDC_ISSUER: https://<domain>/realms/<realm>
+      FLWR_OIDC_CLIENT_ID: <client_id>
+      FLWR_OIDC_CLIENT_SECRET: <client_secret>
+      FLWR_OIDC_VERIFY_TLS: "1"
 ```
 
 Explanation of Parameters:
 
-- `authn_type`: The authentication mechanism being used (e.g., oidc).
-- `authn_url`: The OpenID Connect authentication endpoint where users authenticate.
-- `token_url`: The URL for retrieving access tokens.
-- `validate_url`: The endpoint for validating account authentication.
-- `oidc_client_id`: The client ID issued by the authentication provider.
-- `oidc_client_secret`: The secret key associated with the client ID.
+- `FLWR_OIDC_ISSUER`: The OpenID Connect issuer.
+- `FLWR_OIDC_CLIENT_ID`: The client ID issued by the authentication provider.
+- `FLWR_OIDC_CLIENT_SECRET`: The corresponding client secret.
+- `FLWR_OIDC_VERIFY_TLS`: Whether to verify TLS certificates; defaults to `1`.
+
+The chart sets `FLWR_OIDC_ENABLED=1` when account authentication is enabled.
+As with other Flower binary environment variables, use `1` for true and `0` for
+false. Credentials alone do not enable Control authentication, and
+`FLWR_OIDC_VERIFY_TLS` affects only requests to the OIDC provider.
 
 ### Use an Existing Secret
 
@@ -205,25 +205,21 @@ to the name of the existing secret:
 
 ```yaml
 global:
-  userAuth:
+  accountAuth:
     enabled: true
     config: {}
-    existingSecret: "existing-account-auth-config"
+    existingSecret: "existing-oidc-config"
 ```
 
-Note that the existing secret must contain the key `account-auth-config.yml`:
+The existing Secret must contain the OIDC environment keys:
 
 ```yaml
 kind: Secret
 stringData:
-  account-auth-config.yml: |
-    authentication:
-      authn_type: oidc
-      authn_url: https://<domain>/auth/device
-      token_url: https://<domain>/token
-      validate_url: https://<domain>/userinfo
-      oidc_client_id: <client_id>
-      oidc_client_secret: <client_secret>
+  FLWR_OIDC_ISSUER: https://<domain>/realms/<realm>
+  FLWR_OIDC_CLIENT_ID: <client_id>
+  FLWR_OIDC_CLIENT_SECRET: <client_secret>
+  FLWR_OIDC_VERIFY_TLS: "1"
 ```
 
 ## Change Isolation Mode

--- a/framework/docs/source/how-to-authenticate-accounts.rst
+++ b/framework/docs/source/how-to-authenticate-accounts.rst
@@ -33,34 +33,31 @@ ownership, federation, and entitlement checks.
 Enable Account Authentication on the SuperLink
 ==============================================
 
-Create a YAML configuration file with the following content:
-
-.. code-block:: yaml
-
-    authentication:
-      authn_type: oidc
-      authn_url:          # OIDC provider's authorization_endpoint
-      token_url:          # OIDC provider's token_endpoint
-      validate_url:       # OIDC provider's account-authinfo_endpoint
-      oidc_client_id:     # OIDC provider Client ID
-      oidc_client_secret: # The corresponding Client Secret
-
-Save this file as ``account-auth-config.yaml``. Then pass it to the SuperLink via the
-``--account-auth-config`` flag when deploying the SuperLink:
+Set the following environment variables on the SuperLink process:
 
 .. code-block:: bash
 
-    $ flower-superlink \
-        --account-auth-config=account-auth-config.yaml
-        <other flags>
+    FLWR_OIDC_ENABLED=1
+    FLWR_OIDC_ISSUER=https://<domain>/realms/<realm>
+    FLWR_OIDC_CLIENT_ID=<client_id>
+    FLWR_OIDC_CLIENT_SECRET=<client_secret>
+    FLWR_OIDC_VERIFY_TLS=1
 
-.. warning::
+``FLWR_OIDC_ENABLED`` defaults to ``0``. ``FLWR_OIDC_VERIFY_TLS`` defaults to
+``1``. As with other Flower binary environment variables, use ``1`` for true and
+``0`` for false. Control authentication remains NoOp unless
+``FLWR_OIDC_ENABLED=1``, even when credentials are present.
+``FLWR_OIDC_VERIFY_TLS`` affects only requests to the OIDC provider.
 
-    Starting with Flower ``v1.23.0``, the following options/keys have been renamed:
+Start the SuperLink with these variables in its environment:
 
-    - ``auth_type`` → ``authn_type`` (in YAML configuration)
-    - ``auth_url`` → ``authn_url`` (in YAML configuration)
-    - ``--user-auth-config`` → ``--account-auth-config`` (in SuperLink CLI)
+.. code-block:: bash
+
+    $ FLWR_OIDC_ENABLED=1 \
+        FLWR_OIDC_ISSUER=https://<domain>/realms/<realm> \
+        FLWR_OIDC_CLIENT_ID=<client_id> \
+        FLWR_OIDC_CLIENT_SECRET=<client_secret> \
+        flower-superlink <other flags>
 
 ************************
  Login to the SuperLink

--- a/framework/docs/source/how-to-authenticate-accounts.rst
+++ b/framework/docs/source/how-to-authenticate-accounts.rst
@@ -43,11 +43,11 @@ Set the following environment variables on the SuperLink process:
     FLWR_OIDC_CLIENT_SECRET=<client_secret>
     FLWR_OIDC_VERIFY_TLS=1
 
-``FLWR_OIDC_ENABLED`` defaults to ``0``. ``FLWR_OIDC_VERIFY_TLS`` defaults to
-``1``. As with other Flower binary environment variables, use ``1`` for true and
-``0`` for false. Control authentication remains NoOp unless
-``FLWR_OIDC_ENABLED=1``, even when credentials are present.
-``FLWR_OIDC_VERIFY_TLS`` affects only requests to the OIDC provider.
+``FLWR_OIDC_ENABLED`` defaults to ``0``. ``FLWR_OIDC_VERIFY_TLS`` defaults to ``1``. As
+with other Flower binary environment variables, use ``1`` for true and ``0`` for false.
+Control authentication remains NoOp unless ``FLWR_OIDC_ENABLED=1``, even when
+credentials are present. ``FLWR_OIDC_VERIFY_TLS`` affects only requests to the OIDC
+provider.
 
 Start the SuperLink with these variables in its environment:
 

--- a/framework/py/flwr/common/constant.py
+++ b/framework/py/flwr/common/constant.py
@@ -158,8 +158,6 @@ LOG_UPLOAD_INTERVAL = 0.2  # Minimum interval between two log uploads
 MAX_RETRY_DELAY = 20  # Maximum delay duration between two consecutive retries.
 
 # Constants for account authentication
-AUTHN_TYPE_JSON_KEY = "authn-type"  # For key name in JSON file
-AUTHN_TYPE_YAML_KEY = "authn_type"  # For key name in YAML file
 ACCESS_TOKEN_KEY = "flwr-oidc-access-token"
 REFRESH_TOKEN_KEY = "flwr-oidc-refresh-token"
 

--- a/framework/py/flwr/superlink/auth_plugin/auth_plugin.py
+++ b/framework/py/flwr/superlink/auth_plugin/auth_plugin.py
@@ -17,7 +17,6 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from pathlib import Path
 
 from flwr.supercore.auth.typing import (
     AccountAuthCredentials,
@@ -27,23 +26,10 @@ from flwr.supercore.auth.typing import (
 
 
 class ControlAuthnPlugin(ABC):
-    """Abstract Flower Authentication Plugin class for ControlServicer.
-
-    Parameters
-    ----------
-    account_auth_config_path : Path
-        Path to the YAML file containing the authentication configuration.
-    verify_tls_cert : bool
-        Boolean indicating whether to verify the TLS certificate
-        when making requests to the server.
-    """
+    """Abstract Flower Authentication Plugin class for ControlServicer."""
 
     @abstractmethod
-    def __init__(
-        self,
-        account_auth_config_path: Path,
-        verify_tls_cert: bool,
-    ):
+    def __init__(self) -> None:
         """Abstract constructor."""
 
     @abstractmethod

--- a/framework/py/flwr/superlink/auth_plugin/noop_auth_plugin.py
+++ b/framework/py/flwr/superlink/auth_plugin/noop_auth_plugin.py
@@ -16,7 +16,6 @@
 
 
 from collections.abc import Sequence
-from pathlib import Path
 
 from flwr.common.constant import NOOP_ACCOUNT_NAME, NOOP_FLWR_AID, AuthnType
 from flwr.supercore.auth.typing import (
@@ -36,11 +35,7 @@ NOOP_ACCOUNT_INFO = AccountInfo(
 class NoOpControlAuthnPlugin(ControlAuthnPlugin):
     """No-operation implementation of ControlAuthnPlugin."""
 
-    def __init__(
-        self,
-        account_auth_config_path: Path,
-        verify_tls_cert: bool,
-    ):
+    def __init__(self) -> None:
         pass
 
     def get_login_details(self) -> AccountAuthLoginDetails | None:

--- a/framework/py/flwr/superlink/cli/flower_superlink.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink.py
@@ -396,25 +396,12 @@ def _parse_superlink_lifespan_config() -> SuperLinkLifespanConfig:
                     f"Failed to load SuperExec authentication secret: {err}",
                 )
 
-    # Disable the account auth TLS check if args.disable_oidc_tls_cert_verification is
-    # provided
-    verify_tls_cert = not getattr(args, "disable_oidc_tls_cert_verification", None)
-
-    event_log_plugin: EventLogWriterPlugin | None = None
-    # Load the auth plugin if the args.account_auth_config is provided
-    if cfg_path := getattr(args, "user_auth_config", None):
-        log(
-            WARN,
-            "The `--user-auth-config` flag is deprecated and will be removed in a "
-            "future release. Please use `--account-auth-config` instead.",
-        )
-        args.account_auth_config = cfg_path
-    cfg_path = getattr(args, "account_auth_config", None)
-    authn_plugin = load_control_authn_plugin(cfg_path, verify_tls_cert)
-    if cfg_path is not None:
-        # Enable event logging if the args.enable_event_log is True
-        if args.enable_event_log:
-            event_log_plugin = load_control_event_log_plugin()
+    authn_plugin = load_control_authn_plugin()
+    event_log_plugin = (
+        load_control_event_log_plugin()
+        if getattr(args, "enable_event_log", False)
+        else None
+    )
 
     # Load artifact provider if the args.artifact_provider_config is provided
     artifact_provider = None

--- a/framework/py/flwr/superlink/config_loader.py
+++ b/framework/py/flwr/superlink/config_loader.py
@@ -15,17 +15,12 @@
 """Load SuperLink configuration and config-driven components."""
 
 
+import os
 import sys
-from collections.abc import Callable
 from dataclasses import dataclass
-from logging import WARN
-from pathlib import Path
 
-import yaml
-
-from flwr.common.constant import AUTHN_TYPE_YAML_KEY, AuthnType, EventLogWriterType
+from flwr.common.constant import AuthnType, EventLogWriterType
 from flwr.common.event_log_plugin import EventLogWriterPlugin
-from flwr.common.logger import log
 from flwr.server.superlink.linkstate import LinkStateFactory
 from flwr.supercore.license_plugin import LicensePlugin
 from flwr.supercore.object_store import ObjectStoreFactory
@@ -170,72 +165,15 @@ def get_control_authn_plugins() -> dict[str, type[ControlAuthnPlugin]]:
     return ee_dict | {AuthnType.NOOP: NoOpControlAuthnPlugin}
 
 
-def load_control_authn_plugin(
-    config_path: str | None, verify_tls_cert: bool
-) -> ControlAuthnPlugin:
+def load_control_authn_plugin() -> ControlAuthnPlugin:
     """Obtain the configured authentication plugin."""
-    # Load the NoOp plugin if no authentication config path is provided
-    if config_path is None:
-        config_path = ""
-        config = {"authentication": {AUTHN_TYPE_YAML_KEY: AuthnType.NOOP}}
-    # Load YAML file
-    else:
-        try:
-            with Path(config_path).expanduser().open("r", encoding="utf-8") as file:
-                config = yaml.safe_load(file)
-        except yaml.YAMLError:
-            sys.exit(
-                f"Invalid account authentication configuration in '{config_path}': "
-                "the file is not valid YAML."
-            )
+    if os.getenv("FLWR_OIDC_ENABLED", "0") != "1":
+        return NoOpControlAuthnPlugin()
 
-    if not isinstance(config, dict):
-        sys.exit("Account authentication configuration must be a YAML mapping.")
-
-    unknown_sections = set(config) - {"authentication"}
-    if unknown_sections:
-        sections = ", ".join(sorted(str(section) for section in unknown_sections))
+    try:
+        plugin_cls = get_control_authn_plugins()[AuthnType.OIDC]
+    except KeyError:
         sys.exit(
-            "Unsupported top-level account authentication configuration "
-            f"section(s): {sections}. Only `authentication` is supported."
+            "OIDC account authentication is unavailable in this Flower distribution."
         )
-
-    if "authentication" not in config:
-        sys.exit("No authentication section is provided in the configuration.")
-    if not isinstance(config["authentication"], dict):
-        sys.exit("The authentication configuration must be a YAML mapping.")
-
-    def _load_plugin(
-        section: str,
-        yaml_key: str,
-        loader: Callable[[], dict[str, type[ControlAuthnPlugin]]],
-    ) -> ControlAuthnPlugin:
-        section_cfg = config.get(section, {})
-        auth_plugin_name = section_cfg.get(yaml_key, "")
-        try:
-            plugins = loader()
-            plugin_cls = plugins[auth_plugin_name]
-            return plugin_cls(Path(config_path), verify_tls_cert)
-        except KeyError:
-            if auth_plugin_name:
-                sys.exit(
-                    f"{yaml_key}: {auth_plugin_name} is not supported. "
-                    f"Please provide a valid {section} type in the configuration."
-                )
-            sys.exit(f"No {section} type is provided in the configuration.")
-
-    # Warn deprecated auth_type key
-    if authn_type := config["authentication"].pop("auth_type", None):
-        log(
-            WARN,
-            "The `auth_type` key in the authentication configuration is deprecated. "
-            "Use `%s` instead.",
-            AUTHN_TYPE_YAML_KEY,
-        )
-        config["authentication"][AUTHN_TYPE_YAML_KEY] = authn_type
-
-    return _load_plugin(
-        section="authentication",
-        yaml_key=AUTHN_TYPE_YAML_KEY,
-        loader=get_control_authn_plugins,
-    )
+    return plugin_cls()

--- a/framework/py/flwr/superlink/config_loader_test.py
+++ b/framework/py/flwr/superlink/config_loader_test.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for SuperLink configuration loading."""
+
+
+import pytest
+
+from flwr.common.constant import AuthnType
+from flwr.superlink.auth_plugin import NoOpControlAuthnPlugin
+
+from . import config_loader
+
+
+class FakeOidcControlAuthnPlugin(NoOpControlAuthnPlugin):
+    """Test-only OIDC authentication plugin."""
+
+
+def test_load_control_authn_plugin_disabled_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test OIDC authentication is disabled when the flag is absent."""
+    monkeypatch.delenv("FLWR_OIDC_ENABLED", raising=False)
+
+    assert isinstance(config_loader.load_control_authn_plugin(), NoOpControlAuthnPlugin)
+
+
+def test_load_control_authn_plugin_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test the standard Flower enabled value selects the OIDC plugin."""
+    monkeypatch.setenv("FLWR_OIDC_ENABLED", "1")
+    monkeypatch.setattr(
+        config_loader,
+        "get_control_authn_ee_plugins",
+        lambda: {AuthnType.OIDC: FakeOidcControlAuthnPlugin},
+    )
+
+    assert isinstance(
+        config_loader.load_control_authn_plugin(), FakeOidcControlAuthnPlugin
+    )

--- a/framework/py/flwr/superlink/main.py
+++ b/framework/py/flwr/superlink/main.py
@@ -106,9 +106,7 @@ def create_app(
     if config is None:
         is_simulation = False
         database = get_ee_linkstate_db()
-        authn_plugin = load_control_authn_plugin(
-            os.getenv("FLWR_ACCOUNT_AUTH_CONFIG"), verify_tls_cert=True
-        )
+        authn_plugin = load_control_authn_plugin()
         event_log_plugin = (
             load_control_event_log_plugin()
             if os.getenv("FLWR_ENABLE_EVENT_LOG") == "1"

--- a/framework/py/flwr/superlink/servicer/control/control_grpc_test.py
+++ b/framework/py/flwr/superlink/servicer/control/control_grpc_test.py
@@ -15,7 +15,6 @@
 """Tests for Control API gRPC server wiring."""
 
 
-from pathlib import Path
 from unittest.mock import Mock, patch
 
 from flwr.supercore.interceptors import (
@@ -46,7 +45,7 @@ def test_run_control_api_grpc_adds_expected_interceptors() -> None:
             state_factory=Mock(),
             objectstore_factory=Mock(),
             certificates=None,
-            authn_plugin=NoOpControlAuthnPlugin(Path(), False),
+            authn_plugin=NoOpControlAuthnPlugin(),
         )
 
     interceptors = create_grpc_server.call_args.kwargs["interceptors"]

--- a/framework/py/flwr/superlink/servicer/control/control_servicer_test.py
+++ b/framework/py/flwr/superlink/servicer/control/control_servicer_test.py
@@ -187,7 +187,7 @@ class TestControlServicer(unittest.TestCase):  # pylint: disable=R0904
                 FLWR_IN_MEMORY_DB_NAME, NoOpFederationManager(), objectstore_factory
             ),
             objectstore_factory=objectstore_factory,
-            authn_plugin=(authn_plugin := NoOpControlAuthnPlugin(Mock(), False)),
+            authn_plugin=(authn_plugin := NoOpControlAuthnPlugin()),
         )
         account_info = authn_plugin.validate_tokens_in_metadata([])[1]
         assert account_info is not None
@@ -1181,7 +1181,7 @@ class TestControlServicer(unittest.TestCase):  # pylint: disable=R0904
                 objectstore_factory,
             ),
             objectstore_factory=objectstore_factory,
-            authn_plugin=NoOpControlAuthnPlugin(Mock(), False),
+            authn_plugin=NoOpControlAuthnPlugin(),
         )
 
         response: ListFederationsResponse = servicer.ListFederations(
@@ -1896,7 +1896,7 @@ class TestValidateFederationAndNodesInRequest(unittest.TestCase):
                 FLWR_IN_MEMORY_DB_NAME, NoOpFederationManager(), objectstore_factory
             ),
             objectstore_factory=objectstore_factory,
-            authn_plugin=(authn_plugin := NoOpControlAuthnPlugin(Mock(), False)),
+            authn_plugin=(authn_plugin := NoOpControlAuthnPlugin()),
         )
         account_info = authn_plugin.validate_tokens_in_metadata([])[1]
         assert account_info is not None


### PR DESCRIPTION
## Summary

This PR replaces YAML-based Control account-authentication selection with environment-backed OIDC enablement.

SuperLink now uses `FLWR_OIDC_ENABLED` to select between the NoOp and registered OIDC authentication plugins. Authentication remains disabled by default, and credentials alone do not enable it.

## Changes

- Replace account-auth YAML loading with `FLWR_OIDC_ENABLED`.
- Default to `NoOpControlAuthnPlugin`.
- Load the registered OIDC plugin only when `FLWR_OIDC_ENABLED=1`.
- Fail clearly when OIDC is enabled in a distribution without the EE plugin.
- Change `ControlAuthnPlugin` and `NoOpControlAuthnPlugin` to zero-argument constructors.
- Make CLI and direct application startup use the same environment-backed loader.
- Allow event logging to be enabled independently of account authentication.
- Remove obsolete YAML parsing, validation, deprecated-key handling, and imports.
- Remove the unused `AUTHN_TYPE_JSON_KEY` constant.
- Update public documentation and tests.

## Configuration changes

### Added environment variables

| Variable | Default | Behavior |
|---|---:|---|
| `FLWR_OIDC_ENABLED` | `0` | Exact value `1` enables Control OIDC authentication. Any other value selects NoOp authentication. |

This follows the existing Flower convention for binary environment variables:

- `1` means true.
- `0` means false.
- Only exact `1` activates the feature.

The SuperGrid Extensions consume the remaining OIDC variables:

- `FLWR_OIDC_ISSUER`
- `FLWR_OIDC_CLIENT_ID`
- `FLWR_OIDC_CLIENT_SECRET`
- `FLWR_OIDC_VERIFY_TLS`

### Removed environment variables

- `FLWR_ACCOUNT_AUTH_CONFIG`

### Removed CLI arguments

- `--account-auth-config`
- `--user-auth-config`
- `--disable-oidc-tls-cert-verification`

### Removed file configuration

Account-authentication YAML files are no longer loaded. This removes the following account-auth YAML keys:

- `authentication`
- `authn_type`
- `auth_type`
- `authn_url`
- `auth_url`
- `token_url`
- `validate_url`
- `oidc_client_id`
- `oidc_client_secret`

## Compatibility and rollout

This is an intentional breaking configuration change. Deployments using Control OIDC authentication must set `FLWR_OIDC_ENABLED=1` and provide the OIDC configuration expected by SuperGrid Extensions.