### PR TITLE
feat(framework): Add HTTP retry invoker

### DIFF
--- a/framework/py/flwr/supercore/protobuf/client.py
+++ b/framework/py/flwr/supercore/protobuf/client.py
@@ -165,12 +165,6 @@ class ProtobufClient:
             raise ValueError("Invalid protobuf response payload") from exc
         return result
 
-    def _send_and_raise(self, context: ProtobufRequestContext) -> httpx.Response:
-        """Send a request and raise for an HTTP error response."""
-        response = self._send(context)
-        response.raise_for_status()
-        return response
-
     def _send(self, context: ProtobufRequestContext) -> httpx.Response:
         """Send a request through the configured interceptor chain."""
 

--- a/framework/py/flwr/supercore/protobuf/client.py
+++ b/framework/py/flwr/supercore/protobuf/client.py
@@ -130,24 +130,29 @@ class ProtobufClient:
     ) -> ResponseT:
         """Send a unary request and parse its unary protobuf response."""
         path = path if path.startswith("/") else f"/{path}"
-        http_request = self._client.build_request(
-            method="POST",
-            url=f"{self._base_url}{path}",
-            content=request.SerializeToString(deterministic=True),
-            headers={
-                "content-type": PROTOBUF_MEDIA_TYPE,
-                "accept": PROTOBUF_MEDIA_TYPE,
-            },
-        )
-        context = ProtobufRequestContext(
-            rpc_method=rpc_method,
-            message=request,
-            request=http_request,
-        )
+        content = request.SerializeToString(deterministic=True)
+
+        def send() -> httpx.Response:
+            http_request = self._client.build_request(
+                method="POST",
+                url=f"{self._base_url}{path}",
+                content=content,
+                headers={
+                    "content-type": PROTOBUF_MEDIA_TYPE,
+                    "accept": PROTOBUF_MEDIA_TYPE,
+                },
+            )
+            context = ProtobufRequestContext(
+                rpc_method=rpc_method,
+                message=request,
+                request=http_request,
+            )
+            return self._send_and_raise(context)
+
         response = (
-            self._retry_invoker.invoke(self._send_and_raise, context)
+            self._retry_invoker.invoke(send)
             if self._retry_invoker is not None
-            else self._send_and_raise(context)
+            else send()
         )
 
         result = response_type()

--- a/framework/py/flwr/supercore/protobuf/client.py
+++ b/framework/py/flwr/supercore/protobuf/client.py
@@ -70,7 +70,7 @@ def _wrap_interceptor(
 class ProtobufClient:
     """Client providing shared protobuf-over-HTTP request handling."""
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         base_url: str,
         *,
@@ -89,12 +89,13 @@ class ProtobufClient:
         )
 
     @classmethod
-    def from_server_address(
+    def from_server_address(  # pylint: disable=too-many-arguments
         cls,
         server_address: str,
         insecure: bool,
         root_certificates: bytes | str | None,
         interceptors: Sequence[ProtobufClientInterceptor],
+        *,
         retry_invoker: RetryInvoker | None = None,
     ) -> Self:
         """Create a protobuf-over-HTTP client from a server address."""

--- a/framework/py/flwr/supercore/protobuf/client.py
+++ b/framework/py/flwr/supercore/protobuf/client.py
@@ -19,12 +19,15 @@ from __future__ import annotations
 import ssl
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Protocol, Self, TypeVar
+from typing import TYPE_CHECKING, Protocol, Self, TypeVar
 
 import httpx
 from google.protobuf.message import DecodeError, Message
 
 from .constants import PROTOBUF_MEDIA_TYPE
+
+if TYPE_CHECKING:
+    from flwr.supercore.retry import RetryInvoker
 
 ResponseT = TypeVar("ResponseT", bound=Message)
 
@@ -74,9 +77,11 @@ class ProtobufClient:
         interceptors: Sequence[ProtobufClientInterceptor] = (),
         verify: ssl.SSLContext | bool | str = True,
         timeout: float = 30.0,
+        retry_invoker: RetryInvoker | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._interceptors = tuple(interceptors)
+        self._retry_invoker = retry_invoker
         self._client = httpx.Client(
             verify=verify,
             timeout=timeout,
@@ -90,6 +95,7 @@ class ProtobufClient:
         insecure: bool,
         root_certificates: bytes | str | None,
         interceptors: Sequence[ProtobufClientInterceptor],
+        retry_invoker: RetryInvoker | None = None,
     ) -> Self:
         """Create a protobuf-over-HTTP client from a server address."""
         if insecure and root_certificates is not None:
@@ -111,6 +117,7 @@ class ProtobufClient:
             f"{scheme}://{server_address}",
             interceptors=interceptors,
             verify=verify,
+            retry_invoker=retry_invoker,
         )
 
     def _unary_unary(
@@ -137,9 +144,11 @@ class ProtobufClient:
             message=request,
             request=http_request,
         )
