### PR TITLE
feat(framework): Add PostgreSQL URL helper

### DIFF
--- a/framework/py/flwr/supercore/database.py
+++ b/framework/py/flwr/supercore/database.py
@@ -58,6 +58,8 @@ def postgresql_url_from_environment(
     except ValueError as exc:
         raise ValueError("FLWR_POSTGRES_PORT must be an integer") from exc
 
+    if not 1 <= port <= 65535:
+        raise ValueError("FLWR_POSTGRES_PORT must be between 1 and 65535")
     return URL.create(
         "postgresql+psycopg",
         username=values["FLWR_POSTGRES_USER"],

--- a/framework/py/flwr/supercore/database.py
+++ b/framework/py/flwr/supercore/database.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Database configuration helpers shared by Flower services."""
+
+import os
+from collections.abc import Mapping
+
+from sqlalchemy.engine import URL
+
+
+def postgresql_url_from_environment(
+    environ: Mapping[str, str] | None = None,
+) -> URL:
+    """Build a synchronous PostgreSQL URL from Flower environment variables.
+
+    Parameters
+    ----------
+    environ : Mapping[str, str] | None
+        Environment values to read. If omitted, ``os.environ`` is used.
+
+    Returns
+    -------
+    sqlalchemy.engine.URL
+        A PostgreSQL URL using the psycopg driver.
+
+    Raises
+    ------
+    ValueError
+        If a required value is missing or the configured port is invalid.
+    """
+    values = os.environ if environ is None else environ
+    required = (
+        "FLWR_POSTGRES_USER",
+        "FLWR_POSTGRES_PASSWORD",
+        "FLWR_POSTGRES_HOST",
+        "FLWR_POSTGRES_DATABASE",
+    )
+    missing = [name for name in required if not values.get(name)]
+    if missing:
+        raise ValueError(
+            "Missing required PostgreSQL environment variables: " + ", ".join(missing)
+        )
+
+    try:
+        port = int(values.get("FLWR_POSTGRES_PORT", "5432"))
+    except ValueError as exc:
+        raise ValueError("FLWR_POSTGRES_PORT must be an integer") from exc
+
+    return URL.create(
+        "postgresql+psycopg",
+        username=values["FLWR_POSTGRES_USER"],
+        password=values["FLWR_POSTGRES_PASSWORD"],
+        host=values["FLWR_POSTGRES_HOST"],
+        port=port,
+        database=values["FLWR_POSTGRES_DATABASE"],
+    )

--- a/framework/py/flwr/supercore/database_test.py
+++ b/framework/py/flwr/supercore/database_test.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for database configuration helpers."""
+
+import pytest
+
+from .database import postgresql_url_from_environment
+
+
+def test_postgresql_url_from_environment_preserves_credentials() -> None:
+    """Build a URL without loading unrelated application settings."""
+    url = postgresql_url_from_environment(
+        {
+            "FLWR_POSTGRES_USER": "platform-owner",
+            "FLWR_POSTGRES_PASSWORD": "p@ss word/%",
+            "FLWR_POSTGRES_HOST": "postgres.internal",
+            "FLWR_POSTGRES_PORT": "5544",
+            "FLWR_POSTGRES_DATABASE": "platform",
+        }
+    )
+
+    assert url.drivername == "postgresql+psycopg"
+    assert url.username == "platform-owner"
+    assert url.password == "p@ss word/%"
+    assert url.host == "postgres.internal"
+    assert url.port == 5544
+    assert url.database == "platform"
+
+
+def test_postgresql_url_from_environment_rejects_missing_values() -> None:
+    """Reject incomplete PostgreSQL configuration."""
+    with pytest.raises(ValueError, match="FLWR_POSTGRES_PASSWORD"):
+        postgresql_url_from_environment(
+            {
+                "FLWR_POSTGRES_USER": "platform-owner",
+                "FLWR_POSTGRES_HOST": "postgres.internal",
+                "FLWR_POSTGRES_DATABASE": "platform",
+            }
+        )


### PR DESCRIPTION
## What changed

- Add `flwr.supercore.database.postgresql_url_from_environment`.
- Build a psycopg SQLAlchemy URL from the standard `FLWR_POSTGRES_*` variables.
- Default the PostgreSQL port to `5432` and validate required values and port input.
- Add focused unit coverage for credentials, defaults, and missing configuration.

## Why

Database-backed Flower services need the same safe PostgreSQL URL construction. Keeping this small helper in SuperCore gives those services one typed implementation to import.

## Validation

- Focused PostgreSQL helper tests
- Black, isort, Ruff, mypy, and Pylint
