### PR TITLE
refactor(framework): Standardize Control HTTP authentication errors

### DIFF
--- a/framework/py/flwr/supercore/error/__init__.py
+++ b/framework/py/flwr/supercore/error/__init__.py
@@ -18,10 +18,11 @@
 from .base import ApiErrorCode, FlowerError
 from .exceptions import EntitlementError
 from .grpc import rpc_error_translator
-from .http import http_error_translator
+from .http import BearerAuthenticationError, http_error_translator
 
 __all__ = [
     "ApiErrorCode",
+    "BearerAuthenticationError",
     "EntitlementError",
     "FlowerError",
     "http_error_translator",

--- a/framework/py/flwr/supercore/error/http.py
+++ b/framework/py/flwr/supercore/error/http.py
@@ -29,6 +29,18 @@ from .base import FlowerError
 from .catalog import API_ERROR_MAP
 
 INTERNAL_SERVER_ERROR_MESSAGE = "Internal server error."
+NOT_AUTHENTICATED_DETAIL = "Not authenticated"
+
+
+class BearerAuthenticationError(HTTPException):
+    """Represent failed HTTP Bearer authentication."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=NOT_AUTHENTICATED_DETAIL,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
 
 async def http_error_translator(

--- a/framework/py/flwr/supercore/error/http_test.py
+++ b/framework/py/flwr/supercore/error/http_test.py
@@ -24,7 +24,11 @@ from starlette.datastructures import State
 from .base import ApiErrorCode, FlowerError
 from .catalog import API_ERROR_MAP
 from .exceptions import EntitlementError
-from .http import INTERNAL_SERVER_ERROR_MESSAGE, http_error_translator
+from .http import (
+    INTERNAL_SERVER_ERROR_MESSAGE,
+    BearerAuthenticationError,
+    http_error_translator,
+)
 
 
 def _run_translator(exception: Exception) -> Response:
@@ -148,6 +152,18 @@ def test_http_error_translator_http_exception() -> None:
         status.HTTP_418_IM_A_TEAPOT,
         {"detail": {"message": "short and stout"}},
     )
+
+
+def test_http_error_translator_bearer_authentication_error() -> None:
+    """Translate Bearer authentication failures using FastAPI's error contract."""
+    response = _run_translator(BearerAuthenticationError())
+
+    _assert_json_response(
+        response,
+        status.HTTP_401_UNAUTHORIZED,
+        {"detail": "Not authenticated"},
+    )
+    assert response.headers["www-authenticate"] == "Bearer"
 
 
 def test_http_error_translator_unexpected_error() -> None:

--- a/framework/py/flwr/superlink/dependencies/account.py
+++ b/framework/py/flwr/superlink/dependencies/account.py
@@ -19,7 +19,11 @@ from fastapi.security.utils import get_authorization_scheme_param
 
 from flwr.common.constant import ACCESS_TOKEN_KEY
 from flwr.supercore.auth.typing import AccountInfo
-from flwr.supercore.error import ApiErrorCode, FlowerError
+from flwr.supercore.error import (
+    ApiErrorCode,
+    BearerAuthenticationError,
+    FlowerError,
+)
 from flwr.superlink.auth_plugin import ControlAuthnPlugin
 
 
@@ -45,10 +49,7 @@ class AccountAccessDependency:
         """Return the authenticated account for a request."""
         authorization_headers = request.headers.getlist("authorization")
         if len(authorization_headers) > 1:
-            raise FlowerError(
-                ApiErrorCode.ACCOUNT_AUTHENTICATION_FAILED,
-                "Expected at most one Authorization header with a Bearer token.",
-            )
+            raise BearerAuthenticationError()
 
         metadata: list[tuple[str, str]] = []
         if authorization_headers:
@@ -56,35 +57,19 @@ class AccountAccessDependency:
                 authorization_headers[0]
             )
             if scheme.lower() != "bearer" or not access_token:
-                raise FlowerError(
-                    ApiErrorCode.ACCOUNT_AUTHENTICATION_FAILED,
-                    "Authorization header does not contain a Bearer token.",
-                )
+                raise BearerAuthenticationError()
             metadata = [(ACCESS_TOKEN_KEY, access_token)]
 
         valid_token, account = self.authn_plugin.validate_tokens_in_metadata(metadata)
         if not valid_token:
-            raise FlowerError(
-                ApiErrorCode.ACCOUNT_AUTHENTICATION_FAILED,
-                "Access token validation failed.",
-            )
+            raise BearerAuthenticationError()
 
-        return self._require_account(
-            account=account,
-            missing_account_detail="Token validated, but account info not found",
-        )
+        return self._require_account(account)
 
-    def _require_account(
-        self,
-        account: AccountInfo | None,
-        missing_account_detail: str,
-    ) -> AccountInfo:
+    def _require_account(self, account: AccountInfo | None) -> AccountInfo:
         """Require account information from the authentication plugin."""
         if account is None:
-            raise FlowerError(
-                ApiErrorCode.ACCOUNT_AUTHENTICATION_FAILED,
-                f"{missing_account_detail}: authentication plugin returned no account.",
-            )
+            raise BearerAuthenticationError()
         return account
 
 

--- a/framework/py/flwr/superlink/dependencies/account.py
+++ b/framework/py/flwr/superlink/dependencies/account.py
@@ -19,11 +19,7 @@ from fastapi.security.utils import get_authorization_scheme_param
 
 from flwr.common.constant import ACCESS_TOKEN_KEY
 from flwr.supercore.auth.typing import AccountInfo
-from flwr.supercore.error import (
-    ApiErrorCode,
-    BearerAuthenticationError,
-    FlowerError,
-)
+from flwr.supercore.error import ApiErrorCode, BearerAuthenticationError, FlowerError
 from flwr.superlink.auth_plugin import ControlAuthnPlugin
 
 

--- a/framework/py/flwr/superlink/dependencies/account_test.py
+++ b/framework/py/flwr/superlink/dependencies/account_test.py
@@ -21,11 +21,7 @@ from fastapi import FastAPI, Request
 
 from flwr.common.constant import ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY
 from flwr.supercore.auth.typing import AccountInfo
-from flwr.supercore.error import (
-    ApiErrorCode,
-    BearerAuthenticationError,
-    FlowerError,
-)
+from flwr.supercore.error import ApiErrorCode, BearerAuthenticationError, FlowerError
 
 from .account import AccountAccessDependency, get_account
 

--- a/framework/py/flwr/superlink/dependencies/account_test.py
+++ b/framework/py/flwr/superlink/dependencies/account_test.py
@@ -21,7 +21,11 @@ from fastapi import FastAPI, Request
 
 from flwr.common.constant import ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY
 from flwr.supercore.auth.typing import AccountInfo
-from flwr.supercore.error import ApiErrorCode, FlowerError
+from flwr.supercore.error import (
+    ApiErrorCode,
+    BearerAuthenticationError,
+    FlowerError,
+)
 
 from .account import AccountAccessDependency, get_account
 
@@ -105,10 +109,12 @@ def test_account_access_dependency_rejects_invalid_authorization_header(
     """AccountAccessDependency should reject malformed or duplicate credentials."""
     authn_plugin = Mock()
 
-    with pytest.raises(FlowerError) as exc_info:
+    with pytest.raises(BearerAuthenticationError) as exc_info:
         AccountAccessDependency(authn_plugin)(_make_request(authorization_headers))
 
-    assert exc_info.value.code == ApiErrorCode.ACCOUNT_AUTHENTICATION_FAILED
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Not authenticated"
+    assert exc_info.value.headers == {"WWW-Authenticate": "Bearer"}
     authn_plugin.validate_tokens_in_metadata.assert_not_called()
     authn_plugin.refresh_tokens.assert_not_called()
 
@@ -125,45 +131,38 @@ def test_account_access_dependency_rejects_legacy_headers_without_bearer() -> No
         ),
     )
 
-    with pytest.raises(FlowerError) as exc_info:
+    with pytest.raises(BearerAuthenticationError) as exc_info:
         AccountAccessDependency(authn_plugin)(request)
 