-        response = self._send(context)
-        if response.is_error:
-            response.raise_for_status()
+        response = (
+            self._retry_invoker.invoke(self._send_and_raise, context)
+            if self._retry_invoker is not None
+            else self._send_and_raise(context)
+        )
 
         result = response_type()
         try:
@@ -147,6 +156,12 @@ class ProtobufClient:
         except DecodeError as exc:
             raise ValueError("Invalid protobuf response payload") from exc
         return result
+
+    def _send_and_raise(self, context: ProtobufRequestContext) -> httpx.Response:
+        """Send a request and raise for an HTTP error response."""
+        response = self._send(context)
+        response.raise_for_status()
+        return response
 
     def _send(self, context: ProtobufRequestContext) -> httpx.Response:
         """Send a request through the configured interceptor chain."""

--- a/framework/py/flwr/supercore/protobuf/client.py
+++ b/framework/py/flwr/supercore/protobuf/client.py
@@ -148,7 +148,9 @@ class ProtobufClient:
                 message=request,
                 request=http_request,
             )
-            return self._send_and_raise(context)
+            http_response = self._send(context)
+            http_response.raise_for_status()
+            return http_response
 
         response = (
             self._retry_invoker.invoke(send)

--- a/framework/py/flwr/supercore/protobuf/client_test.py
+++ b/framework/py/flwr/supercore/protobuf/client_test.py
@@ -24,6 +24,7 @@ from flwr.proto.runtime_pb2 import (  # pylint: disable=E0611
     ClaimTaskRequest,
     ClaimTaskResponse,
 )
+from flwr.supercore.interceptors import RuntimeTokenHttpInterceptor
 from flwr.supercore.protobuf.constants import PROTOBUF_MEDIA_TYPE
 from flwr.supercore.retry import make_simple_http_retry_invoker
 
@@ -147,6 +148,30 @@ def test_unary_unary_uses_retry_invoker() -> None:
 
     assert result == _RESPONSE
     assert send.call_count == 2
+
+
+def test_retry_rebuilds_request_before_applying_interceptors() -> None:
+    """Apply HTTP interceptors to a fresh request on every retry attempt."""
+    retry_invoker = make_simple_http_retry_invoker()
+    retry_invoker.max_tries = 2
+    retry_invoker.jitter = None
+    retry_invoker.wait_function = lambda _: None
+    client = ProtobufClient(
+        "http://api.example",
+        interceptors=[RuntimeTokenHttpInterceptor("task-token")],
+        retry_invoker=retry_invoker,
+    )
+
+    with patch(
+        "flwr.supercore.protobuf.client.httpx.Client.send",
+        side_effect=[_response(503), _response(200, _RESPONSE.SerializeToString())],
+    ) as send:
+        result = _call(client)
+
+    assert result == _RESPONSE
+    assert send.call_count == 2
+    for call in send.call_args_list:
+        assert call.args[0].headers["flwr-task-token"] == "task-token"
 
 
 def test_unary_unary_rejects_invalid_protobuf_response() -> None:

--- a/framework/py/flwr/supercore/protobuf/client_test.py
+++ b/framework/py/flwr/supercore/protobuf/client_test.py
@@ -25,6 +25,7 @@ from flwr.proto.runtime_pb2 import (  # pylint: disable=E0611
     ClaimTaskResponse,
 )
 from flwr.supercore.protobuf.constants import PROTOBUF_MEDIA_TYPE
+from flwr.supercore.retry import make_simple_http_retry_invoker
 
 from .client import ProtobufCall, ProtobufClient, ProtobufRequestContext
 
@@ -124,6 +125,28 @@ def test_unary_unary_raises_for_http_error() -> None:
         pytest.raises(httpx.HTTPStatusError),
     ):
         _call(ProtobufClient("http://api.example"))
