### PR TITLE
ci(framework): Reuse Docker artifacts when inputs are unchanged

### DIFF
--- a/.github/workflows/framework-commit-artifacts.yml
+++ b/.github/workflows/framework-commit-artifacts.yml
@@ -31,14 +31,27 @@ jobs:
 
       - name: Check Docker-relevant changes
         id: docker-changes
+        env:
+          AWS_DEFAULT_REGION: ${{ secrets.ARTIFACT_AWS_DEFAULT_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.ARTIFACT_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.ARTIFACT_AWS_SECRET_KEY_ID }}
+          ARTIFACT_BUCKET: ${{ secrets.ARTIFACT_AWS_BUCKET_NAME }}
         run: |
-          if git diff --quiet "${{ github.event.before }}" "${GITHUB_SHA}" -- \
+          BEFORE_SHA="${{ github.event.before }}"
+          if git diff --quiet "${BEFORE_SHA}" "${GITHUB_SHA}" -- \
             framework/py/ \
             framework/pyproject.toml \
             framework/docker/ \
             framework/dev/build-docker-image-matrix.py \
             framework/dev/release/resolve-docker-matrix.py; then
-            echo "required=false" >> "$GITHUB_OUTPUT"
+            # Only reuse when the previous commit's digest index exists.
+            if [[ -z "${BEFORE_SHA}" || "${BEFORE_SHA}" =~ ^0{40}$ ]]; then
+              echo "required=true" >> "$GITHUB_OUTPUT"
+            elif aws s3 ls "s3://${ARTIFACT_BUCKET}/framework/commits/${BEFORE_SHA}/digests.json" > /dev/null 2>&1; then
+              echo "required=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "required=true" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "required=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/framework-commit-artifacts.yml
+++ b/.github/workflows/framework-commit-artifacts.yml
@@ -23,8 +23,25 @@ jobs:
     timeout-minutes: 5
     outputs:
       whl_path: ${{ steps.artifacts.outputs.WHL_PATH }}
+      docker-required: ${{ steps.docker-changes.outputs.required }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check Docker-relevant changes
+        id: docker-changes
+        run: |
+          if git diff --quiet "${{ github.event.before }}" "${GITHUB_SHA}" -- \
+            framework/py/ \
+            framework/pyproject.toml \
+            framework/docker/ \
+            framework/dev/build-docker-image-matrix.py \
+            framework/dev/release/resolve-docker-matrix.py; then
+            echo "required=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "required=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap
@@ -59,7 +76,30 @@ jobs:
             s3://${{ secrets.ARTIFACT_AWS_BUCKET_NAME }}/framework/commits/${GITHUB_SHA}/ \
             --recursive
 
+      - name: Reuse previous Docker artifact index
+        if: steps.docker-changes.outputs.required == 'false'
+        env:
+          AWS_DEFAULT_REGION: ${{ secrets.ARTIFACT_AWS_DEFAULT_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.ARTIFACT_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.ARTIFACT_AWS_SECRET_KEY_ID }}
+        run: |
+          aws s3 cp \
+            s3://${{ secrets.ARTIFACT_AWS_BUCKET_NAME }}/framework/commits/${{ github.event.before }}/digests.json \
+            digests.previous.json
+
+          jq \
+            --arg commit_sha "${GITHUB_SHA}" \
+            '.commit_sha = $commit_sha' \
+            digests.previous.json > digests.json
+
+          aws s3 cp \
+            --content-disposition "attachment" \
+            --cache-control "no-cache" \
+            digests.json \
+            s3://${{ secrets.ARTIFACT_AWS_BUCKET_NAME }}/framework/commits/${GITHUB_SHA}/digests.json
+
   prepare-docker-build-matrix:
+    if: needs.package-distributions.outputs.docker-required == 'true'
     name: Collect Docker build parameters
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/.github/workflows/framework-commit-artifacts.yml
+++ b/.github/workflows/framework-commit-artifacts.yml
@@ -38,7 +38,6 @@ jobs:
           ARTIFACT_BUCKET: ${{ secrets.ARTIFACT_AWS_BUCKET_NAME }}
         run: |
           BEFORE_SHA="${{ github.event.before }}"
-          BEFORE_SHA="${{ github.event.before }}"
 
           required=true
           if git diff --quiet "${BEFORE_SHA}" "${GITHUB_SHA}" -- \

--- a/.github/workflows/framework-commit-artifacts.yml
+++ b/.github/workflows/framework-commit-artifacts.yml
@@ -38,23 +38,24 @@ jobs:
           ARTIFACT_BUCKET: ${{ secrets.ARTIFACT_AWS_BUCKET_NAME }}
         run: |
           BEFORE_SHA="${{ github.event.before }}"
+          BEFORE_SHA="${{ github.event.before }}"
+
+          required=true
           if git diff --quiet "${BEFORE_SHA}" "${GITHUB_SHA}" -- \
-            framework/py/ \
-            framework/pyproject.toml \
-            framework/docker/ \
-            framework/dev/build-docker-image-matrix.py \
-            framework/dev/release/resolve-docker-matrix.py; then
-            # Only reuse when the previous commit's digest index exists.
-            if [[ -z "${BEFORE_SHA}" || "${BEFORE_SHA}" =~ ^0{40}$ ]]; then
-              echo "required=true" >> "$GITHUB_OUTPUT"
-            elif aws s3 ls "s3://${ARTIFACT_BUCKET}/framework/commits/${BEFORE_SHA}/digests.json" > /dev/null 2>&1; then
-              echo "required=false" >> "$GITHUB_OUTPUT"
-            else
-              echo "required=true" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            echo "required=true" >> "$GITHUB_OUTPUT"
+              framework/py/ \
+              framework/pyproject.toml \
+              framework/docker/ \
+              framework/dev/build-docker-image-matrix.py \
+              framework/dev/release/resolve-docker-matrix.py &&
+            aws s3api head-object \
+              --bucket "${ARTIFACT_BUCKET}" \
+              --key "framework/commits/${BEFORE_SHA}/digests.json" \
+              > /dev/null 2>&1
+          then
+            required=false
           fi
+
+          echo "required=${required}" >> "$GITHUB_OUTPUT"
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap


### PR DESCRIPTION
## What changed

- detect whether a commit changes Docker-relevant framework paths
- skip Docker matrix generation and image builds when those inputs are unchanged
- copy the previous commit's Docker digest index forward and update its `commit_sha`

## Why

The main-branch artifact workflow currently rebuilds Docker images for every framework commit, even when the commit cannot affect those images. Reusing the prior digest index avoids unnecessary Docker builds while preserving per-commit artifact metadata.

## Impact

Commits that do not touch Docker-relevant inputs will publish package artifacts as before and reuse the previous Docker artifact index. Commits that do touch those inputs will continue through the existing Docker build and index-generation jobs.

## Validation

- Reviewed the workflow diff against `main`.
- Ran `actionlint` on `.github/workflows/framework-commit-artifacts.yml`; it stopped on the existing `concurrency.queue` key, which the current linter release does not recognize. The reported line is unchanged by this PR.