### PR TITLE
fix(framework): Cancel gRPC retries during shutdown

### DIFF
--- a/framework/py/flwr/supercore/retry/grpc_retry.py
+++ b/framework/py/flwr/supercore/retry/grpc_retry.py
@@ -32,16 +32,64 @@ from flwr.supercore.run import RunNotRunningException
 from .retry_invoker import RetryInvoker, RetryState, exponential
 
 
+class _RetryWaitState:
+    """Coordinate retry health and cancellation with reentrant synchronization."""
+
+    def __init__(self) -> None:
+        self._condition = threading.Condition(threading.RLock())
+        self._system_healthy = True
+        self._cancelled = False
+
+    @property
+    def cancelled(self) -> bool:
+        """Return whether retry waits have been cancelled."""
+        with self._condition:
+            return self._cancelled
+
+    def mark_healthy(self) -> None:
+        """Mark the system healthy and wake waiting invocations."""
+        with self._condition:
+            self._system_healthy = True
+            self._condition.notify_all()
+
+    def mark_unhealthy(self) -> None:
+        """Mark the system unhealthy unless shutdown already cancelled retries."""
+        with self._condition:
+            if not self._cancelled:
+                self._system_healthy = False
+
+    def wait_until_healthy_or_cancelled(self, timeout: float) -> None:
+        """Wait until another invocation succeeds, shutdown starts, or timeout."""
+        with self._condition:
+            self._condition.wait_for(
+                lambda: self._system_healthy or self._cancelled,
+                timeout=timeout,
+            )
+
+    def wait_until_cancelled(self, timeout: float) -> None:
+        """Wait until shutdown cancels retries or timeout expires."""
+        with self._condition:
+            self._condition.wait_for(lambda: self._cancelled, timeout=timeout)
+
+    def cancel(self) -> None:
+        """Cancel retry waits permanently and wake all current waiters."""
+        with self._condition:
+            self._cancelled = True
+            self._system_healthy = True
+            self._condition.notify_all()
+
+
 def make_simple_grpc_retry_invoker() -> RetryInvoker:
     """Create a simple gRPC retry invoker."""
     lock = threading.Lock()
-    shutdown_lock = threading.Lock()
+    retry_wait_state = _RetryWaitState()
+    # Signal handlers can synchronously re-enter authentication failure handling.
+    shutdown_lock = threading.RLock()
     shutdown_requested = False
-    system_healthy = threading.Event()
-    system_healthy.set()  # Initially, the connection is healthy
+    retry_invoker: RetryInvoker
 
     def _on_success(retry_state: RetryState) -> None:
-        system_healthy.set()
+        retry_wait_state.mark_healthy()
         if retry_state.tries > 1:
             log(
                 INFO,
@@ -51,13 +99,13 @@ def make_simple_grpc_retry_invoker() -> RetryInvoker:
             )
 
     def _on_backoff(retry_state: RetryState) -> None:
-        system_healthy.clear()
+        retry_wait_state.mark_unhealthy()
         log(
             DEBUG, "Connection attempt failed with exception: %s", retry_state.exception
         )
 
     def _on_giveup(retry_state: RetryState) -> None:
-        system_healthy.clear()
+        retry_wait_state.mark_unhealthy()
         if retry_state.tries > 1:
             log(
                 WARN,
@@ -71,6 +119,11 @@ def make_simple_grpc_retry_invoker() -> RetryInvoker:
         if e.code() == grpc.StatusCode.PERMISSION_DENIED:  # type: ignore
             raise RunNotRunningException
         if e.code() == grpc.StatusCode.UNAUTHENTICATED:  # type: ignore
+            # Exit handlers disable retries before stopping background RPC workers.
+            # A late response from one of those workers must not interrupt the final
+            # task-output RPC with a nested shutdown signal.
+            if retry_invoker.retries_disabled:
+                return True
             # Authentication failures should trigger shutdown rather than retrying
             # This can occur, for example, when the user runs `flwr stop`
             # Note: On Windows, `os.kill` terminates the process abruptly, not ideal
@@ -82,7 +135,7 @@ def make_simple_grpc_retry_invoker() -> RetryInvoker:
                     return True
                 shutdown_requested = True
             os.kill(os.getpid(), signal.SIGINT)
-            time.sleep(FORCE_EXIT_TIMEOUT_SECONDS + 1)
+            retry_wait_state.wait_until_cancelled(FORCE_EXIT_TIMEOUT_SECONDS + 1)
             return False
         if e.code() == grpc.StatusCode.UNAVAILABLE:  # type: ignore
             # Check if this is an SSL handshake failure - these should fail fast
@@ -94,9 +147,15 @@ def make_simple_grpc_retry_invoker() -> RetryInvoker:
         return True
 
     def _wait(wait_time: float) -> None:
+        if retry_wait_state.cancelled:
+            return
+
         # Use a lock to prevent multiple gRPC calls from retrying concurrently,
         # which is unnecessary since they are all likely to fail.
         with lock:
+            if retry_wait_state.cancelled:
+                return
+
             # Log the wait time
             log(
                 WARN,
@@ -106,13 +165,21 @@ def make_simple_grpc_retry_invoker() -> RetryInvoker:
 
             start = time.monotonic()
             # Avoid sequential waits if the system is healthy
-            system_healthy.wait(wait_time)
+            retry_wait_state.wait_until_healthy_or_cancelled(wait_time)
+
+        if retry_wait_state.cancelled:
+            return
 
         remaining_time = wait_time - (time.monotonic() - start)
         if remaining_time > 0:
-            time.sleep(remaining_time)
+            retry_wait_state.wait_until_cancelled(remaining_time)
 
-    return RetryInvoker(
+    def _cancel_wait() -> None:
+        # Keep the state healthy after cancellation so all current and future
+        # waiters return, even if another invocation gives up concurrently.
+        retry_wait_state.cancel()
+
+    retry_invoker = RetryInvoker(
         wait_gen_factory=lambda: exponential(max_delay=MAX_RETRY_DELAY),
         recoverable_exceptions=grpc.RpcError,
         max_tries=None,
@@ -122,7 +189,9 @@ def make_simple_grpc_retry_invoker() -> RetryInvoker:
         on_giveup=_on_giveup,
         should_giveup=_should_giveup_fn,
         wait_function=_wait,
+        cancel_wait_function=_cancel_wait,
     )
+    return retry_invoker
 
 
 def wrap_stub(

--- a/framework/py/flwr/supercore/retry/grpc_retry_test.py
+++ b/framework/py/flwr/supercore/retry/grpc_retry_test.py
@@ -1,0 +1,176 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for gRPC retry utilities."""
+
+
+import threading
+from unittest.mock import Mock, patch
+
+import grpc
+import pytest
+
+from .grpc_retry import make_simple_grpc_retry_invoker
+from .retry_invoker import RetryState
+
+
+class _UnauthenticatedError(grpc.RpcError):  # type: ignore[misc]
+    """gRPC error reporting an authentication failure."""
+
+    def code(self) -> grpc.StatusCode:
+        """Return the gRPC status code."""
+        return grpc.StatusCode.UNAUTHENTICATED
+
+
+class _UnavailableError(grpc.RpcError):  # type: ignore[misc]
+    """gRPC error reporting an unavailable endpoint."""
+
+    def code(self) -> grpc.StatusCode:
+        """Return the gRPC status code."""
+        return grpc.StatusCode.UNAVAILABLE
+
+
+@patch("flwr.supercore.retry.grpc_retry.os.kill")
+def test_unauthenticated_does_not_signal_when_retries_disabled(
+    mock_kill: Mock,
+) -> None:
+    """Late background RPC failures must not interrupt graceful shutdown."""
+    retry_invoker = make_simple_grpc_retry_invoker()
+    retry_invoker.disable_retries()
+
+    with pytest.raises(_UnauthenticatedError):
+        retry_invoker.invoke(Mock(side_effect=_UnauthenticatedError()))
+
+    mock_kill.assert_not_called()
+
+
+@patch("flwr.supercore.retry.grpc_retry.os.kill")
+def test_unauthenticated_signals_when_max_tries_is_one(
+    mock_kill: Mock,
+) -> None:
+    """A configured one-attempt limit must not look like executor shutdown."""
+    retry_invoker = make_simple_grpc_retry_invoker()
+    retry_invoker.max_tries = 1
+    mock_kill.side_effect = lambda *_args: retry_invoker.disable_retries()
+
+    with pytest.raises(_UnauthenticatedError):
+        retry_invoker.invoke(Mock(side_effect=_UnauthenticatedError()))
+
+    mock_kill.assert_called_once()
+
+
+def test_disable_retries_interrupts_grpc_backoff() -> None:
+    """Executor shutdown must not wait for an active gRPC retry backoff."""
+    retry_invoker = make_simple_grpc_retry_invoker()
+    target_called = threading.Event()
+    invocation_finished = threading.Event()
+    errors: list[grpc.RpcError] = []
+
+    def target() -> None:
+        target_called.set()
+        raise _UnavailableError
+
+    def invoke() -> None:
+        try:
+            retry_invoker.invoke(target)
+        except grpc.RpcError as err:
+            errors.append(err)
+        finally:
+            invocation_finished.set()
+
+    thread = threading.Thread(target=invoke)
+    thread.start()
+    assert target_called.wait(timeout=5.0), "Retry target was not called"
+
+    retry_invoker.disable_retries()
+    assert invocation_finished.wait(
+        timeout=5.0
+    ), "gRPC retry invocation did not stop after cancellation"
+    thread.join()
+
+    assert not thread.is_alive()
+    assert len(errors) == 1
+
+
+def test_disable_retries_interrupts_all_grpc_backoffs() -> None:
+    """Shutdown must wake every invocation sharing the retry coordinator."""
+    retry_invoker = make_simple_grpc_retry_invoker()
+    retry_invoker.jitter = lambda _wait_time: 60.0
+    backoff_barrier = threading.Barrier(3)
+    errors: list[grpc.RpcError] = []
+    original_on_backoff = retry_invoker.on_backoff
+    assert original_on_backoff is not None
+
+    def on_backoff(retry_state: RetryState) -> None:
+        original_on_backoff(retry_state)
+        backoff_barrier.wait(timeout=5.0)
+
+    retry_invoker.on_backoff = on_backoff
+
+    def target() -> None:
+        raise _UnavailableError
+
+    def invoke(invocation_finished: threading.Event) -> None:
+        try:
+            retry_invoker.invoke(target)
+        except grpc.RpcError as err:
+            errors.append(err)
+        finally:
+            invocation_finished.set()
+
+    invocation_finished_events = [threading.Event() for _ in range(2)]
+    threads = [
+        threading.Thread(target=invoke, args=(invocation_finished,))
+        for invocation_finished in invocation_finished_events
+    ]
+    for thread in threads:
+        thread.start()
+    backoff_barrier.wait(timeout=5.0)
+
+    retry_invoker.disable_retries()
+    for invocation_finished in invocation_finished_events:
+        assert invocation_finished.wait(
+            timeout=5.0
+        ), "Concurrent gRPC retry invocation did not stop after cancellation"
+    for thread in threads:
+        thread.join()
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(errors) == 2
+
+
+def test_disable_retries_is_reentrant_from_retry_callback() -> None:
+    """A signal during a retry callback must not deadlock shutdown."""
+    retry_wait_lock = threading.RLock()
+    with patch(
+        "flwr.supercore.retry.grpc_retry.threading.RLock",
+        return_value=retry_wait_lock,
+    ):
+        retry_invoker = make_simple_grpc_retry_invoker()
+    thread_finished = threading.Event()
+
+    def disable_while_locked() -> None:
+        # Simulate SIGINT while a retry callback owns the state condition.
+        with retry_wait_lock:
+            retry_invoker.disable_retries()
+        thread_finished.set()
+
+    thread = threading.Thread(target=disable_while_locked, daemon=True)
+    thread.start()
+    assert thread_finished.wait(
+        timeout=5.0
+    ), "Retry cancellation did not finish while re-entering the wait-state lock"
+    thread.join()
+
+    assert not thread.is_alive()


### PR DESCRIPTION
## What changed

- cancel all active gRPC retry waits when retries are disabled
- suppress late authentication-failure shutdown signals after cleanup begins
- coordinate retry health and cancellation with reentrant synchronization
- retain normal authentication-failure shutdown behavior before cleanup starts

## Why

A background RPC can be in retry backoff when shutdown starts. It must wake immediately, and a late `UNAUTHENTICATED` response must not send a nested shutdown signal while final task output is in flight.

## Stack

Umbrella/reference: [#7895 — Prevent task executor shutdown deadlock](https://github.com/flwrlabs/flower/pull/7895)

- Previous: [#7915 — Make retry waits cancellable](https://github.com/flwrlabs/flower/pull/7915)
- This PR: **#7916 — Cancel gRPC retries during shutdown**
- Next: [#7917 — Bound task heartbeat shutdown](https://github.com/flwrlabs/flower/pull/7917)

Merge the stack in order. After the previous PR merges, retarget this PR to `main`.

## Validation

- `pytest py/flwr/supercore/retry/grpc_retry_test.py py/flwr/supercore/retry/retry_invoker_test.py`
- Ruff and Black on `py/flwr/supercore/retry`
- `git diff --check`