+
+
+def test_unary_unary_uses_retry_invoker() -> None:
+    """Retry a transient HTTP response before parsing the protobuf response."""
+    retry_invoker = make_simple_http_retry_invoker()
+    retry_invoker.max_tries = 2
+    retry_invoker.jitter = None
+    retry_invoker.wait_function = lambda _: None
+
+    with patch(
+        "flwr.supercore.protobuf.client.httpx.Client.send",
+        side_effect=[_response(503), _response(200, _RESPONSE.SerializeToString())],
+    ) as send:
+        result = _call(
+            ProtobufClient(
+                "http://api.example",
+                retry_invoker=retry_invoker,
+            )
+        )
+
+    assert result == _RESPONSE
+    assert send.call_count == 2
 
 
 def test_unary_unary_rejects_invalid_protobuf_response() -> None:

--- a/framework/py/flwr/supercore/retry/__init__.py
+++ b/framework/py/flwr/supercore/retry/__init__.py
@@ -16,6 +16,7 @@
 
 
 from .grpc_retry import make_simple_grpc_retry_invoker, wrap_stub
+from .http_retry import make_simple_http_retry_invoker
 from .retry_invoker import RetryInvoker, RetryState, constant, exponential, full_jitter
 
 __all__ = [
@@ -25,5 +26,6 @@ __all__ = [
     "exponential",
     "full_jitter",
     "make_simple_grpc_retry_invoker",
+    "make_simple_http_retry_invoker",
     "wrap_stub",
 ]

--- a/framework/py/flwr/supercore/retry/http_retry.py
+++ b/framework/py/flwr/supercore/retry/http_retry.py
@@ -35,6 +35,16 @@ _RETRYABLE_STATUS_CODES = frozenset(
         httpx.codes.GATEWAY_TIMEOUT,
     }
 )
+_RETRYABLE_TRANSPORT_ERRORS: tuple[type[httpx.TransportError], ...] = (
+    httpx.ConnectError,
+    httpx.ReadError,
+    httpx.WriteError,
+    httpx.RemoteProtocolError,
+    httpx.ConnectTimeout,
+    httpx.ReadTimeout,
+    httpx.WriteTimeout,
+    httpx.PoolTimeout,
+)
 
 
 def make_simple_http_retry_invoker() -> RetryInvoker:
