### PR TITLE
ci(framework): Update release PR via REST

### DIFF
--- a/.github/workflows/framework-e2e.yml
+++ b/.github/workflows/framework-e2e.yml
@@ -27,24 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # Temporary check for https://github.com/flwrlabs/flower/pull/7897.
-      - name: Test release bot PR lookup without read:org
-        if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
-        env:
-          GH_TOKEN: ${{ secrets.FLWRMACHINE_TOKEN }}
-        run: |
-          pr_number="$(
-            gh pr list \
-              --repo "${GITHUB_REPOSITORY}" \
-              --head "${GITHUB_HEAD_REF}" \
-              --state open \
-              --limit 1 \
-              --json number \
-              --jq '.[0].number'
-          )"
-          test -n "${pr_number}"
-          echo "Resolved PR #${pr_number} with FLWRMACHINE_TOKEN."
-
       - name: Filter changed paths
         id: filter
         uses: dorny/paths-filter@v3

--- a/.github/workflows/framework-e2e.yml
+++ b/.github/workflows/framework-e2e.yml
@@ -27,6 +27,24 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Temporary check for https://github.com/flwrlabs/flower/pull/7897.
+      - name: Test release bot PR lookup without read:org
+        if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+        env:
+          GH_TOKEN: ${{ secrets.FLWRMACHINE_TOKEN }}
+        run: |
+          pr_number="$(
+            gh pr list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --head "${GITHUB_HEAD_REF}" \
+              --state open \
+              --limit 1 \
+              --json number \
+              --jq '.[0].number'
+          )"
+          test -n "${pr_number}"
+          echo "Resolved PR #${pr_number} with FLWRMACHINE_TOKEN."
+
       - name: Filter changed paths
         id: filter
         uses: dorny/paths-filter@v3

--- a/.github/workflows/framework-release-prepare.yml
+++ b/.github/workflows/framework-release-prepare.yml
@@ -258,7 +258,20 @@ jobs:
               --body-file "${body_file}" \
               --draft
           else
-            gh pr edit "${BRANCH}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --body-file "${body_file}"
+            pr_number="$(
+              gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
+                --field "head=${GITHUB_REPOSITORY_OWNER}:${BRANCH}" \
+                --field state=open \
+                --jq '.[0].number'
+            )"
+            if [[ -z "${pr_number}" ]]; then
+              echo "No open release PR found for branch ${BRANCH}." >&2
+              exit 1
+            fi
+
+            jq -n --rawfile body "${body_file}" '{body: $body}' \
+              | gh api --method PATCH \
+                "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" \
+                --input - \
+                --jq '.html_url'
           fi

--- a/.github/workflows/framework-release-prepare.yml
+++ b/.github/workflows/framework-release-prepare.yml
@@ -259,9 +259,12 @@ jobs:
               --draft
           else
             pr_number="$(
-              gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
-                --field "head=${GITHUB_REPOSITORY_OWNER}:${BRANCH}" \
-                --field state=open \
+              gh pr list \
+                --repo "${GITHUB_REPOSITORY}" \
+                --head "${BRANCH}" \
+                --state open \
+                --limit 1 \
+                --json number \
                 --jq '.[0].number'
             )"
             if [[ -z "${pr_number}" ]]; then


### PR DESCRIPTION
## Summary

- Resolve the open Framework release PR with a minimal `gh pr list --json number` query during refresh runs.
- Update the PR description through the targeted REST `PATCH` endpoint.
- Fail with a clear message when the expected open release PR cannot be found.

## Root cause

[`gh pr edit`](https://cli.github.com/manual/gh_pr_edit) performs a GraphQL lookup that requests organization metadata. The release bot's classic token has `repo` and `workflow`, which are sufficient to update the PR, but the lookup fails because the token lacks `read:org`.

Failed run: https://github.com/flwrlabs/flower/actions/runs/32016976405/job/95348430260

As an alternative to this change, we could re-create `FLWRMACHINE_TOKEN` with the `read:org` permission. That would allow the existing `gh pr edit` command to run, but would expand the token's visibility into organization membership and teams. The minimal `gh pr list` query requests only the PR number, and the targeted REST update avoids requiring that additional scope.

## Validation

- Parsed the modified workflow as YAML.
- Extracted the modified workflow step and validated it with `bash -n`.
- Confirmed the minimal `gh pr list` query resolves this PR (#7897) with a normal token.
- Temporarily ran the same query in Framework E2E with `FLWRMACHINE_TOKEN`; it successfully resolved PR #7897 in [the `changes` job](https://github.com/flwrlabs/flower/actions/runs/32024614199/job/95371282242). The temporary probe was then removed.
- Ran `git diff --check`.