### PR TITLE
fix(framework): Scope ObjectStore mutation locks per database

### DIFF
--- a/framework/py/flwr/supercore/object_store/object_store_test.py
+++ b/framework/py/flwr/supercore/object_store/object_store_test.py
@@ -495,8 +495,8 @@ class SqlPersistentObjectStoreTestMixin(unittest.TestCase):
     def test_mutation_session_locks_each_database(self) -> None:
         """Ensure nested mutations acquire a lock for each database."""
         store = self.object_store_factory()
-        with tempfile.NamedTemporaryFile(suffix=".db") as database_file:
-            second_store = SqlObjectStore(database_file.name)
+        with tempfile.TemporaryDirectory() as database_dir:
+            second_store = SqlObjectStore(f"{database_dir}/second.db")
             second_store.initialize()
             store._lock_objectstore_mutation = Mock()  # type: ignore[method-assign]
             second_store._lock_objectstore_mutation = Mock()  # type: ignore[method-assign]

--- a/framework/py/flwr/supercore/object_store/object_store_test.py
+++ b/framework/py/flwr/supercore/object_store/object_store_test.py
@@ -492,6 +492,22 @@ class SqlPersistentObjectStoreTestMixin(unittest.TestCase):
 
         store._lock_objectstore_mutation.assert_called_once_with()
 
+    def test_mutation_session_locks_each_database(self) -> None:
+        """Ensure nested mutations acquire a lock for each database."""
+        store = self.object_store_factory()
+        with tempfile.NamedTemporaryFile(suffix=".db") as database_file:
+            second_store = SqlObjectStore(database_file.name)
+            second_store.initialize()
+            store._lock_objectstore_mutation = Mock()  # type: ignore[method-assign]
+            second_store._lock_objectstore_mutation = Mock()  # type: ignore[method-assign]
+
+            with store._mutation_session():  # pylint: disable=protected-access
+                with second_store._mutation_session():  # pylint: disable=protected-access
+                    pass
+
+            store._lock_objectstore_mutation.assert_called_once_with()
+            second_store._lock_objectstore_mutation.assert_called_once_with()
+
     # pylint: enable=protected-access
 
     def test_concurrent_preregister_and_run_cleanup(self) -> None:

--- a/framework/py/flwr/supercore/object_store/sql_object_store.py
+++ b/framework/py/flwr/supercore/object_store/sql_object_store.py
@@ -41,9 +41,9 @@ from flwr.supercore.utils import uint64_to_int64
 
 from .object_store import NoObjectInStoreError, ObjectStore
 
-_objectstore_mutation_lock_held: ContextVar[bool] = ContextVar(
-    "objectstore_mutation_lock_held",
-    default=False,
+_objectstore_mutation_lock_scopes: ContextVar[frozenset[object]] = ContextVar(
+    "objectstore_mutation_lock_scopes",
+    default=frozenset(),
 )
 
 
@@ -280,16 +280,19 @@ class SqlObjectStore(ObjectStore, SqlMixin):
     def _mutation_session(self) -> Iterator[Session]:
         """Start a mutation transaction and acquire its SQL lock once."""
         with self.session() as session:
-            if _objectstore_mutation_lock_held.get():
+            lock_scopes = _objectstore_mutation_lock_scopes.get()
+            if self._session_scope in lock_scopes:
                 yield session
                 return
 
-            token = _objectstore_mutation_lock_held.set(True)
+            token = _objectstore_mutation_lock_scopes.set(
+                lock_scopes | {self._session_scope}
+            )
             try:
                 self._lock_objectstore_mutation()
                 yield session
             finally:
-                _objectstore_mutation_lock_held.reset(token)
+                _objectstore_mutation_lock_scopes.reset(token)
 
     def _lock_objectstore_mutation(self) -> None:
         """Serialize structural ObjectStore writes within the active transaction."""


### PR DESCRIPTION
## Issue

### Description

ObjectStore's mutation-lock `ContextVar` stores one process-wide boolean. If a mutation on database A invokes a mutation on database B in the same context, database B sees the flag and skips acquiring its own SQL lock. This can leave B's structural writes unserialized against other contexts.

### Related issues/PRs

Introduced by the locking support in #7365. I did not find an existing issue or PR for cross-database nesting.

## Proposal

### Explanation

Track active session scopes instead of a single boolean, so nested mutations skip only the lock already held for their own database. Add a regression test covering nested mutation sessions across two persistent databases.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [ ] Update documentation (not applicable; no user-facing behavior changes)
- [x] Address LLM-reviewer comments, if applicable (none yet)
- [x] Make local checks pass
- [ ] Ping maintainers on Slack

### Any other comments?

Verified with:

- `python -m pytest py/flwr/supercore/object_store/object_store_test.py -q`
- `python -m ruff check py/flwr/supercore/object_store/sql_object_store.py py/flwr/supercore/object_store/object_store_test.py --no-respect-gitignore`
- `python -m mypy py/flwr/supercore/object_store/sql_object_store.py`