@@ -109,7 +119,10 @@ def make_simple_http_retry_invoker() -> RetryInvoker:
 
     return RetryInvoker(
         wait_gen_factory=lambda: exponential(max_delay=MAX_RETRY_DELAY),
-        recoverable_exceptions=(httpx.TransportError, httpx.HTTPStatusError),
+        recoverable_exceptions=(
+            *_RETRYABLE_TRANSPORT_ERRORS,
+            httpx.HTTPStatusError,
+        ),
         max_tries=None,
         max_time=None,
         on_success=_on_success,

--- a/framework/py/flwr/supercore/retry/http_retry.py
+++ b/framework/py/flwr/supercore/retry/http_retry.py
@@ -18,7 +18,7 @@ import os
 import signal
 import threading
 import time
-from logging import DEBUG, ERROR, INFO, WARN
+from logging import DEBUG, ERROR, INFO, WARNING
 
 import httpx
 
@@ -65,7 +65,7 @@ def make_simple_http_retry_invoker() -> RetryInvoker:
         system_healthy.clear()
         if retry_state.tries > 1:
             log(
-                WARN,
+                WARNING,
                 "Giving up reconnection after %.2f seconds and %s tries.",
                 retry_state.elapsed_time,
                 retry_state.tries,
@@ -96,7 +96,7 @@ def make_simple_http_retry_invoker() -> RetryInvoker:
     def _wait(wait_time: float) -> None:
         with lock:
             log(
-                WARN,
+                WARNING,
                 "Connection attempt failed, retrying in %.2f seconds",
                 wait_time,
             )

--- a/framework/py/flwr/supercore/retry/http_retry.py
+++ b/framework/py/flwr/supercore/retry/http_retry.py
@@ -1,0 +1,120 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""HTTP retry utilities."""
+
+import os
+import signal
+import threading
+import time
+from logging import DEBUG, ERROR, INFO, WARN
+
+import httpx
+
+from flwr.common.constant import MAX_RETRY_DELAY
+from flwr.common.logger import log
+from flwr.supercore.constant import FORCE_EXIT_TIMEOUT_SECONDS
+from flwr.supercore.run import RunNotRunningException
+
+from .retry_invoker import RetryInvoker, RetryState, exponential
+
+_RETRYABLE_STATUS_CODES = frozenset(
+    {
+        httpx.codes.SERVICE_UNAVAILABLE,
+        httpx.codes.GATEWAY_TIMEOUT,
+    }
+)
+
+
+def make_simple_http_retry_invoker() -> RetryInvoker:
+    """Create a simple HTTP retry invoker."""
+    lock = threading.Lock()
+    shutdown_lock = threading.Lock()
+    shutdown_requested = False
+    system_healthy = threading.Event()
+    system_healthy.set()
+
+    def _on_success(retry_state: RetryState) -> None:
+        system_healthy.set()
+        if retry_state.tries > 1:
+            log(
+                INFO,
+                "Connection successful after %.2f seconds and %s tries.",
+                retry_state.elapsed_time,
+                retry_state.tries,
+            )
+
+    def _on_backoff(retry_state: RetryState) -> None:
+        system_healthy.clear()
+        log(
+            DEBUG, "Connection attempt failed with exception: %s", retry_state.exception
+        )
+
+    def _on_giveup(retry_state: RetryState) -> None:
+        system_healthy.clear()
+        if retry_state.tries > 1:
+            log(
+                WARN,
+                "Giving up reconnection after %.2f seconds and %s tries.",
+                retry_state.elapsed_time,
+                retry_state.tries,
+            )
+
+    def _should_giveup(exc: Exception) -> bool:
+        nonlocal shutdown_requested
+        if isinstance(exc, httpx.HTTPStatusError):
+            status_code = exc.response.status_code
+            if status_code == httpx.codes.FORBIDDEN:
+                raise RunNotRunningException
+            if status_code == httpx.codes.UNAUTHORIZED:
+                with shutdown_lock:
+                    if shutdown_requested:
+                        return True
+                    shutdown_requested = True
+                os.kill(os.getpid(), signal.SIGINT)
+                time.sleep(FORCE_EXIT_TIMEOUT_SECONDS + 1)
+                return False
+            return status_code not in _RETRYABLE_STATUS_CODES
+
+        error_message = str(exc).lower()
+        if any(term in error_message for term in ("certificate", "ssl", "tls")):
+            log(ERROR, "SSL/TLS handshake error detected.")
+            return True
+        return False
+
+    def _wait(wait_time: float) -> None:
+        with lock:
+            log(
+                WARN,
+                "Connection attempt failed, retrying in %.2f seconds",
+                wait_time,
+            )
+            start = time.monotonic()
+            system_healthy.wait(wait_time)
+
+        remaining_time = wait_time - (time.monotonic() - start)
+        if remaining_time > 0:
+            time.sleep(remaining_time)
+
+    return RetryInvoker(
+        wait_gen_factory=lambda: exponential(max_delay=MAX_RETRY_DELAY),
+        recoverable_exceptions=(httpx.TransportError, httpx.HTTPStatusError),
+        max_tries=None,
+        max_time=None,
+        on_success=_on_success,
+        on_backoff=_on_backoff,
+        on_giveup=_on_giveup,
+        should_giveup=_should_giveup,
+        wait_function=_wait,
+    )

--- a/framework/py/flwr/supercore/retry/http_retry_test.py
+++ b/framework/py/flwr/supercore/retry/http_retry_test.py
@@ -1,0 +1,105 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for HTTP retry utilities."""
+
+import os
+import signal
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+
+from flwr.supercore.run import RunNotRunningException
+
+from .http_retry import make_simple_http_retry_invoker
+from .retry_invoker import RetryInvoker
+
+
+def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "http://api.example")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(
+        "HTTP request failed", request=request, response=response
+    )
+
+
+def _make_test_invoker() -> RetryInvoker:
+    invoker = make_simple_http_retry_invoker()
+    invoker.max_tries = 2
+    invoker.jitter = None
+    invoker.wait_function = lambda _: None
+    return invoker
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        httpx.ConnectError(
+            "Connection refused",
+            request=httpx.Request("POST", "http://api.example"),
+        ),
+        _http_status_error(httpx.codes.SERVICE_UNAVAILABLE),
+        _http_status_error(httpx.codes.GATEWAY_TIMEOUT),
+    ],
+)
+def test_retries_transient_http_failures(exception: Exception) -> None:
+    """Retry transport failures and unavailable HTTP responses."""
+    target = Mock(side_effect=[exception, "success"])
+
+    assert _make_test_invoker().invoke(target) == "success"
+    assert target.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        _http_status_error(httpx.codes.INTERNAL_SERVER_ERROR),
+        httpx.ConnectError(
+            "certificate verify failed",
+            request=httpx.Request("POST", "https://api.example"),
+        ),
+    ],
+)
+def test_does_not_retry_permanent_http_failures(exception: Exception) -> None:
+    """Give up immediately for permanent HTTP and TLS failures."""
+    target = Mock(side_effect=exception)
+
+    with pytest.raises(type(exception)):
+        _make_test_invoker().invoke(target)
+    target.assert_called_once_with()
+
+
+def test_forbidden_response_raises_run_not_running() -> None:
+    """Translate a forbidden response into a stopped-run signal."""
+    target = Mock(side_effect=_http_status_error(httpx.codes.FORBIDDEN))
+
+    with pytest.raises(RunNotRunningException):
+        _make_test_invoker().invoke(target)
+    target.assert_called_once_with()
+
+
+def test_unauthorized_response_requests_shutdown() -> None:
+    """Request process shutdown for an authentication failure."""
+    error = _http_status_error(httpx.codes.UNAUTHORIZED)
+    target = Mock(side_effect=[error, "success"])
+    invoker = _make_test_invoker()
+
+    with (
+        patch("flwr.supercore.retry.http_retry.os.kill") as kill,
+        patch("flwr.supercore.retry.http_retry.time.sleep"),
+    ):
+        assert invoker.invoke(target) == "success"
+
+    kill.assert_called_once_with(os.getpid(), signal.SIGINT)

