### PR TITLE
refactor(framework): Prepare for HTTP `RuntimeAPI` switch in `SuperNode`

### DIFF
--- a/framework/py/flwr/supernode/cli/flower_supernode.py
+++ b/framework/py/flwr/supernode/cli/flower_supernode.py
@@ -47,10 +47,12 @@ from flwr.supercore.auth import (
 )
 from flwr.supercore.exit import ExitCode, flwr_exit
 from flwr.supercore.grpc_health import add_args_health
+from flwr.supercore.object_store import ObjectStoreFactory
 from flwr.supercore.telemetry import EventType, event
 from flwr.supercore.tls import try_obtain_optional_runtime_server_certificates
 from flwr.supercore.update_check import warn_if_flwr_update_available
 from flwr.supercore.version import package_version
+from flwr.supernode.nodestate import NodeStateFactory
 from flwr.supernode.start_client_internal import start_client_internal
 
 
@@ -152,7 +154,10 @@ def flower_supernode() -> None:
 
     log(DEBUG, "Isolation mode: %s", config.isolation)
 
+    objectstore_factory = ObjectStoreFactory()
+    state_factory = NodeStateFactory(objectstore_factory=objectstore_factory)
     start_client_internal(
+        state_factory=state_factory,
         server_address=config.server_address,
         transport=config.transport,
         root_certificates=config.root_certificates,

--- a/framework/py/flwr/supernode/cli/flower_supernode.py
+++ b/framework/py/flwr/supernode/cli/flower_supernode.py
@@ -142,7 +142,9 @@ def _parse_supernode_lifespan_config() -> SuperNodeLifespanConfig:
         runtime_api_address=args.runtime_api_address,
         runtime_certificates=runtime_certificates,
         runtime_root_certificates_path=(
-            args.runtime_ssl_ca_certfile if runtime_certificates is not None else None
+            str(Path(args.runtime_ssl_ca_certfile).expanduser())
+            if runtime_certificates is not None
+            else None
         ),
         health_server_address=args.health_server_address,
         trusted_entities=trusted_entities,
@@ -151,8 +153,16 @@ def _parse_supernode_lifespan_config() -> SuperNodeLifespanConfig:
         enable_http_api=args.enable_http_api,
         host=args.host,
         port=args.port,
-        runtime_ssl_certfile=args.runtime_ssl_certfile,
-        runtime_ssl_keyfile=args.runtime_ssl_keyfile,
+        runtime_ssl_certfile=(
+            str(Path(args.runtime_ssl_certfile).expanduser())
+            if runtime_certificates is not None
+            else None
+        ),
+        runtime_ssl_keyfile=(
+            str(Path(args.runtime_ssl_keyfile).expanduser())
+            if runtime_certificates is not None
+            else None
+        ),
     )
 
 

--- a/framework/py/flwr/supernode/cli/flower_supernode.py
+++ b/framework/py/flwr/supernode/cli/flower_supernode.py
@@ -16,10 +16,13 @@
 
 
 import argparse
+import threading
 from dataclasses import dataclass
 from logging import DEBUG, INFO, WARN
 from pathlib import Path
+from time import sleep
 
+import uvicorn
 import yaml
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives.asymmetric import ec, ed25519
@@ -45,6 +48,7 @@ from flwr.supercore.auth import (
     add_superexec_auth_secret_args,
     load_superexec_auth_secret,
 )
+from flwr.supercore.constant import UVICORN_DEFAULT_HOST, UVICORN_DEFAULT_PORT
 from flwr.supercore.exit import ExitCode, flwr_exit
 from flwr.supercore.grpc_health import add_args_health
 from flwr.supercore.object_store import ObjectStoreFactory
@@ -78,6 +82,11 @@ class SuperNodeLifespanConfig:  # pylint: disable=too-many-instance-attributes
     trusted_entities: dict[str, str] | None
     superexec_auth_secret: bytes | None
     runtime_dependency_install: bool
+    enable_http_api: bool
+    host: str
+    port: int
+    runtime_ssl_certfile: str | None
+    runtime_ssl_keyfile: str | None
 
 
 def _parse_supernode_lifespan_config() -> SuperNodeLifespanConfig:
@@ -139,6 +148,11 @@ def _parse_supernode_lifespan_config() -> SuperNodeLifespanConfig:
         trusted_entities=trusted_entities,
         superexec_auth_secret=superexec_auth_secret,
         runtime_dependency_install=args.runtime_dependency_install,
+        enable_http_api=args.enable_http_api,
+        host=args.host,
+        port=args.port,
+        runtime_ssl_certfile=args.runtime_ssl_certfile,
+        runtime_ssl_keyfile=args.runtime_ssl_keyfile,
     )
 
 
@@ -156,25 +170,72 @@ def flower_supernode() -> None:
 
     objectstore_factory = ObjectStoreFactory()
     state_factory = NodeStateFactory(objectstore_factory=objectstore_factory)
-    start_client_internal(
-        state_factory=state_factory,
-        server_address=config.server_address,
-        transport=config.transport,
-        root_certificates=config.root_certificates,
-        insecure=config.insecure,
-        authentication_keys=config.authentication_keys,
-        max_retries=config.max_retries,
-        max_wait_time=config.max_wait_time,
-        node_config=config.node_config,
-        isolation=config.isolation,
-        runtime_api_address=config.runtime_api_address,
-        runtime_certificates=config.runtime_certificates,
-        runtime_root_certificates_path=config.runtime_root_certificates_path,
-        health_server_address=config.health_server_address,
-        trusted_entities=config.trusted_entities,
-        superexec_auth_secret=config.superexec_auth_secret,
-        runtime_dependency_install=config.runtime_dependency_install,
+    http_server = None
+    http_thread = None
+    if config.enable_http_api:
+        http_server, http_thread = _start_supernode_http_api(config, state_factory)
+
+    try:
+        start_client_internal(
+            state_factory=state_factory,
+            server_address=config.server_address,
+            transport=config.transport,
+            root_certificates=config.root_certificates,
+            insecure=config.insecure,
+            authentication_keys=config.authentication_keys,
+            max_retries=config.max_retries,
+            max_wait_time=config.max_wait_time,
+            node_config=config.node_config,
+            isolation=config.isolation,
+            runtime_api_address=config.runtime_api_address,
+            runtime_certificates=config.runtime_certificates,
+            runtime_root_certificates_path=config.runtime_root_certificates_path,
+            health_server_address=config.health_server_address,
+            trusted_entities=config.trusted_entities,
+            superexec_auth_secret=config.superexec_auth_secret,
+            runtime_dependency_install=config.runtime_dependency_install,
+        )
+    finally:
+        if http_server is not None and http_thread is not None:
+            http_server.should_exit = True
+            http_thread.join()
+
+
+def _start_supernode_http_api(
+    config: SuperNodeLifespanConfig,
+    state_factory: NodeStateFactory,
+) -> tuple[uvicorn.Server, threading.Thread]:
+    """Start the experimental Runtime HTTP API in a background thread."""
+    from flwr.supernode.main import (  # pylint: disable=import-outside-toplevel
+        create_app,
     )
+
+    fastapi_app = create_app(
+        state_factory=state_factory,
+        superexec_auth_secret=config.superexec_auth_secret,
+    )
+    server = uvicorn.Server(
+        uvicorn.Config(
+            app=fastapi_app,
+            host=config.host,
+            port=config.port,
+            reload=False,
+            access_log=True,
+            ssl_certfile=config.runtime_ssl_certfile,
+            ssl_keyfile=config.runtime_ssl_keyfile,
+            workers=1,
+        )
+    )
+    thread = threading.Thread(
+        target=server.run,
+        name="supernode-http-api",
+    )
+    thread.start()
+    while thread.is_alive() and not server.started:
+        sleep(0.1)
+    if not server.started:
+        raise RuntimeError("SuperNode Runtime HTTP API failed to start.")
+    return server, thread
 
 
 def _parse_args_run_supernode() -> argparse.ArgumentParser:
@@ -248,8 +309,38 @@ def _parse_args_run_supernode() -> argparse.ArgumentParser:
     add_superexec_auth_secret_args(parser)
     add_args_runtime_dependency_install(parser)
     add_args_health(parser)
+    _add_args_http_api(parser)
 
     return parser
+
+
+def _add_args_http_api(parser: argparse.ArgumentParser) -> None:
+    """Add temporary Runtime HTTP API arguments."""
+    parser.add_argument(
+        "--enable-http-api",
+        action="store_true",
+        default=False,
+        help="EXPERIMENTAL: Start the Runtime HTTP API alongside gRPC.",
+    )
+    parser.add_argument(
+        "--host",
+        default=UVICORN_DEFAULT_HOST,
+        help=f"Host for the Runtime HTTP API (default: {UVICORN_DEFAULT_HOST}).",
+    )
+    parser.add_argument(
+        "--port",
+        type=_port_int,
+        default=UVICORN_DEFAULT_PORT,
+        help=f"Port for the Runtime HTTP API (default: {UVICORN_DEFAULT_PORT}).",
+    )
+
+
+def _port_int(value: str) -> int:
+    """Parse a valid TCP port."""
+    parsed = int(value)
+    if parsed < 0 or parsed > 65535:
+        raise argparse.ArgumentTypeError("value must be between 0 and 65535")
+    return parsed
 
 
 def _parse_args_common(parser: argparse.ArgumentParser) -> None:

--- a/framework/py/flwr/supernode/cli/flower_supernode_test.py
+++ b/framework/py/flwr/supernode/cli/flower_supernode_test.py
@@ -165,3 +165,38 @@ def test_flower_supernode_checks_for_update(
         flower_supernode_module.flower_supernode()
 
     assert captured == ["update", "flower-supernode"]
+
+
+def test_flower_supernode_injects_state_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SuperNode should pass its state factory into the internal startup path."""
+    config = Mock()
+    objectstore_factory = Mock()
+    state_factory = Mock()
+    start_client_internal = Mock()
+
+    monkeypatch.setattr(
+        flower_supernode_module, "warn_if_flwr_update_available", Mock()
+    )
+    monkeypatch.setattr(flower_supernode_module, "event", Mock())
+    monkeypatch.setattr(
+        flower_supernode_module,
+        "_parse_supernode_lifespan_config",
+        Mock(return_value=config),
+    )
+    monkeypatch.setattr(
+        flower_supernode_module,
+        "ObjectStoreFactory",
+        Mock(return_value=objectstore_factory),
+    )
+    node_state_factory = Mock(return_value=state_factory)
+    monkeypatch.setattr(flower_supernode_module, "NodeStateFactory", node_state_factory)
+    monkeypatch.setattr(
+        flower_supernode_module, "start_client_internal", start_client_internal
+    )
+
+    flower_supernode_module.flower_supernode()
+
+    node_state_factory.assert_called_once_with(objectstore_factory=objectstore_factory)
+    assert start_client_internal.call_args.kwargs["state_factory"] is state_factory

--- a/framework/py/flwr/supernode/cli/flower_supernode_test.py
+++ b/framework/py/flwr/supernode/cli/flower_supernode_test.py
@@ -17,6 +17,7 @@
 
 import importlib
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -143,6 +144,37 @@ def test_parse_supernode_lifespan_config_preserves_appio_tls_args(
     assert config.runtime_root_certificates_path == "appio-ca.pem"
     assert config.runtime_ssl_certfile == "appio-cert.pem"
     assert config.runtime_ssl_keyfile == "appio-key.pem"
+
+
+def test_parse_supernode_lifespan_config_expands_appio_tls_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """SuperNode should pass expanded AppIO TLS paths to Uvicorn."""
+    cert_dir = tmp_path / "certs"
+    cert_dir.mkdir()
+    for filename in ("ca.pem", "cert.pem", "key.pem"):
+        (cert_dir / filename).write_bytes(filename.encode())
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "flower-supernode",
+            "--insecure",
+            "--appio-ssl-certfile",
+            "~/certs/cert.pem",
+            "--appio-ssl-keyfile",
+            "~/certs/key.pem",
+            "--appio-ssl-ca-certfile",
+            "~/certs/ca.pem",
+        ],
+    )
+
+    config = _parse_supernode_lifespan_config()
+
+    assert config.runtime_root_certificates_path == str(cert_dir / "ca.pem")
+    assert config.runtime_ssl_certfile == str(cert_dir / "cert.pem")
+    assert config.runtime_ssl_keyfile == str(cert_dir / "key.pem")
 
 
 def test_flower_supernode_checks_for_update(

--- a/framework/py/flwr/supernode/cli/flower_supernode_test.py
+++ b/framework/py/flwr/supernode/cli/flower_supernode_test.py
@@ -28,6 +28,7 @@ from flwr.common.constant import (
     SUPERNODE_RUNTIME_API_DEFAULT_SERVER_ADDRESS,
     TRANSPORT_TYPE_GRPC_RERE,
 )
+from flwr.supercore.constant import UVICORN_DEFAULT_HOST, UVICORN_DEFAULT_PORT
 from flwr.supercore.version import package_version
 
 from .flower_supernode import (
@@ -93,6 +94,22 @@ def test_parse_supernode_lifespan_config_returns_final_defaults(
     assert config.trusted_entities is None
     assert config.superexec_auth_secret is None
     assert config.runtime_dependency_install is False
+    assert config.enable_http_api is False
+    assert config.host == UVICORN_DEFAULT_HOST
+    assert config.port == UVICORN_DEFAULT_PORT
+    assert config.runtime_ssl_certfile is None
+    assert config.runtime_ssl_keyfile is None
+
+
+def test_parse_supernode_http_api_args() -> None:
+    """SuperNode should parse its temporary Runtime HTTP API arguments."""
+    args = _parse_args_run_supernode().parse_args(
+        ["--enable-http-api", "--host", "0.0.0.0", "--port", "8080"]
+    )
+
+    assert args.enable_http_api is True
+    assert args.host == "0.0.0.0"
+    assert args.port == 8080
 
 
 def test_parse_supernode_lifespan_config_preserves_appio_tls_args(
@@ -124,6 +141,8 @@ def test_parse_supernode_lifespan_config_preserves_appio_tls_args(
 
     assert config.runtime_certificates == runtime_certificates
     assert config.runtime_root_certificates_path == "appio-ca.pem"
+    assert config.runtime_ssl_certfile == "appio-cert.pem"
+    assert config.runtime_ssl_keyfile == "appio-key.pem"
 
 
 def test_flower_supernode_checks_for_update(
@@ -167,14 +186,18 @@ def test_flower_supernode_checks_for_update(
     assert captured == ["update", "flower-supernode"]
 
 
-def test_flower_supernode_injects_state_factory(
+def test_flower_supernode_injects_state_factory_and_manages_http_api(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """SuperNode should pass its state factory into the internal startup path."""
+    """SuperNode should share state and stop its background HTTP API."""
     config = Mock()
+    config.enable_http_api = True
     objectstore_factory = Mock()
     state_factory = Mock()
     start_client_internal = Mock()
+    http_server = Mock()
+    http_thread = Mock()
+    start_http_api = Mock(return_value=(http_server, http_thread))
 
     monkeypatch.setattr(
         flower_supernode_module, "warn_if_flwr_update_available", Mock()
@@ -195,8 +218,14 @@ def test_flower_supernode_injects_state_factory(
     monkeypatch.setattr(
         flower_supernode_module, "start_client_internal", start_client_internal
     )
+    monkeypatch.setattr(
+        flower_supernode_module, "_start_supernode_http_api", start_http_api
+    )
 
     flower_supernode_module.flower_supernode()
 
     node_state_factory.assert_called_once_with(objectstore_factory=objectstore_factory)
     assert start_client_internal.call_args.kwargs["state_factory"] is state_factory
+    start_http_api.assert_called_once_with(config, state_factory)
+    assert http_server.should_exit is True
+    http_thread.join.assert_called_once_with()

--- a/framework/py/flwr/supernode/main.py
+++ b/framework/py/flwr/supernode/main.py
@@ -26,11 +26,16 @@ from fastapi import FastAPI
 from flwr import __version__
 from flwr.common import log
 from flwr.supercore.error import http_error_translator
+from flwr.supercore.protobuf.translation import ProtobufTranslationMiddleware
 from flwr.supercore.routers import health
+from flwr.supernode.nodestate import NodeStateFactory
 from flwr.supernode.routers import runtime
 
 
-def create_app() -> FastAPI:
+def create_app(
+    state_factory: NodeStateFactory | None = None,
+    superexec_auth_secret: bytes | None = None,
+) -> FastAPI:
     """Create the SuperNode FastAPI app."""
 
     @asynccontextmanager
@@ -46,12 +51,16 @@ def create_app() -> FastAPI:
         redoc_url=None,
         lifespan=lifespan,
     )
+    fastapi_app.state.nodestate_factory = state_factory
+    fastapi_app.state.superexec_auth_secret = superexec_auth_secret
 
     # Core APIs
     fastapi_app.include_router(health.router)
 
     # SuperNode APIs
     fastapi_app.include_router(runtime.router)
+
+    fastapi_app.add_middleware(ProtobufTranslationMiddleware)
 
     # Apply the FlowerError translation layer last to make it outermost
     fastapi_app.middleware("http")(http_error_translator)

--- a/framework/py/flwr/supernode/main_test.py
+++ b/framework/py/flwr/supernode/main_test.py
@@ -15,7 +15,12 @@
 """Tests for SuperNode FastAPI application construction."""
 
 
+from unittest.mock import Mock
+
 from fastapi.routing import iter_route_contexts
+
+from flwr.supercore.protobuf.translation import ProtobufTranslationMiddleware
+from flwr.supernode.nodestate import NodeStateFactory
 
 from .main import create_app
 
@@ -31,3 +36,18 @@ def test_create_app_mounts_health_without_readiness() -> None:
 
     assert "/health" in paths
     assert "/ready" not in paths
+
+
+def test_create_app_configures_runtime_dependencies() -> None:
+    """Expose the shared state and protobuf translation to Runtime routes."""
+    state_factory = Mock(spec=NodeStateFactory)
+    secret = b"secret"
+
+    app = create_app(state_factory, secret)
+
+    assert app.state.nodestate_factory is state_factory
+    assert app.state.superexec_auth_secret is secret
+    assert any(
+        middleware.cls is ProtobufTranslationMiddleware
+        for middleware in app.user_middleware
+    )

--- a/framework/py/flwr/supernode/start_client_internal.py
+++ b/framework/py/flwr/supernode/start_client_internal.py
@@ -64,7 +64,7 @@ from flwr.supercore.inflatable.inflatable_utils import (
     pull_objects,
     push_object_contents_from_iterable,
 )
-from flwr.supercore.object_store import ObjectStore, ObjectStoreFactory
+from flwr.supercore.object_store import ObjectStore
 from flwr.supercore.primitives.asymmetric_ed25519 import (
     create_message_to_sign,
     decode_base64url,
@@ -88,6 +88,7 @@ FAB_VERIFICATION_ERROR = Error(ErrorCode.INVALID_FAB, "The FAB could not be veri
 # pylint: disable=too-many-arguments
 def start_client_internal(
     *,
+    state_factory: NodeStateFactory,
     server_address: str,
     node_config: UserConfig,
     root_certificates: bytes | str | None = None,
@@ -111,6 +112,8 @@ def start_client_internal(
 
     Parameters
     ----------
+    state_factory : NodeStateFactory
+        Factory providing the state shared by the Fleet worker and Runtime API.
     server_address : str
         The IPv4 or IPv6 address of the server. If the Flower
         server runs on the same machine on port 8080, then `server_address`
@@ -185,9 +188,7 @@ def start_client_internal(
             f"to the Flower documentation for more information: {url_v}{page}",
         )
 
-    # Initialize factories
-    object_store_factory = ObjectStoreFactory()
-    state_factory = NodeStateFactory(objectstore_factory=object_store_factory)
+    object_store_factory = state_factory.objectstore_factory
 
     if isolation == ISOLATION_MODE_SUBPROCESS:
         if superexec_auth_secret is not None:

--- a/framework/py/flwr/supernode/start_client_internal_test.py
+++ b/framework/py/flwr/supernode/start_client_internal_test.py
@@ -29,6 +29,8 @@ from flwr.supercore.inflatable.inflatable_object import (
     get_all_nested_objects,
     get_object_tree,
 )
+from flwr.supercore.object_store import ObjectStoreFactory
+from flwr.supernode.nodestate import NodeStateFactory
 
 from .start_client_internal import (
     FAB_VERIFICATION_ERROR,
@@ -418,6 +420,7 @@ def _run_until_connection_start(
     bound_address: str = "127.0.0.1:9094",
 ) -> tuple[Mock, Mock]:
     """Run startup only far enough to inspect Runtime API and SuperExec wiring."""
+    state_factory = NodeStateFactory(objectstore_factory=ObjectStoreFactory())
     with (
         patch(
             "flwr.supernode.start_client_internal.run_runtime_api_grpc"
@@ -434,6 +437,7 @@ def _run_until_connection_start(
         # Raising there keeps this test focused on the setup performed before it.
         with pytest.raises(_StopAfterSuperExecLaunch):
             start_client_internal(
+                state_factory=state_factory,
                 server_address="127.0.0.1:9092",
                 node_config={},
                 root_certificates=None,
@@ -444,6 +448,11 @@ def _run_until_connection_start(
                 runtime_root_certificates_path=runtime_root_certificates_path,
             )
 
+    assert run_runtime.call_args.kwargs["state_factory"] is state_factory
+    assert (
+        run_runtime.call_args.kwargs["objectstore_factory"]
+        is state_factory.objectstore_factory
+    )
     return run_runtime, popen
 
 

--- a/framework/py/flwr/supernode/start_client_internal_test.py
+++ b/framework/py/flwr/supernode/start_client_internal_test.py
@@ -29,6 +29,7 @@ from flwr.supercore.inflatable.inflatable_object import (
     get_all_nested_objects,
     get_object_tree,
 )
+
 from .start_client_internal import (
     FAB_VERIFICATION_ERROR,
     _pull_and_store_message,
@@ -447,10 +448,7 @@ def _run_until_connection_start(
             )
 
     assert run_runtime.call_args.kwargs["state_factory"] is state_factory
-    assert (
-        run_runtime.call_args.kwargs["objectstore_factory"]
-        is objectstore_factory
-    )
+    assert run_runtime.call_args.kwargs["objectstore_factory"] is objectstore_factory
     return run_runtime, popen
 
 

--- a/framework/py/flwr/supernode/start_client_internal_test.py
+++ b/framework/py/flwr/supernode/start_client_internal_test.py
@@ -29,9 +29,6 @@ from flwr.supercore.inflatable.inflatable_object import (
     get_all_nested_objects,
     get_object_tree,
 )
-from flwr.supercore.object_store import ObjectStoreFactory
-from flwr.supernode.nodestate import NodeStateFactory
-
 from .start_client_internal import (
     FAB_VERIFICATION_ERROR,
     _pull_and_store_message,
@@ -420,7 +417,8 @@ def _run_until_connection_start(
     bound_address: str = "127.0.0.1:9094",
 ) -> tuple[Mock, Mock]:
     """Run startup only far enough to inspect Runtime API and SuperExec wiring."""
-    state_factory = NodeStateFactory(objectstore_factory=ObjectStoreFactory())
+    objectstore_factory = Mock()
+    state_factory = Mock(objectstore_factory=objectstore_factory)
     with (
         patch(
             "flwr.supernode.start_client_internal.run_runtime_api_grpc"
@@ -451,7 +449,7 @@ def _run_until_connection_start(
     assert run_runtime.call_args.kwargs["state_factory"] is state_factory
     assert (
         run_runtime.call_args.kwargs["objectstore_factory"]
-        is state_factory.objectstore_factory
+        is objectstore_factory
     )
     return run_runtime, popen
 


### PR DESCRIPTION
- Runs Runtime HTTP in a background thread while Fleet processing remains on the main thread.
- Keeps the existing Runtime gRPC API and SuperExec behavior unchanged.
- Shares the same NodeStateFactory between HTTP, gRPC, and Fleet.
- Reuses existing Runtime TLS and authentication configuration.
- Gracefully stops the HTTP server when SuperNode exits.