### PR TITLE
docs(framework:skip): Remove obsolete changelog tokens

### DIFF
--- a/framework/docs/source/changelog/v1.10.0.md
+++ b/framework/docs/source/changelog/v1.10.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Adam Narozniak`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Danny`, `Gustavo Bertoli`, `Heng Pan`, `Ikko Eltociear Ashimine`, `Javier`, `Jiahao Tan`, `Mohammad Naseri`, `Robert Steiner`, `Sebastian van der Voort`, `Taner Topal`, `Yan Gao` <!---TOKEN_v1.10.0-->
+`Adam Narozniak`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Danny`, `Gustavo Bertoli`, `Heng Pan`, `Ikko Eltociear Ashimine`, `Javier`, `Jiahao Tan`, `Mohammad Naseri`, `Robert Steiner`, `Sebastian van der Voort`, `Taner Topal`, `Yan Gao`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.11.0.md
+++ b/framework/docs/source/changelog/v1.11.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Adam Narozniak`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Danny`, `Edoardo Gabrielli`, `Heng Pan`, `Javier`, `Meng Yan`, `Michal Danilowski`, `Mohammad Naseri`, `Robert Steiner`, `Steve Laskaridis`, `Taner Topal`, `Yan Gao` <!---TOKEN_v1.11.0-->
+`Adam Narozniak`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Danny`, `Edoardo Gabrielli`, `Heng Pan`, `Javier`, `Meng Yan`, `Michal Danilowski`, `Mohammad Naseri`, `Robert Steiner`, `Steve Laskaridis`, `Taner Topal`, `Yan Gao`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.11.1.md
+++ b/framework/docs/source/changelog/v1.11.1.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Heng Pan`, `Javier`, `Robert Steiner`, `Yan Gao` <!---TOKEN_v1.11.1-->
+`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Heng Pan`, `Javier`, `Robert Steiner`, `Yan Gao`
 
 ### Improvements
 

--- a/framework/docs/source/changelog/v1.12.0.md
+++ b/framework/docs/source/changelog/v1.12.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Adam Narozniak`, `Audris`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Jiahao Tan`, `Julian Rußmeyer`, `Mohammad Naseri`, `Ray Sun`, `Robert Steiner`, `Yan Gao`, `xiliguguagua` <!---TOKEN_v1.12.0-->
+`Adam Narozniak`, `Audris`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Jiahao Tan`, `Julian Rußmeyer`, `Mohammad Naseri`, `Ray Sun`, `Robert Steiner`, `Yan Gao`, `xiliguguagua`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.13.0.md
+++ b/framework/docs/source/changelog/v1.13.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Adam Narozniak`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Heng Pan`, `Javier`, `Mohammad Naseri`, `Robert Steiner`, `Waris Gill`, `William Lindskog`, `Yan Gao`, `Yao Xu`, `wwjang` <!---TOKEN_v1.13.0-->
+`Adam Narozniak`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Heng Pan`, `Javier`, `Mohammad Naseri`, `Robert Steiner`, `Waris Gill`, `William Lindskog`, `Yan Gao`, `Yao Xu`, `wwjang`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.13.1.md
+++ b/framework/docs/source/changelog/v1.13.1.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Adam Narozniak`, `Charles Beauville`, `Heng Pan`, `Javier`, `Robert Steiner` <!---TOKEN_v1.13.1-->
+`Adam Narozniak`, `Charles Beauville`, `Heng Pan`, `Javier`, `Robert Steiner`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.14.0.md
+++ b/framework/docs/source/changelog/v1.14.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Adam Narozniak`, `Charles Beauville`, `Chong Shen Ng`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Heng Pan`, `Javier`, `Meng Yan`, `Mohammad Naseri`, `Robert Steiner`, `Taner Topal`, `Vidit Khandelwal`, `Yan Gao` <!---TOKEN_v1.14.0-->
+`Adam Narozniak`, `Charles Beauville`, `Chong Shen Ng`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Heng Pan`, `Javier`, `Meng Yan`, `Mohammad Naseri`, `Robert Steiner`, `Taner Topal`, `Vidit Khandelwal`, `Yan Gao`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.15.0.md
+++ b/framework/docs/source/changelog/v1.15.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Haoran Jie`, `Heng Pan`, `Ivelin Ivanov`, `Javier`, `Kevin Patel`, `Mohammad Naseri`, `Pavlos Bouzinis`, `Robert Steiner` <!---TOKEN_v1.15.0-->
+`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Haoran Jie`, `Heng Pan`, `Ivelin Ivanov`, `Javier`, `Kevin Patel`, `Mohammad Naseri`, `Pavlos Bouzinis`, `Robert Steiner`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.15.1.md
+++ b/framework/docs/source/changelog/v1.15.1.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Dimitris Stripelis`, `Heng Pan`, `Javier`, `Taner Topal`, `Yan Gao` <!---TOKEN_v1.15.1-->
+`Dimitris Stripelis`, `Heng Pan`, `Javier`, `Taner Topal`, `Yan Gao`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.15.2.md
+++ b/framework/docs/source/changelog/v1.15.2.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Charles Beauville`, `Heng Pan`, `Javier`, `Leandro Collier`, `Stephane Moroso`, `Yan Gao` <!---TOKEN_v1.15.2-->
+`Charles Beauville`, `Heng Pan`, `Javier`, `Leandro Collier`, `Stephane Moroso`, `Yan Gao`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.16.0.md
+++ b/framework/docs/source/changelog/v1.16.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Alan Silva`, `Andrej Jovanović`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Dimitris Stripelis`, `Heng Pan`, `Javier`, `Kevin Ta`, `Li Shaoyu`, `Mohammad Naseri`, `Taner Topal`, `Yan Gao` <!---TOKEN_v1.16.0-->
+`Alan Silva`, `Andrej Jovanović`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Dimitris Stripelis`, `Heng Pan`, `Javier`, `Kevin Ta`, `Li Shaoyu`, `Mohammad Naseri`, `Taner Topal`, `Yan Gao`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.17.0.md
+++ b/framework/docs/source/changelog/v1.17.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Aline Almeida`, `Charles Beauville`, `Chong Shen Ng`, `Daniel Hinjos García`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Heng Pan`, `Javier`, `Robert Steiner`, `Yan Gao` <!---TOKEN_v1.17.0-->
+`Aline Almeida`, `Charles Beauville`, `Chong Shen Ng`, `Daniel Hinjos García`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Heng Pan`, `Javier`, `Robert Steiner`, `Yan Gao`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.18.0.md
+++ b/framework/docs/source/changelog/v1.18.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Alan Silva`, `Andrej Jovanović`, `Charles Beauville`, `Chong Shen Ng`, `Chunhui XU`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Guanheng Liu`, `Gustavo Bertoli`, `Heng Pan`, `Javier`, `Khoa Nguyen`, `Mohammad Naseri`, `Pinji Chen`, `Robert Steiner`, `Stephane Moroso`, `Taner Topal`, `William Lindskog`, `Yan Gao` <!---TOKEN_v1.18.0-->
+`Alan Silva`, `Andrej Jovanović`, `Charles Beauville`, `Chong Shen Ng`, `Chunhui XU`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Guanheng Liu`, `Gustavo Bertoli`, `Heng Pan`, `Javier`, `Khoa Nguyen`, `Mohammad Naseri`, `Pinji Chen`, `Robert Steiner`, `Stephane Moroso`, `Taner Topal`, `William Lindskog`, `Yan Gao`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.19.0.md
+++ b/framework/docs/source/changelog/v1.19.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Adam Tupper`, `Andrej Jovanović`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Haoran Jie`, `Heng Pan`, `Javier`, `Kevin Ta`, `Mohammad Naseri`, `Ragnar`, `Robert Steiner`, `William Lindskog`, `ashley09`, `dennis-grinwald`, `sukrucildirr` <!---TOKEN_v1.19.0-->
+`Adam Tupper`, `Andrej Jovanović`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Haoran Jie`, `Heng Pan`, `Javier`, `Kevin Ta`, `Mohammad Naseri`, `Ragnar`, `Robert Steiner`, `William Lindskog`, `ashley09`, `dennis-grinwald`, `sukrucildirr`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.20.0.md
+++ b/framework/docs/source/changelog/v1.20.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Heng Pan`, `Javier`, `Kumbham Ajay Goud`, `Robert Steiner`, `William Lindskog`, `Yan Gao` <!---TOKEN_v1.20.0-->
+`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Heng Pan`, `Javier`, `Kumbham Ajay Goud`, `Robert Steiner`, `William Lindskog`, `Yan Gao`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.21.0.md
+++ b/framework/docs/source/changelog/v1.21.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Evram`, `Heng Pan`, `Javier`, `Robert Steiner`, `Yan Gao` <!---TOKEN_v1.21.0-->
+`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Evram`, `Heng Pan`, `Javier`, `Robert Steiner`, `Yan Gao`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.22.0.md
+++ b/framework/docs/source/changelog/v1.22.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Dimitris Stripelis`, `Heng Pan`, `Javier`, `Mohammad Naseri`, `Patrick Foley`, `William Lindskog`, `Yan Gao` <!---TOKEN_v1.22.0-->
+`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Dimitris Stripelis`, `Heng Pan`, `Javier`, `Mohammad Naseri`, `Patrick Foley`, `William Lindskog`, `Yan Gao`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.23.0.md
+++ b/framework/docs/source/changelog/v1.23.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Adam Tupper`, `Alan Yi`, `Alireza Ghasemi`, `Charles Beauville`, `Chong Shen Ng`, `Daniel Anoruo`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Patrick Foley`, `Robert Steiner`, `Rohat Bozyil`, `Yan Gao`, `combe4259`, `han97901`, `maviva` <!---TOKEN_v1.23.0-->
+`Adam Tupper`, `Alan Yi`, `Alireza Ghasemi`, `Charles Beauville`, `Chong Shen Ng`, `Daniel Anoruo`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Patrick Foley`, `Robert Steiner`, `Rohat Bozyil`, `Yan Gao`, `combe4259`, `han97901`, `maviva`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.24.0.md
+++ b/framework/docs/source/changelog/v1.24.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Patrick Foley`, `Robert Steiner`, `Yan Gao` <!---TOKEN_v1.24.0-->
+`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Patrick Foley`, `Robert Steiner`, `Yan Gao`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.25.0.md
+++ b/framework/docs/source/changelog/v1.25.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Chong Shen Ng`, `Daniel J. Beutel`, `Heng Pan`, `Javier`, `Mohammad Naseri`, `Soumik Sarker`, `William Lindskog`, `Yan Gao`, `sarahhfalco` <!---TOKEN_v1.25.0-->
+`Chong Shen Ng`, `Daniel J. Beutel`, `Heng Pan`, `Javier`, `Mohammad Naseri`, `Soumik Sarker`, `William Lindskog`, `Yan Gao`, `sarahhfalco`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.26.0.md
+++ b/framework/docs/source/changelog/v1.26.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Flippchen`, `Heng Pan`, `Iason Ofeidis`, `Javier`, `Jun S`, `Soumik Sarker`, `Taner Topal`, `Yan Gao`, `nihonge` <!---TOKEN_v1.26.0-->
+`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Flippchen`, `Heng Pan`, `Iason Ofeidis`, `Javier`, `Jun S`, `Soumik Sarker`, `Taner Topal`, `Yan Gao`, `nihonge`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.26.1.md
+++ b/framework/docs/source/changelog/v1.26.1.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Heng Pan`, `Javier`, `Taner Topal` <!---TOKEN_v1.26.1-->
+`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Heng Pan`, `Javier`, `Taner Topal`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.27.0.md
+++ b/framework/docs/source/changelog/v1.27.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Heng Pan`, `Javier`, `Micah Sheller`, `Mohammad Naseri`, `Roma Klapaukh`, `Ruth Galindo`, `Taner Topal`, `Yan Gao` <!---TOKEN_v1.27.0-->
+`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Heng Pan`, `Javier`, `Micah Sheller`, `Mohammad Naseri`, `Roma Klapaukh`, `Ruth Galindo`, `Taner Topal`, `Yan Gao`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.28.0.md
+++ b/framework/docs/source/changelog/v1.28.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Julian Rußmeyer`, `Micah Sheller`, `Mohammad Naseri`, `Patrick Foley`, `Taner Topal`, `William Lindskog`, `Yan Gao`, `xiaoyanshen799` <!---TOKEN_v1.28.0-->
+`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Julian Rußmeyer`, `Micah Sheller`, `Mohammad Naseri`, `Patrick Foley`, `Taner Topal`, `William Lindskog`, `Yan Gao`, `xiaoyanshen799`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.29.0.md
+++ b/framework/docs/source/changelog/v1.29.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Heng Pan`, `Javier`, `Micah Sheller`, `Mohammad Naseri`, `Patrick Foley`, `Yan Gao` <!---TOKEN_v1.29.0-->
+`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Heng Pan`, `Javier`, `Micah Sheller`, `Mohammad Naseri`, `Patrick Foley`, `Yan Gao`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.30.0.md
+++ b/framework/docs/source/changelog/v1.30.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Micah Sheller`, `Mohammad Naseri`, `Patrick Foley`, `Taner Topal`, `Yan Gao` <!---TOKEN_v1.30.0-->
+`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Micah Sheller`, `Mohammad Naseri`, `Patrick Foley`, `Taner Topal`, `Yan Gao`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.31.0.md
+++ b/framework/docs/source/changelog/v1.31.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Gustavo Bertoli`, `Heng Pan`, `Javier`, `Leandro`, `Lorenzo Sani`, `Micah Sheller`, `Mohammad Naseri`, `Nyam2C`, `Patrick Foley`, `Seulki Yun`, `Sijiaomg Ohoh`, `Taner Topal`, `Yan Gao`, `Young D. Kwon`, `reducedradius` <!---TOKEN_v1.31.0-->
+`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Gustavo Bertoli`, `Heng Pan`, `Javier`, `Leandro`, `Lorenzo Sani`, `Micah Sheller`, `Mohammad Naseri`, `Nyam2C`, `Patrick Foley`, `Seulki Yun`, `Sijiaomg Ohoh`, `Taner Topal`, `Yan Gao`, `Young D. Kwon`, `reducedradius`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.32.0.md
+++ b/framework/docs/source/changelog/v1.32.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Aleksei Balan`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Julian Rußmeyer`, `Micah Sheller`, `Mohammad Naseri`, `Patrick Foley`, `Ruth Galindo`, `William Lindskog`, `reducedradius` <!---TOKEN_v1.32.0-->
+`Aleksei Balan`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Julian Rußmeyer`, `Micah Sheller`, `Mohammad Naseri`, `Patrick Foley`, `Ruth Galindo`, `William Lindskog`, `reducedradius`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.32.1.md
+++ b/framework/docs/source/changelog/v1.32.1.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Chong Shen Ng`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Micah Sheller` <!---TOKEN_v1.32.1-->
+`Chong Shen Ng`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Micah Sheller`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.33.0.md
+++ b/framework/docs/source/changelog/v1.33.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Heng Pan`, `Javier`, `Micah Sheller`, `Mohammad Naseri`, `Patrick Foley`, `Stephane Moroso`, `Taner Topal` <!---TOKEN_v1.33.0-->
+`Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Heng Pan`, `Javier`, `Micah Sheller`, `Mohammad Naseri`, `Patrick Foley`, `Stephane Moroso`, `Taner Topal`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.5.0.md
+++ b/framework/docs/source/changelog/v1.5.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Adam Narozniak`, `Anass Anhari`, `Charles Beauville`, `Dana-Farber`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Edoardo Gabrielli`, `Gustavo Bertoli`, `Heng Pan`, `Javier`, `Mahdi`, `Steven Hé (Sīchàng)`, `Taner Topal`, `achiverram28`, `danielnugraha`, `eunchung`, `ruthgal` <!---TOKEN_v1.5.0-->
+`Adam Narozniak`, `Anass Anhari`, `Charles Beauville`, `Dana-Farber`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Edoardo Gabrielli`, `Gustavo Bertoli`, `Heng Pan`, `Javier`, `Mahdi`, `Steven Hé (Sīchàng)`, `Taner Topal`, `achiverram28`, `danielnugraha`, `eunchung`, `ruthgal`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.6.0.md
+++ b/framework/docs/source/changelog/v1.6.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Aashish Kolluri`, `Adam Narozniak`, `Alessio Mora`, `Barathwaja S`, `Charles Beauville`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Gabriel Mota`, `Heng Pan`, `Ivan Agarský`, `JS.KIM`, `Javier`, `Marius Schlegel`, `Navin Chandra`, `Nic Lane`, `Peterpan828`, `Qinbin Li`, `Shaz-hash`, `Steve Laskaridis`, `Taner Topal`, `William Lindskog`, `Yan Gao`, `cnxdeveloper`, `k3nfalt` <!---TOKEN_v1.6.0-->
+`Aashish Kolluri`, `Adam Narozniak`, `Alessio Mora`, `Barathwaja S`, `Charles Beauville`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Gabriel Mota`, `Heng Pan`, `Ivan Agarský`, `JS.KIM`, `Javier`, `Marius Schlegel`, `Navin Chandra`, `Nic Lane`, `Peterpan828`, `Qinbin Li`, `Shaz-hash`, `Steve Laskaridis`, `Taner Topal`, `William Lindskog`, `Yan Gao`, `cnxdeveloper`, `k3nfalt`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.7.0.md
+++ b/framework/docs/source/changelog/v1.7.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Aasheesh Singh`, `Adam Narozniak`, `Aml Hassan Esmil`, `Charles Beauville`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Edoardo Gabrielli`, `Gustavo Bertoli`, `HelinLin`, `Heng Pan`, `Javier`, `M S Chaitanya Kumar`, `Mohammad Naseri`, `Nikos Vlachakis`, `Pritam Neog`, `Robert Kuska`, `Robert Steiner`, `Taner Topal`, `Yahia Salaheldin Shaaban`, `Yan Gao`, `Yasar Abbas` <!---TOKEN_v1.7.0-->
+`Aasheesh Singh`, `Adam Narozniak`, `Aml Hassan Esmil`, `Charles Beauville`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Edoardo Gabrielli`, `Gustavo Bertoli`, `HelinLin`, `Heng Pan`, `Javier`, `M S Chaitanya Kumar`, `Mohammad Naseri`, `Nikos Vlachakis`, `Pritam Neog`, `Robert Kuska`, `Robert Steiner`, `Taner Topal`, `Yahia Salaheldin Shaaban`, `Yan Gao`, `Yasar Abbas`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.8.0.md
+++ b/framework/docs/source/changelog/v1.8.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Adam Narozniak`, `Charles Beauville`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Danny`, `Gustavo Bertoli`, `Heng Pan`, `Ikko Eltociear Ashimine`, `Jack Cook`, `Javier`, `Raj Parekh`, `Robert Steiner`, `Sebastian van der Voort`, `Taner Topal`, `Yan Gao`, `mohammadnaseri`, `tabdar-khan` <!---TOKEN_v1.8.0-->
+`Adam Narozniak`, `Charles Beauville`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Danny`, `Gustavo Bertoli`, `Heng Pan`, `Ikko Eltociear Ashimine`, `Jack Cook`, `Javier`, `Raj Parekh`, `Robert Steiner`, `Sebastian van der Voort`, `Taner Topal`, `Yan Gao`, `mohammadnaseri`, `tabdar-khan`
 
 ### What's new?
 

--- a/framework/docs/source/changelog/v1.9.0.md
+++ b/framework/docs/source/changelog/v1.9.0.md
@@ -4,7 +4,7 @@
 
 We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
 
-`Adam Narozniak`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Mahdi Beitollahi`, `Robert Steiner`, `Taner Topal`, `Yan Gao`, `bapic`, `mohammadnaseri` <!---TOKEN_v1.9.0-->
+`Adam Narozniak`, `Charles Beauville`, `Chong Shen Ng`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Heng Pan`, `Javier`, `Mahdi Beitollahi`, `Robert Steiner`, `Taner Topal`, `Yan Gao`, `bapic`, `mohammadnaseri`
 
 ### What's new?
 


### PR DESCRIPTION
## What changed

Removed all obsolete `<!---TOKEN_vxxx-->` comments from the versioned changelog files.

## Why

These placeholders are no longer used and add unnecessary markup to the published changelog sources.

## Impact

Documentation source cleanup only; there is no runtime or user-facing behavior change.

## Validation

- Confirmed no matching token comments remain under `framework/docs/source/changelog/`
- Ran `git diff --check`
- Validated the PR title with `dev/devtool/check_pr_title.py` using Python 3.11