### PR TITLE
fix(framework): Make retry waits cancellable

### DIFF
--- a/framework/py/flwr/supercore/exit/exit.py
+++ b/framework/py/flwr/supercore/exit/exit.py
@@ -96,15 +96,15 @@ def flwr_exit(
     # Log the exit message
     log(log_level, exit_message)
 
-    # Trigger exit handlers
-    trigger_exit_handlers()
-
     # Start a daemon thread to force exit if graceful exit fails
     def force_exit() -> None:
         time.sleep(FORCE_EXIT_TIMEOUT_SECONDS)
         os._exit(sys_exit_code)
 
     threading.Thread(target=force_exit, daemon=True).start()
+
+    # Trigger exit handlers
+    trigger_exit_handlers()
 
     # Wait for telemetry event to be sent before exiting
     if event_future:

--- a/framework/py/flwr/supercore/exit/exit_handler.py
+++ b/framework/py/flwr/supercore/exit/exit_handler.py
@@ -26,7 +26,9 @@ SIGNAL_TO_EXIT_CODE: dict[int, int] = {
     signal.SIGTERM: ExitCode.GRACEFUL_EXIT_SIGTERM,
 }
 registered_exit_handlers: list[Callable[[], None]] = []
-_lock_handlers = threading.Lock()
+# Python signal handlers run synchronously on the main thread and can interrupt this
+# critical section, so nested exit handling must be able to reacquire the lock.
+_lock_handlers = threading.RLock()
 
 # SIGQUIT is not available on Windows
 if hasattr(signal, "SIGQUIT"):
@@ -55,12 +57,21 @@ def add_exit_handler(exit_handler: Callable[[], None]) -> None:
 
 
 def trigger_exit_handlers() -> None:
-    """Trigger all registered exit handlers in LIFO order."""
+    """Trigger registered exit handlers in LIFO order.
+
+    Handlers registered before this call are removed from the registry before
+    execution. Each handler is invoked at most once, and handlers registered
+    while callbacks are running remain registered for a subsequent call.
+    """
     with _lock_handlers:
-        for handler in reversed(registered_exit_handlers):
-            try:
-                handler()
-            except Exception:  # pylint: disable=broad-exception-caught
-                # Ignore exceptions in exit handlers
-                pass
+        handlers = list(reversed(registered_exit_handlers))
         registered_exit_handlers.clear()
+
+    # Run handlers without holding the registry lock. This keeps registration and
+    # nested exit handling independent of long-running callbacks.
+    for handler in handlers:
+        try:
+            handler()
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Ignore exceptions in exit handlers
+            pass

--- a/framework/py/flwr/supercore/exit/exit_handler_test.py
+++ b/framework/py/flwr/supercore/exit/exit_handler_test.py
@@ -15,7 +15,7 @@
 """Tests for exit handler functions."""
 
 
-from .exit_handler import add_exit_handler, trigger_exit_handlers
+from .exit_handler import _lock_handlers, add_exit_handler, trigger_exit_handlers
 
 
 def test_trigger_exit_handlers() -> None:
@@ -86,3 +86,30 @@ def test_trigger_exit_handlers_ignores_exceptions() -> None:
 
     # Assert - all handlers should have been called in LIFO order
     assert execution_order == [3, 2, 1]
+
+
+def test_trigger_exit_handlers_is_reentrant() -> None:
+    """Test that a nested exit does not deadlock on the handler registry lock."""
+    execution_order = []
+
+    def handler() -> None:
+        execution_order.append(1)
+        trigger_exit_handlers()
+        execution_order.append(2)
+
+    add_exit_handler(handler)
+
+    trigger_exit_handlers()
+
+    assert execution_order == [1, 2]
+
+
+def test_exit_handler_registry_lock_is_reentrant() -> None:
+    """A signal inside the registry critical section must not deadlock exit."""
+    with _lock_handlers:
+        # pylint: disable-next=consider-using-with
+        reacquired = _lock_handlers.acquire(blocking=False)
+        if reacquired:
+            _lock_handlers.release()
+
+    assert reacquired

--- a/framework/py/flwr/supercore/exit/exit_test.py
+++ b/framework/py/flwr/supercore/exit/exit_test.py
@@ -15,11 +15,12 @@
 """Tests for the exit function."""
 
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+import pytest
 from parameterized import parameterized
 
-from .exit import _get_code_url
+from .exit import _get_code_url, flwr_exit
 
 
 @parameterized.expand(  # type: ignore
@@ -39,3 +40,23 @@ def test_get_code_url(version: str, subdir: str) -> None:
             expected_url = "https://flower.ai/docs/framework/"
             expected_url += f"{subdir}ref-exit-codes/{code}.html"
             assert actual_url == expected_url
+
+
+@patch("flwr.supercore.exit.exit._try_obtain_telemetry_event", return_value=None)
+@patch("flwr.supercore.exit.exit.trigger_exit_handlers")
+@patch("flwr.supercore.exit.exit.threading.Thread")
+def test_force_exit_starts_before_exit_handlers(
+    mock_thread_cls: Mock,
+    mock_trigger_exit_handlers: Mock,
+    _mock_telemetry_event: Mock,
+) -> None:
+    """Test that blocked exit handlers cannot prevent the force-exit watchdog."""
+    call_order = []
+    mock_thread = mock_thread_cls.return_value
+    mock_thread.start.side_effect = lambda: call_order.append("watchdog")
+    mock_trigger_exit_handlers.side_effect = lambda: call_order.append("handlers")
+
+    with pytest.raises(SystemExit):
+        flwr_exit(0)
+
+    assert call_order == ["watchdog", "handlers"]

--- a/framework/py/flwr/supercore/exit/signal_handler.py
+++ b/framework/py/flwr/supercore/exit/signal_handler.py
@@ -17,7 +17,7 @@
 
 import signal
 from collections.abc import Callable
-from threading import Lock, Thread
+from threading import RLock, Thread
 from types import FrameType
 
 from grpc import Server
@@ -65,7 +65,10 @@ def register_signal_handlers(
     """
     default_handlers: dict[int, Callable[[int, FrameType], None]] = {}
     is_exiting = False
-    lock = Lock()
+    # Python runs signal handlers on the main thread between bytecode instructions.
+    # A second signal can therefore re-enter this handler while its first invocation
+    # still holds the guard; an RLock prevents that same thread from deadlocking.
+    lock = RLock()
 
     def _wait_to_stop() -> None:
         if grpc_servers is not None:

--- a/framework/py/flwr/supercore/exit/signal_handler_test.py
+++ b/framework/py/flwr/supercore/exit/signal_handler_test.py
@@ -17,6 +17,7 @@
 
 import os
 import signal
+import threading
 import unittest
 from unittest.mock import Mock, patch
 
@@ -65,3 +66,31 @@ class TestExitHandlers(unittest.TestCase):
 
         # Assert
         self.assertIn(handler, registered_exit_handlers)
+
+    def test_signal_handler_reenters_exiting_guard(self) -> None:
+        """A nested signal inside the guard must not deadlock shutdown."""
+        guard = threading.RLock()
+        with (
+            patch("flwr.supercore.exit.signal_handler.RLock", return_value=guard),
+            patch("flwr.supercore.exit.signal_handler.signal.signal") as mock_signal,
+            patch("flwr.supercore.exit.signal_handler.flwr_exit") as mock_flwr_exit,
+        ):
+            register_signal_handlers(EventType.PING)
+            graceful_exit_handler = mock_signal.call_args_list[0].args[1]
+            thread_finished = threading.Event()
+
+            def invoke_while_locked() -> None:
+                with guard:
+                    graceful_exit_handler(signal.SIGTERM, Mock())
+                thread_finished.set()
+
+            thread = threading.Thread(target=invoke_while_locked, daemon=True)
+            thread.start()
+            self.assertTrue(
+                thread_finished.wait(timeout=5.0),
+                "Signal handler did not finish while re-entering its guard",
+            )
+            thread.join()
+
+        self.assertFalse(thread.is_alive())
+        mock_flwr_exit.assert_called_once()

--- a/framework/py/flwr/supercore/retry/retry_invoker.py
+++ b/framework/py/flwr/supercore/retry/retry_invoker.py
@@ -17,6 +17,7 @@
 
 import itertools
 import random
+import threading
 import time
 from collections.abc import Callable, Generator, Iterable
 from dataclasses import dataclass
@@ -153,6 +154,8 @@ class RetryInvoker:
         for different execution environments. If set to `None`, the `wait_function`
         defaults to `time.sleep`, which is ideal for synchronous operations. Custom
         functions should manage execution flow to prevent blocking or interference.
+    cancel_wait_function: Optional[Callable[[], None]] (default: None)
+        A function that interrupts an active retry wait when retries are disabled.
 
     Examples
     --------
@@ -181,7 +184,10 @@ class RetryInvoker:
         jitter: Callable[[float], float] | None = full_jitter,
         should_giveup: Callable[[Exception], bool] | None = None,
         wait_function: Callable[[float], None] | None = None,
+        cancel_wait_function: Callable[[], None] | None = None,
     ) -> None:
+        # Signals can synchronously re-enter `disable_retries` on the main thread.
+        self._state_lock = threading.RLock()
         self.wait_gen_factory = wait_gen_factory
         self.recoverable_exceptions = recoverable_exceptions
         self.max_tries = max_tries
@@ -191,9 +197,26 @@ class RetryInvoker:
         self.on_giveup = on_giveup
         self.jitter = jitter
         self.should_giveup = should_giveup
+        self.cancel_wait_function = cancel_wait_function
+        self._retries_disabled = False
         if wait_function is None:
             wait_function = time.sleep
         self.wait_function = wait_function
+
+    @property
+    def retries_disabled(self) -> bool:
+        """Return whether retries have been disabled."""
+        with self._state_lock:
+            return self._retries_disabled
+
+    def disable_retries(self) -> None:
+        """Disable further retries and interrupt an active retry wait."""
+        with self._state_lock:
+            self._retries_disabled = True
+            self.max_tries = 1
+            cancel_wait = self.cancel_wait_function
+        if cancel_wait is not None:
+            cancel_wait()
 
     # pylint: disable-next=too-many-locals
     def invoke(
@@ -267,7 +290,9 @@ class RetryInvoker:
             except self.recoverable_exceptions as err:
                 state.exception = err
                 # Check if giveup event should be triggered
-                max_tries_exceeded = try_cnt == self.max_tries
+                with self._state_lock:
+                    max_tries = self.max_tries
+                max_tries_exceeded = max_tries is not None and try_cnt >= max_tries
                 max_time_exceeded = (
                     self.max_time is not None and elapsed_time >= self.max_time
                 )
@@ -299,6 +324,13 @@ class RetryInvoker:
 
                 # Sleep
                 self.wait_function(state.actual_wait)
+
+                # `disable_retries` can lower the limit while the wait is active.
+                with self._state_lock:
+                    max_tries = self.max_tries
+                if max_tries is not None and try_cnt >= max_tries:
+                    try_call_event_handler(self.on_giveup)
+                    raise err
             else:
                 # Trigger success event
                 try_call_event_handler(self.on_success)

--- a/framework/py/flwr/supercore/retry/retry_invoker_test.py
+++ b/framework/py/flwr/supercore/retry/retry_invoker_test.py
@@ -15,6 +15,7 @@
 """Tests for `RetryInvoker`."""
 
 
+import threading
 from collections.abc import Generator
 from unittest.mock import MagicMock, Mock, patch
 
@@ -126,6 +127,71 @@ def test_max_tries(mock_sleep: MagicMock) -> None:
         invoker.invoke(failing_function)
     # Assert 1 sleep call due to the max_tries being set to 2
     mock_sleep.assert_called_once_with(0.1)
+
+
+def test_disable_retries_interrupts_wait() -> None:
+    """Disabling retries should stop waiting and cap an active invocation."""
+    target = Mock(side_effect=[ValueError("first"), TypeError])
+    invoker: RetryInvoker
+
+    def disable_retries(_wait_time: float) -> None:
+        invoker.disable_retries()
+
+    invoker = RetryInvoker(
+        lambda: constant(0.1),
+        ValueError,
+        max_tries=3,
+        max_time=None,
+        wait_function=disable_retries,
+    )
+
+    with pytest.raises(ValueError, match="first"):
+        invoker.invoke(target)
+
+    assert target.call_count == 1
+
+
+def test_disable_retries_calls_wait_canceller() -> None:
+    """Disabling retries should interrupt a wait already in progress."""
+    cancel_wait = Mock()
+    invoker = RetryInvoker(
+        lambda: constant(0.1),
+        ValueError,
+        max_tries=None,
+        max_time=None,
+        cancel_wait_function=cancel_wait,
+    )
+
+    invoker.disable_retries()
+
+    assert invoker.max_tries == 1
+    cancel_wait.assert_called_once_with()
+
+
+def test_disable_retries_reenters_state_update() -> None:
+    """A signal during a retry-state update must not deadlock shutdown."""
+    invoker = RetryInvoker(
+        lambda: constant(0.1),
+        ValueError,
+        max_tries=None,
+        max_time=None,
+    )
+    thread_finished = threading.Event()
+
+    def disable_while_locked() -> None:
+        with invoker._state_lock:  # pylint: disable=protected-access
+            invoker.disable_retries()
+        thread_finished.set()
+
+    thread = threading.Thread(target=disable_while_locked, daemon=True)
+    thread.start()
+    assert thread_finished.wait(
+        timeout=5.0
+    ), "Retry cancellation did not finish while re-entering its state lock"
+    thread.join()
+
+    assert not thread.is_alive()
+    assert invoker.retries_disabled
 
 
 def test_max_time(mock_time: MagicMock, mock_sleep: MagicMock) -> None:


### PR DESCRIPTION
## What changed

- add an explicit `RetryInvoker.disable_retries()` API
- allow retry implementations to interrupt an active wait
- re-check retry limits after an interrupted wait
- protect mutable retry state with reentrant synchronization

## Why

Lowering `max_tries` does not wake an invocation that is already sleeping in backoff. Shutdown needs an explicit operation that prevents new retries and interrupts current waits.

## Stack

Umbrella/reference: [#7895 — Prevent task executor shutdown deadlock](https://github.com/flwrlabs/flower/pull/7895)

- Previous: [#7914 — Make exit handling bounded and reentrant](https://github.com/flwrlabs/flower/pull/7914)
- This PR: **#7915 — Make retry waits cancellable**
- Next: [#7916 — Cancel gRPC retries during shutdown](https://github.com/flwrlabs/flower/pull/7916)

Merge the stack in order. After the previous PR merges, retarget this PR to `main`.

## Validation

- `pytest py/flwr/supercore/retry/retry_invoker_test.py`
- Ruff and Black on the changed retry modules
- `git diff --check`