### PR TITLE
feat(framework): Block agentapp in simulation federation

### DIFF
--- a/framework/py/flwr/superlink/servicer/control/control_handlers.py
+++ b/framework/py/flwr/superlink/servicer/control/control_handlers.py
@@ -525,7 +525,9 @@ def start_run(  # pylint: disable=too-many-branches,too-many-locals,too-many-sta
         resolved_federation_config = None
         runtime = RunTime.DEPLOYMENT
         sim_cfg = state.federation_manager.get_simulation_config(federation_id)
-        if sim_cfg and not is_agentapp_bundle:
+        if sim_cfg and is_agentapp_bundle:
+            raise ValueError("AgentApp cannot run in a simulation federation.")
+        if sim_cfg:
             primary_task_type = TaskType.SIMULATION
             runtime = RunTime.SIMULATION
             resolved_federation_config = SimulationConfig()

--- a/framework/py/flwr/superlink/servicer/control/control_handlers.py
+++ b/framework/py/flwr/superlink/servicer/control/control_handlers.py
@@ -526,7 +526,11 @@ def start_run(  # pylint: disable=too-many-branches,too-many-locals,too-many-sta
         runtime = RunTime.DEPLOYMENT
         sim_cfg = state.federation_manager.get_simulation_config(federation_id)
         if sim_cfg and is_agentapp_bundle:
-            raise ValueError("AgentApp cannot run in a simulation federation.")
+            raise FlowerError(
+                ApiErrorCode.INVALID_RUN_CONFIG,
+                "AgentApp cannot run in a simulation federation.",
+                public_details="AgentApp cannot run in a simulation federation.",
+            )
         if sim_cfg:
             primary_task_type = TaskType.SIMULATION
             runtime = RunTime.SIMULATION

--- a/framework/py/flwr/superlink/servicer/control/control_servicer_test.py
+++ b/framework/py/flwr/superlink/servicer/control/control_servicer_test.py
@@ -587,8 +587,8 @@ class TestControlServicer(unittest.TestCase):  # pylint: disable=R0904
         self.assertEqual(tasks[0].run_id, response.run_id)
         self.assertEqual(tasks[0].type, expected_task_type)
 
-    def test_start_run_creates_agentapp_run_from_local_fab(self) -> None:
-        """Test StartRun creates an AgentApp run for a submitted AgentApp FAB."""
+    def test_start_run_rejects_agentapp_in_simulation_federation(self) -> None:
+        """Test StartRun rejects an AgentApp in a simulation federation."""
         fab_content = b"test AgentApp FAB content"
         request = StartRunRequest()
         request.fab.hash_str = hashlib.sha256(fab_content).hexdigest()
@@ -602,14 +602,12 @@ class TestControlServicer(unittest.TestCase):  # pylint: disable=R0904
             patch(
                 "flwr.superlink.servicer.control.control_handlers.get_fab_config"
             ) as mock_get_fab_config,
-            patch(
-                "flwr.superlink.servicer.control.control_handlers.get_metadata_from_config"
-            ) as mock_get_metadata_from_config,
             patch.object(
                 self.state.federation_manager,
                 "get_simulation_config",
                 return_value=SimulationConfig(),
             ),
+            self.assertRaises(FlowerError) as error,
         ):
             mock_get_fab_config.return_value = {
                 "tool": {
@@ -621,23 +619,10 @@ class TestControlServicer(unittest.TestCase):  # pylint: disable=R0904
                     }
                 }
             }
-            mock_get_metadata_from_config.return_value = ("flwr/agent", "0.1.0")
-            response = self.servicer.StartRun(request, Mock())
+            self.servicer.StartRun(request, Mock())
 
-        runs = self.state.get_run_info(run_ids=[response.run_id])
-        tasks = self.state.get_tasks()
-        series = self.state.get_run_series(series_ids=[response.series_id])
-
-        self.assertEqual(len(runs), 1)
-        self.assertEqual(runs[0].fab_id, "flwr/agent")
-        self.assertEqual(runs[0].fab_version, "0.1.0")
-        self.assertEqual(runs[0].primary_task_type, TaskType.AGENT_APP)
-        self.assertEqual(runs[0].override_config["agent.input"], agent_input)
-        self.assertEqual(series[0].description, "Hello from the agent")
-        self.assertEqual(len(tasks), 1)
-        self.assertEqual(tasks[0].run_id, response.run_id)
-        self.assertEqual(tasks[0].type, TaskType.AGENT_APP)
-        self.assertEqual(tasks[0].fab_hash, runs[0].fab_hash)
+        self.assertEqual(error.exception.code, ApiErrorCode.INVALID_RUN_CONFIG)
+        self.assertEqual(list(self.state.get_run_info()), [])
 
     def test_start_run_creates_builtin_agentapp_run_from_app_spec(self) -> None:
         """Test StartRun creates an AgentApp run for the built-in flwr agent."""

--- a/framework/py/flwr/superlink/servicer/control/control_servicer_test.py
+++ b/framework/py/flwr/superlink/servicer/control/control_servicer_test.py
@@ -622,6 +622,10 @@ class TestControlServicer(unittest.TestCase):  # pylint: disable=R0904
             self.servicer.StartRun(request, Mock())
 
         self.assertEqual(error.exception.code, ApiErrorCode.INVALID_RUN_CONFIG)
+        self.assertEqual(
+            error.exception.public_details,
+            "AgentApp cannot run in a simulation federation.",
+        )
         self.assertEqual(list(self.state.get_run_info()), [])
 
     def test_start_run_creates_builtin_agentapp_run_from_app_spec(self) -> None:


### PR DESCRIPTION
Block agentapp to only run in deployment federations.