--- a/framework/py/flwr/supercore/retry/http_retry_test.py
+++ b/framework/py/flwr/supercore/retry/http_retry_test.py
@@ -35,6 +35,15 @@ def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
     )
 
 
+def _transport_error(
+    exception_type: type[httpx.TransportError],
+) -> httpx.TransportError:
+    return exception_type(
+        "Transport failed",
+        request=httpx.Request("POST", "http://api.example"),
+    )
+
+
 def _make_test_invoker() -> RetryInvoker:
     invoker = make_simple_http_retry_invoker()
     invoker.max_tries = 2
@@ -46,10 +55,14 @@ def _make_test_invoker() -> RetryInvoker:
 @pytest.mark.parametrize(
     "exception",
     [
-        httpx.ConnectError(
-            "Connection refused",
-            request=httpx.Request("POST", "http://api.example"),
-        ),
+        _transport_error(httpx.ConnectError),
+        _transport_error(httpx.ReadError),
+        _transport_error(httpx.WriteError),
+        _transport_error(httpx.RemoteProtocolError),
+        _transport_error(httpx.ConnectTimeout),
+        _transport_error(httpx.ReadTimeout),
+        _transport_error(httpx.WriteTimeout),
+        _transport_error(httpx.PoolTimeout),
         _http_status_error(httpx.codes.SERVICE_UNAVAILABLE),
         _http_status_error(httpx.codes.GATEWAY_TIMEOUT),
     ],
@@ -70,6 +83,8 @@ def test_retries_transient_http_failures(exception: Exception) -> None:
             "certificate verify failed",
             request=httpx.Request("POST", "https://api.example"),
         ),
+        _transport_error(httpx.UnsupportedProtocol),
+        _transport_error(httpx.LocalProtocolError),
     ],
 )
 def test_does_not_retry_permanent_http_failures(exception: Exception) -> None:


### PR DESCRIPTION
Adds `make_simple_http_retry_invoker`, providing HTTP retry behavior analogous to the existing gRPC retry invoker. A follow up PR, will introduce a transport-agnostic `make_simple_retry_invoker` with shared behaviour for both `HTTP` and `gRPC`