### PR TITLE
refactor(framework): Use ORM for LinkState message lookup

### DIFF
--- a/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
@@ -1239,19 +1239,18 @@ class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
 
         Return Message if valid.
         """
-        with self.session():
+        with self.session() as session:
             self._check_stored_messages({message_id})
-            query = """
-                SELECT *
-                FROM message_ins
-                WHERE message_id = :message_id
-            """
-            rows = self.query(query, {"message_id": message_id})
-            if not rows:
+            model = session.scalar(
+                select(MessageInsModel).where(
+                    MessageInsModel.message_id == message_id
+                )
+            )
+            if model is None:
                 # Message does not exist
                 return None
 
-        return dict(rows[0])
+        return _message_model_to_dict(model)
 
     def store_traffic(self, run_id: int, *, bytes_sent: int, bytes_recv: int) -> None:
         """Store traffic data for the specified `run_id`."""

--- a/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
@@ -1242,9 +1242,7 @@ class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
         with self.session() as session:
             self._check_stored_messages({message_id})
             model = session.scalar(
-                select(MessageInsModel).where(
-                    MessageInsModel.message_id == message_id
-                )
+                select(MessageInsModel).where(MessageInsModel.message_id == message_id)
             )
             if model is None:
                 # Message does not exist

--- a/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
@@ -1249,8 +1249,7 @@ class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
             if model is None:
                 # Message does not exist
                 return None
-
-        return _message_model_to_dict(model)
+            return _message_model_to_dict(model)
 
     def store_traffic(self, run_id: int, *, bytes_sent: int, bytes_recv: int) -> None:
         """Store traffic data for the specified `run_id`."""


### PR DESCRIPTION
## What this PR does

Migrates the remaining raw SQL lookup in `SqlLinkState.get_valid_message_ins` to a SQLAlchemy ORM statement.

The method now loads `MessageInsModel` through the active session and keeps the existing dictionary compatibility adapter and message-validation behavior unchanged. Together with #7833, this removes all raw `SqlMixin.query()` call sites from `SqlLinkState`.

## Validation

- `linkstate_test.py`
- Ruff
- mypy