### PR TITLE
refactor(framework): Use models as LinkState metadata source

### DIFF
--- a/framework/py/flwr/supercore/state/schema/linkstate_tables.py
+++ b/framework/py/flwr/supercore/state/schema/linkstate_tables.py
@@ -12,144 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""SQLAlchemy Core Table definitions for LinkState."""
+"""Compatibility wrapper for LinkState SQLAlchemy metadata."""
 
+from sqlalchemy import MetaData
 
-from sqlalchemy import (
-    BigInteger,
-    Column,
-    Float,
-    ForeignKey,
-    Index,
-    LargeBinary,
-    MetaData,
-    String,
-    Table,
-    UniqueConstraint,
-    text,
-)
+from flwr.supercore.state.schema.linkstate_models import LinkStateBase
 
 
 def create_linkstate_metadata() -> MetaData:
     """Create and return MetaData with LinkState table definitions."""
     metadata = MetaData()
-
-    # --------------------------------------------------------------------------
-    #  Table: node
-    # --------------------------------------------------------------------------
-    Table(
-        "node",
-        metadata,
-        Column("node_id", BigInteger, unique=True),
-        Column("owner_aid", String),
-        Column("owner_name", String),
-        Column("status", String),
-        Column("registered_at", String),
-        Column("last_activated_at", String, nullable=True),
-        Column("last_deactivated_at", String, nullable=True),
-        Column("unregistered_at", String, nullable=True),
-        Column("online_until", Float, nullable=True),
-        Column("heartbeat_interval", Float),
-        Column("public_key", LargeBinary, unique=True),
-        # Indexes
-        # Used in delete_node and get_node_info (security/filtering)
-        Index("idx_node_owner_aid", "owner_aid"),
-        # Used in get_nodes and activation checks (frequent filtering)
-        Index("idx_node_status", "status"),
-        # Used in heartbeat checks to efficiently find expired nodes
-        Index("idx_online_until", "online_until"),
-    )
-
-    # --------------------------------------------------------------------------
-    #  Table: run
-    # --------------------------------------------------------------------------
-    Table(
-        "run",
-        metadata,
-        Column("run_id", BigInteger, unique=True),
-        Column("fab_id", String),
-        Column("fab_version", String),
-        Column("fab_hash", String),
-        Column("override_config", String),
-        Column("usage_reported_at", String, nullable=False, server_default=text("''")),
-        Column("federation_id", String),
-        Column("primary_task_id", BigInteger, nullable=False),
-        Column("federation_config", String),
-        Column("series_id", BigInteger, nullable=True),
-        Column("flwr_aid", String),
-        Column("bytes_sent", BigInteger, server_default="0"),
-        Column("bytes_recv", BigInteger, server_default="0"),
-        Column("clientapp_runtime", Float, server_default="0.0"),
-        Index("idx_run_series_id", "series_id"),
-    )
-
-    # --------------------------------------------------------------------------
-    #  Table: logs
-    # --------------------------------------------------------------------------
-    Table(
-        "logs",
-        metadata,
-        Column("timestamp", Float),
-        Column("run_id", BigInteger, ForeignKey("run.run_id")),
-        Column("node_id", BigInteger),
-        Column("log", String),
-        # Composite PK
-        UniqueConstraint("timestamp", "run_id", "node_id"),
-    )
-
-    # --------------------------------------------------------------------------
-    #  Table: context
-    # --------------------------------------------------------------------------
-    Table(
-        "context",
-        metadata,
-        Column("run_id", BigInteger, ForeignKey("run.run_id"), unique=True),
-        Column("context", LargeBinary),
-    )
-
-    # --------------------------------------------------------------------------
-    #  Table: message_ins
-    # --------------------------------------------------------------------------
-    Table(
-        "message_ins",
-        metadata,
-        Column("message_id", String, unique=True),
-        Column("group_id", String),
-        Column("run_id", BigInteger, ForeignKey("run.run_id")),
-        Column("src_node_id", BigInteger),
-        Column("dst_node_id", BigInteger),
-        Column("reply_to_message_id", String),
-        Column("created_at", Float),
-        Column("delivered_at", String),
-        Column("ttl", Float),
-        Column("message_type", String),
-        Column("content", LargeBinary, nullable=True),
-        Column("error", LargeBinary, nullable=True),
-    )
-
-    # --------------------------------------------------------------------------
-    #  Table: message_res
-    # --------------------------------------------------------------------------
-    Table(
-        "message_res",
-        metadata,
-        Column("message_id", String, unique=True),
-        Column("group_id", String),
-        Column("run_id", BigInteger, ForeignKey("run.run_id")),
-        Column("src_node_id", BigInteger),
-        Column("dst_node_id", BigInteger),
-        Column("reply_to_message_id", String),
-        Column("created_at", Float),
-        Column("delivered_at", String),
-        Column("ttl", Float),
-        Column("message_type", String),
-        Column("content", LargeBinary, nullable=True),
-        Column("error", LargeBinary, nullable=True),
-        Index(
-            "idx_message_res_reply_to_message_id_unique",
-            "reply_to_message_id",
-            unique=True,
-        ),
-    )
-
+    for table in LinkStateBase.metadata.tables.values():
+        table.to_metadata(metadata)
     return metadata


### PR DESCRIPTION
## Issue

### Description

LinkState metadata is still duplicated between declarative models and the legacy table wrapper.

## Proposal

### Explanation

Use the declarative LinkState model registry when building compatibility metadata. This removes the duplicate table definitions without changing the physical schema or runtime behavior.

Validation: LinkState/schema tests, Alembic metadata no-diff test, Ruff, Black, mypy, Pylint, and diff checks pass.