### PR TITLE
feat(framework): Add HTTP task heartbeat support

### DIFF
--- a/framework/py/flwr/supercore/heartbeat.py
+++ b/framework/py/flwr/supercore/heartbeat.py
@@ -19,6 +19,7 @@ import random
 import signal
 import threading
 from collections.abc import Callable
+from http import HTTPStatus
 
 import grpc
 import httpx
@@ -170,7 +171,10 @@ def make_task_heartbeat_fn_http(
         except httpx.TransportError:
             return False
         except httpx.HTTPStatusError as err:
-            if err.response.status_code in (503, 504):
+            if err.response.status_code in (
+                HTTPStatus.SERVICE_UNAVAILABLE,  # 503
+                HTTPStatus.GATEWAY_TIMEOUT,  # 504
+            ):
                 return False
             raise
 

--- a/framework/py/flwr/supercore/heartbeat.py
+++ b/framework/py/flwr/supercore/heartbeat.py
@@ -21,6 +21,7 @@ import threading
 from collections.abc import Callable
 
 import grpc
+import httpx
 
 from flwr.common.constant import (
     HEARTBEAT_BASE_MULTIPLIER,
@@ -33,6 +34,7 @@ from flwr.common.constant import (
 from flwr.proto.runtime_pb2 import SendTaskHeartbeatRequest
 from flwr.proto.runtime_pb2_grpc import RuntimeStub
 from flwr.supercore.retry import RetryInvoker, exponential
+from flwr.supercore.runtime import RuntimeHttpStub
 
 # pylint: enable=E0611
 
@@ -150,6 +152,25 @@ def make_task_heartbeat_fn_grpc(
         # Raise SIGINT to trigger graceful shutdown if heartbeat failed
         if not res.success:
             # Never reach here due to token authentication unless race conditions occur
+            signal.raise_signal(signal.SIGINT)
+        return True
+
+    return fn
+
+
+def make_task_heartbeat_fn_http(
+    stub: RuntimeHttpStub,
+) -> Callable[[], bool]:
+    """Get the function to send a heartbeat to an HTTP Runtime endpoint."""
+    req = SendTaskHeartbeatRequest()
+
+    def fn() -> bool:
+        try:
+            res = stub.SendTaskHeartbeat(req)
+        except httpx.TransportError:
+            return False
+
+        if not res.success:
             signal.raise_signal(signal.SIGINT)
         return True
 

--- a/framework/py/flwr/supercore/heartbeat.py
+++ b/framework/py/flwr/supercore/heartbeat.py
@@ -169,6 +169,10 @@ def make_task_heartbeat_fn_http(
             res = stub.SendTaskHeartbeat(req)
         except httpx.TransportError:
             return False
+        except httpx.HTTPStatusError as err:
+            if err.response.status_code in (503, 504):
+                return False
+            raise
 
         if not res.success:
             signal.raise_signal(signal.SIGINT)

--- a/framework/py/flwr/supercore/heartbeat.py
+++ b/framework/py/flwr/supercore/heartbeat.py
@@ -172,8 +172,8 @@ def make_task_heartbeat_fn_http(
             return False
         except httpx.HTTPStatusError as err:
             if err.response.status_code in (
-                HTTPStatus.SERVICE_UNAVAILABLE,  # 503
-                HTTPStatus.GATEWAY_TIMEOUT,  # 504
+                httpx.codes.SERVICE_UNAVAILABLE,  # 503
+                httpx.codes.GATEWAY_TIMEOUT,  # 504
             ):
                 return False
             raise

--- a/framework/py/flwr/supercore/heartbeat.py
+++ b/framework/py/flwr/supercore/heartbeat.py
@@ -19,7 +19,6 @@ import random
 import signal
 import threading
 from collections.abc import Callable
-from http import HTTPStatus
 
 import grpc
 import httpx

--- a/framework/py/flwr/supercore/heartbeat.py
+++ b/framework/py/flwr/supercore/heartbeat.py
@@ -160,14 +160,14 @@ def make_task_heartbeat_fn_grpc(
 
 
 def make_task_heartbeat_fn_http(
-    stub: RuntimeHttpStub,
+    client: RuntimeHttpStub,
 ) -> Callable[[], bool]:
     """Get the function to send a heartbeat to an HTTP Runtime endpoint."""
     req = SendTaskHeartbeatRequest()
 
     def fn() -> bool:
         try:
-            res = stub.SendTaskHeartbeat(req)
+            res = client.SendTaskHeartbeat(req)
         except httpx.TransportError:
             return False
         except httpx.HTTPStatusError as err:

--- a/framework/py/flwr/supercore/heartbeat_test.py
+++ b/framework/py/flwr/supercore/heartbeat_test.py
@@ -118,7 +118,10 @@ def test_http_heartbeat_returns_true_on_success() -> None:
 def test_http_heartbeat_returns_false_on_transport_error() -> None:
     """HTTP heartbeat should report transport errors as retryable failures."""
     stub = Mock()
-    stub.SendTaskHeartbeat.side_effect = httpx.ConnectError("connection failed")
+    stub.SendTaskHeartbeat.side_effect = httpx.ConnectError(
+        "connection failed",
+        request=httpx.Request("POST", "http://runtime.example"),
+    )
 
     assert make_task_heartbeat_fn_http(stub)() is False
 

--- a/framework/py/flwr/supercore/heartbeat_test.py
+++ b/framework/py/flwr/supercore/heartbeat_test.py
@@ -21,10 +21,20 @@ import unittest
 from unittest.mock import Mock, patch
 
 import httpx
+import pytest
 
 from flwr.proto.runtime_pb2 import SendTaskHeartbeatResponse  # pylint: disable=E0611
 
 from .heartbeat import HeartbeatSender, make_task_heartbeat_fn_http
+
+
+def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    """Create an HTTP status error for a Runtime request."""
+    request = httpx.Request("POST", "http://runtime.example")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(
+        "Runtime request failed", request=request, response=response
+    )
 
 
 # pylint: disable=protected-access
@@ -111,6 +121,27 @@ def test_http_heartbeat_returns_false_on_transport_error() -> None:
     stub.SendTaskHeartbeat.side_effect = httpx.ConnectError("connection failed")
 
     assert make_task_heartbeat_fn_http(stub)() is False
+
+
+@pytest.mark.parametrize("status_code", [503, 504])
+def test_http_heartbeat_returns_false_on_transient_status(status_code: int) -> None:
+    """HTTP heartbeat should report transient statuses as retryable failures."""
+    stub = Mock()
+    stub.SendTaskHeartbeat.side_effect = _http_status_error(status_code)
+
+    assert make_task_heartbeat_fn_http(stub)() is False
+
+
+def test_http_heartbeat_raises_non_transient_status_error() -> None:
+    """HTTP heartbeat should preserve non-transient status errors."""
+    stub = Mock()
+    error = _http_status_error(500)
+    stub.SendTaskHeartbeat.side_effect = error
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        make_task_heartbeat_fn_http(stub)()
+
+    assert exc_info.value is error
 
 
 def test_http_heartbeat_raises_sigint_when_rejected() -> None:

--- a/framework/py/flwr/supercore/heartbeat_test.py
+++ b/framework/py/flwr/supercore/heartbeat_test.py
@@ -19,7 +19,11 @@ import time
 import unittest
 from unittest.mock import Mock
 
-from .heartbeat import HeartbeatSender
+import httpx
+
+from flwr.proto.runtime_pb2 import SendTaskHeartbeatResponse  # pylint: disable=E0611
+
+from .heartbeat import HeartbeatSender, make_task_heartbeat_fn_http
 
 
 # pylint: disable=protected-access
@@ -90,3 +94,19 @@ class TestHeartbeatSender(unittest.TestCase):
     def test_thread_is_daemon(self) -> None:
         """Test that the thread is a daemon thread."""
         self.assertTrue(self.heartbeat_sender._thread.daemon)
+
+
+def test_http_heartbeat_returns_true_on_success() -> None:
+    """HTTP heartbeat should report a successful Runtime response."""
+    stub = Mock()
+    stub.SendTaskHeartbeat.return_value = SendTaskHeartbeatResponse(success=True)
+
+    assert make_task_heartbeat_fn_http(stub)() is True
+
+
+def test_http_heartbeat_retries_transport_errors() -> None:
+    """HTTP heartbeat should make transport failures retryable."""
+    stub = Mock()
+    stub.SendTaskHeartbeat.side_effect = httpx.ConnectError("connection failed")
+
+    assert make_task_heartbeat_fn_http(stub)() is False

--- a/framework/py/flwr/supercore/heartbeat_test.py
+++ b/framework/py/flwr/supercore/heartbeat_test.py
@@ -15,9 +15,10 @@
 """Tests for heartbeat sender."""
 
 
+import signal
 import time
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import httpx
 
@@ -104,9 +105,21 @@ def test_http_heartbeat_returns_true_on_success() -> None:
     assert make_task_heartbeat_fn_http(stub)() is True
 
 
-def test_http_heartbeat_retries_transport_errors() -> None:
-    """HTTP heartbeat should make transport failures retryable."""
+def test_http_heartbeat_returns_false_on_transport_error() -> None:
+    """HTTP heartbeat should report transport errors as retryable failures."""
     stub = Mock()
     stub.SendTaskHeartbeat.side_effect = httpx.ConnectError("connection failed")
 
     assert make_task_heartbeat_fn_http(stub)() is False
+
+
+def test_http_heartbeat_raises_sigint_when_rejected() -> None:
+    """HTTP heartbeat should trigger graceful shutdown when rejected."""
+    stub = Mock()
+    stub.SendTaskHeartbeat.return_value = SendTaskHeartbeatResponse(success=False)
+
+    with patch("flwr.supercore.heartbeat.signal.raise_signal") as raise_signal:
+        result = make_task_heartbeat_fn_http(stub)()
+
+    raise_signal.assert_called_once_with(signal.SIGINT)
+    assert result is True

--- a/framework/py/flwr/supercore/heartbeat_test.py
+++ b/framework/py/flwr/supercore/heartbeat_test.py
@@ -109,51 +109,51 @@ class TestHeartbeatSender(unittest.TestCase):
 
 def test_http_heartbeat_returns_true_on_success() -> None:
     """HTTP heartbeat should report a successful Runtime response."""
-    stub = Mock()
-    stub.SendTaskHeartbeat.return_value = SendTaskHeartbeatResponse(success=True)
+    client = Mock()
+    client.SendTaskHeartbeat.return_value = SendTaskHeartbeatResponse(success=True)
 
-    assert make_task_heartbeat_fn_http(stub)() is True
+    assert make_task_heartbeat_fn_http(client)() is True
 
 
 def test_http_heartbeat_returns_false_on_transport_error() -> None:
     """HTTP heartbeat should report transport errors as retryable failures."""
-    stub = Mock()
-    stub.SendTaskHeartbeat.side_effect = httpx.ConnectError(
+    client = Mock()
+    client.SendTaskHeartbeat.side_effect = httpx.ConnectError(
         "connection failed",
         request=httpx.Request("POST", "http://runtime.example"),
     )
 
-    assert make_task_heartbeat_fn_http(stub)() is False
+    assert make_task_heartbeat_fn_http(client)() is False
 
 
 @pytest.mark.parametrize("status_code", [503, 504])
 def test_http_heartbeat_returns_false_on_transient_status(status_code: int) -> None:
     """HTTP heartbeat should report transient statuses as retryable failures."""
-    stub = Mock()
-    stub.SendTaskHeartbeat.side_effect = _http_status_error(status_code)
+    client = Mock()
+    client.SendTaskHeartbeat.side_effect = _http_status_error(status_code)
 
-    assert make_task_heartbeat_fn_http(stub)() is False
+    assert make_task_heartbeat_fn_http(client)() is False
 
 
 def test_http_heartbeat_raises_non_transient_status_error() -> None:
     """HTTP heartbeat should preserve non-transient status errors."""
-    stub = Mock()
+    client = Mock()
     error = _http_status_error(500)
-    stub.SendTaskHeartbeat.side_effect = error
+    client.SendTaskHeartbeat.side_effect = error
 
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        make_task_heartbeat_fn_http(stub)()
+        make_task_heartbeat_fn_http(client)()
 
     assert exc_info.value is error
 
 
 def test_http_heartbeat_raises_sigint_when_rejected() -> None:
     """HTTP heartbeat should trigger graceful shutdown when rejected."""
-    stub = Mock()
-    stub.SendTaskHeartbeat.return_value = SendTaskHeartbeatResponse(success=False)
+    client = Mock()
+    client.SendTaskHeartbeat.return_value = SendTaskHeartbeatResponse(success=False)
 
     with patch("flwr.supercore.heartbeat.signal.raise_signal") as raise_signal:
-        result = make_task_heartbeat_fn_http(stub)()
+        result = make_task_heartbeat_fn_http(client)()
 
     raise_signal.assert_called_once_with(signal.SIGINT)
     assert result is True


### PR DESCRIPTION
Adds `make_task_heartbeat_fn_http`, providing the HTTP equivalent of the existing gRPC task heartbeat helper.