-    assert exc_info.value.code == ApiErrorCode.ACCOUNT_AUTHENTICATION_FAILED
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Not authenticated"
+    assert exc_info.value.headers == {"WWW-Authenticate": "Bearer"}
     authn_plugin.validate_tokens_in_metadata.assert_called_once_with([])
     authn_plugin.refresh_tokens.assert_not_called()
 
 
 @pytest.mark.parametrize(
-    ("valid_token", "account", "detail"),
+    ("valid_token", "account"),
     [
-        (
-            False,
-            None,
-            "Access token validation failed.",
-        ),
-        (
-            True,
-            None,
-            "Token validated, but account info not found: authentication plugin "
-            "returned no account.",
-        ),
+        (False, None),
+        (True, None),
     ],
 )
 def test_account_access_dependency_rejects_unauthenticated_requests(
     valid_token: bool,
     account: AccountInfo | None,
-    detail: str,
 ) -> None:
     """AccountAccessDependency should reject absent or incomplete authentication."""
     authn_plugin = Mock()
     authn_plugin.validate_tokens_in_metadata.return_value = (valid_token, account)
 
-    with pytest.raises(FlowerError) as exc_info:
+    with pytest.raises(BearerAuthenticationError) as exc_info:
         AccountAccessDependency(authn_plugin)(_make_request())
 
-    assert exc_info.value.code == ApiErrorCode.ACCOUNT_AUTHENTICATION_FAILED
-    assert exc_info.value.message == detail
-    assert "access-token" not in exc_info.value.message
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Not authenticated"
+    assert exc_info.value.headers == {"WWW-Authenticate": "Bearer"}
+    assert "access-token" not in exc_info.value.detail
     authn_plugin.refresh_tokens.assert_not_called()
 
 

--- a/framework/py/flwr/superlink/routers/control/router_test.py
+++ b/framework/py/flwr/superlink/routers/control/router_test.py
@@ -165,11 +165,7 @@ def test_list_runs_rejects_invalid_token_without_refresh() -> None:
     )
 
     assert response.status_code == 401
-    assert response.json() == {
-        "code": ApiErrorCode.ACCOUNT_AUTHENTICATION_FAILED,
-        "public_message": "Authentication failed.",
-        "public_details": None,
-    }
+    assert response.json() == {"detail": "Not authenticated"}
     assert response.headers["www-authenticate"] == "Bearer"
     assert "x-access-token" not in response.headers
     assert "x-refresh-token" not in response.headers


### PR DESCRIPTION
## Summary

Standardize authentication failures from protected Control HTTP endpoints on FastAPI’s native error-response format.

All Control HTTP Bearer authentication failures now return:

```http
HTTP/1.1 401 Unauthorized
Content-Type: application/json
WWW-Authenticate: Bearer
```

```json
{
  "detail": "Not authenticated"
}
```

This matches the established response shape used by Platform API endpoints and gives all SuperLink HTTP endpoints a consistent public authentication-error contract.

## Changes

- Add a shared `BearerAuthenticationError` based on FastAPI’s `HTTPException`.
- Use it for Control HTTP failures caused by:
  - Malformed or non-Bearer Authorization headers
  - Duplicate Authorization headers
  - Rejected access tokens
  - Authentication plugins returning no account
- Preserve `WWW-Authenticate: Bearer` on every authentication `401`.
- Never include access tokens or internal validation details in public responses.

## Public API change

### Before

Control HTTP authentication failures returned the Flower error envelope:

```json
{
  "code": 36,
  "public_message": "Authentication failed.",
  "public_details": null
}
```

### After

```json
{
  "detail": "Not authenticated"
}
```

### Breaking change

This changes the response body schema for Control HTTP authentication failures. Any client deserializing the Flower error envelope would need to use the FastAPI-style `detail` field instead.

This is acceptable because the Control HTTP endpoints currently have no active users.

The following remain unchanged:

- HTTP status: `401 Unauthorized`
- Response media type: `application/json`
- `WWW-Authenticate: Bearer`
- Successful protobuf requests and responses
- Control gRPC authentication and metadata
- Control gRPC token refresh
- Authentication-not-initialized `503` responses
- Other Flower HTTP error envelopes

## Tests

Updated and added coverage for:

- Shared Bearer authentication error translation
- Malformed and duplicate Authorization headers
- Token validation failures
- Missing account information
- Exact Control HTTP response body and challenge header
- Absence of refreshed-token response headers
- Unchanged protobuf behavior

Validated with:

- Control HTTP error, dependency, and router tests
- Control gRPC authentication interceptor tests
- Ruff
- Black
- Mypy