### PR TITLE
fix(framework): Stop heartbeat executors before completion

### DIFF
--- a/framework/py/flwr/supercore/constant.py
+++ b/framework/py/flwr/supercore/constant.py
@@ -133,6 +133,11 @@ DEFAULT_FEDERATION_SIMULATION = "workspace"
 # Constants for exit handling
 FORCE_EXIT_TIMEOUT_SECONDS = 5  # Used in `flwr_exit` function
 TELEMETRY_TIMEOUT_SECONDS = 4  # Timeout for sending telemetry events during exit
+# Use half of the five-second watchdog window for background-worker cleanup. This
+# reserves roughly two seconds for final task output before its 4.5-second deadline,
+# plus 0.5 seconds for transport cleanup and scheduling delays before forced exit.
+EXIT_HANDLER_CLEANUP_TIMEOUT_SECONDS = 2.5
+EXIT_HANDLER_TIMEOUT_SECONDS = FORCE_EXIT_TIMEOUT_SECONDS - 0.5
 
 # Constants for message processing timing
 MESSAGE_TIME_ENTRY_MAX_AGE_SECONDS = 3600

--- a/framework/py/flwr/supercore/task_process/connector/run_connector.py
+++ b/framework/py/flwr/supercore/task_process/connector/run_connector.py
@@ -17,11 +17,12 @@
 
 from __future__ import annotations
 
+import time
 from logging import DEBUG, ERROR
 
 import grpc
 
-from flwr.common.constant import SubStatus
+from flwr.common.constant import TASK_WORKER_CALL_TIMEOUT, SubStatus
 from flwr.common.logger import log
 from flwr.proto.runtime_pb2 import (  # pylint: disable=E0611
     PullTaskInputRequest,
@@ -30,6 +31,10 @@ from flwr.proto.runtime_pb2 import (  # pylint: disable=E0611
 )
 from flwr.proto.runtime_pb2_grpc import RuntimeStub
 from flwr.supercore.app_utils import start_parent_process_monitor
+from flwr.supercore.constant import (
+    EXIT_HANDLER_CLEANUP_TIMEOUT_SECONDS,
+    EXIT_HANDLER_TIMEOUT_SECONDS,
+)
 from flwr.supercore.exit import ExitCode, flwr_exit, register_signal_handlers
 from flwr.supercore.grpc import create_channel, on_channel_state_change
 from flwr.supercore.heartbeat import HeartbeatSender, make_task_heartbeat_fn_grpc
@@ -69,19 +74,29 @@ def run_connector(  # pylint: disable=too-many-locals
     def on_exit() -> None:
         log(DEBUG, "[flwr-connector] Will push Connector task output")
 
-        retry_invoker.max_tries = 1
+        # Disable retries and interrupt active backoff before bounded shutdown.
+        retry_invoker.disable_retries()
+        started_at = time.monotonic()
+        cleanup_deadline = started_at + EXIT_HANDLER_CLEANUP_TIMEOUT_SECONDS
+        exit_deadline = started_at + EXIT_HANDLER_TIMEOUT_SECONDS
+
+        # Stop heartbeats before finishing the task, which revokes its token.
+        if heartbeat_sender and heartbeat_sender.is_running:
+            heartbeat_sender.stop(timeout=max(0.0, cleanup_deadline - time.monotonic()))
 
         pushoutput_req = PushTaskOutputRequest(
             sub_status=sub_status,
             details=details,
         )
         try:
-            stub.PushTaskOutput(pushoutput_req)
+            # Do not use the one-second worker deadline: give this critical final
+            # write the remaining exit-handler budget.
+            stub.PushTaskOutput(
+                pushoutput_req,
+                timeout=max(0.0, exit_deadline - time.monotonic()),
+            )
         except grpc.RpcError as err:
             log(ERROR, "Failed to push task output: %s", str(err))
-
-        if heartbeat_sender and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
 
         channel.close()
 
@@ -92,7 +107,10 @@ def run_connector(  # pylint: disable=too-many-locals
     )
 
     try:
-        heartbeat_sender = HeartbeatSender(make_task_heartbeat_fn_grpc(stub))
+        heartbeat_sender = HeartbeatSender(
+            make_task_heartbeat_fn_grpc(stub),
+            call_timeout=TASK_WORKER_CALL_TIMEOUT,
+        )
         heartbeat_sender.start()
 
         log(DEBUG, "[flwr-connector] Pull task input")

--- a/framework/py/flwr/supercore/task_process/model/run_model.py
+++ b/framework/py/flwr/supercore/task_process/model/run_model.py
@@ -17,11 +17,12 @@
 
 from __future__ import annotations
 
+import time
 from logging import DEBUG, ERROR
 
 import grpc
 
-from flwr.common.constant import SubStatus
+from flwr.common.constant import TASK_WORKER_CALL_TIMEOUT, SubStatus
 from flwr.common.logger import log
 from flwr.proto.runtime_pb2 import (  # pylint: disable=E0611
     PullTaskInputRequest,
@@ -30,6 +31,10 @@ from flwr.proto.runtime_pb2 import (  # pylint: disable=E0611
 )
 from flwr.proto.runtime_pb2_grpc import RuntimeStub
 from flwr.supercore.app_utils import start_parent_process_monitor
+from flwr.supercore.constant import (
+    EXIT_HANDLER_CLEANUP_TIMEOUT_SECONDS,
+    EXIT_HANDLER_TIMEOUT_SECONDS,
+)
 from flwr.supercore.exit import ExitCode, flwr_exit, register_signal_handlers
 from flwr.supercore.grpc import create_channel, on_channel_state_change
 from flwr.supercore.heartbeat import HeartbeatSender, make_task_heartbeat_fn_grpc
@@ -71,8 +76,15 @@ def run_model(  # pylint: disable=too-many-locals
     def on_exit() -> None:
         log(DEBUG, "[flwr-model] Will push Model task output")
 
-        # Set Grpc max retries to 1 to avoid blocking on exit
-        retry_invoker.max_tries = 1
+        # Disable retries and interrupt active backoff before bounded shutdown.
+        retry_invoker.disable_retries()
+        started_at = time.monotonic()
+        cleanup_deadline = started_at + EXIT_HANDLER_CLEANUP_TIMEOUT_SECONDS
+        exit_deadline = started_at + EXIT_HANDLER_TIMEOUT_SECONDS
+
+        # Stop heartbeats before finishing the task, which revokes its token.
+        if heartbeat_sender and heartbeat_sender.is_running:
+            heartbeat_sender.stop(timeout=max(0.0, cleanup_deadline - time.monotonic()))
 
         # Push final status
         pushoutput_req = PushTaskOutputRequest(
@@ -80,13 +92,14 @@ def run_model(  # pylint: disable=too-many-locals
             details=details,
         )
         try:
-            stub.PushTaskOutput(pushoutput_req)
+            # Do not use the one-second worker deadline: give this critical final
+            # write the remaining exit-handler budget.
+            stub.PushTaskOutput(
+                pushoutput_req,
+                timeout=max(0.0, exit_deadline - time.monotonic()),
+            )
         except grpc.RpcError as err:
             log(ERROR, "Failed to push task output: %s", str(err))
-
-        # Stop heartbeat sender
-        if heartbeat_sender and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
 
         # Close the Grpc connection
         channel.close()
@@ -99,7 +112,10 @@ def run_model(  # pylint: disable=too-many-locals
 
     try:
         # Set up heartbeat sender
-        heartbeat_sender = HeartbeatSender(make_task_heartbeat_fn_grpc(stub))
+        heartbeat_sender = HeartbeatSender(
+            make_task_heartbeat_fn_grpc(stub),
+            call_timeout=TASK_WORKER_CALL_TIMEOUT,
+        )
         heartbeat_sender.start()
 
         # Pull task input from SuperLink

--- a/framework/py/flwr/supernode/runtime/run_clientapp.py
+++ b/framework/py/flwr/supernode/runtime/run_clientapp.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Flower ClientApp process."""
 
-
+import time
 from logging import DEBUG, ERROR
 
 import grpc
@@ -26,7 +26,12 @@ from flwr.cli.install import install_from_fab
 from flwr.clientapp.client_app import ClientApp, LoadClientAppError
 from flwr.clientapp.utils import get_load_client_app_fn
 from flwr.common.config import get_project_dir
-from flwr.common.constant import RUNTIME_DEPENDENCY_INSTALL, ErrorCode, SubStatus
+from flwr.common.constant import (
+    RUNTIME_DEPENDENCY_INSTALL,
+    TASK_WORKER_CALL_TIMEOUT,
+    ErrorCode,
+    SubStatus,
+)
 from flwr.common.logger import log
 from flwr.common.serde import (
     context_from_proto,
@@ -46,6 +51,10 @@ from flwr.proto.runtime_pb2 import (  # pylint: disable=E0611
 )
 from flwr.proto.runtime_pb2_grpc import RuntimeStub
 from flwr.supercore.app_utils import start_parent_process_monitor
+from flwr.supercore.constant import (
+    EXIT_HANDLER_CLEANUP_TIMEOUT_SECONDS,
+    EXIT_HANDLER_TIMEOUT_SECONDS,
+)
 from flwr.supercore.exit import ExitCode, flwr_exit, register_signal_handlers
 from flwr.supercore.fab import Fab
 from flwr.supercore.grpc import create_channel, on_channel_state_change
@@ -118,20 +127,27 @@ def run_clientapp(  # pylint: disable=R0913, R0914, R0915, R0917
     exit_code = ExitCode.SUCCESS
 
     def on_exit() -> None:
-        # Set Grpc max retries to 1 to avoid blocking on exit
-        retry_invoker.max_tries = 1
+        # Disable retries and interrupt active backoff before bounded shutdown.
+        retry_invoker.disable_retries()
+        started_at = time.monotonic()
+        cleanup_deadline = started_at + EXIT_HANDLER_CLEANUP_TIMEOUT_SECONDS
+        exit_deadline = started_at + EXIT_HANDLER_TIMEOUT_SECONDS
+
+        # Stop heartbeats before finishing the task, which revokes its token.
+        if heartbeat_sender is not None and heartbeat_sender.is_running:
+            heartbeat_sender.stop(timeout=max(0.0, cleanup_deadline - time.monotonic()))
 
         # Push final status and context (if available)
+        # Do not use the one-second worker deadline: give this critical final write
+        # the remaining exit-handler budget.
         push_task_output(
             stub=stub,
             context=context,
             sub_status=sub_status,
             details=details,
+            timeout=max(0.0, exit_deadline - time.monotonic()),
         )
 
-        # Stop heartbeat sender
-        if heartbeat_sender is not None and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
         channel.close()
 
         cleanup_app_runtime_environment(runtime_env_dir)
@@ -144,7 +160,10 @@ def run_clientapp(  # pylint: disable=R0913, R0914, R0915, R0917
 
     try:
         # Start task heartbeat
-        heartbeat_sender = HeartbeatSender(make_task_heartbeat_fn_grpc(stub))
+        heartbeat_sender = HeartbeatSender(
+            make_task_heartbeat_fn_grpc(stub),
+            call_timeout=TASK_WORKER_CALL_TIMEOUT,
+        )
         heartbeat_sender.start()
 
         # Pull Message, Context, Run and FAB from SuperNode
@@ -306,16 +325,19 @@ def push_task_output(  # pylint: disable=R0913, R0917
     context: Context | None,
     sub_status: str,
     details: str,
+    timeout: float | None = None,
 ) -> None:
     """Push TaskOutput to SuperNode."""
     try:
         # Push Context and final status
-        stub.PushTaskOutput(
-            PushTaskOutputRequest(
-                context=context_to_proto(context) if context else None,
-                sub_status=sub_status,
-                details=details,
-            )
+        request = PushTaskOutputRequest(
+            context=context_to_proto(context) if context else None,
+            sub_status=sub_status,
+            details=details,
         )
+        if timeout is None:
+            stub.PushTaskOutput(request)
+        else:
+            stub.PushTaskOutput(request, timeout=timeout)
     except grpc.RpcError as err:
         log(ERROR, "Failed to push task output: %s", str(err))

--- a/framework/py/flwr/supernode/runtime/run_clientapp_test.py
+++ b/framework/py/flwr/supernode/runtime/run_clientapp_test.py
@@ -34,7 +34,7 @@ from flwr.supercore.interceptors import (
     RuntimeVersionClientInterceptor,
 )
 
-from .run_clientapp import pull_task_input, run_clientapp
+from .run_clientapp import pull_task_input, push_task_output, run_clientapp
 
 
 class TestRunClientApp(unittest.TestCase):
@@ -94,3 +94,17 @@ class TestRunClientApp(unittest.TestCase):
         self.assertEqual(
             flwr_exit.call_args.kwargs["code"], ExitCode.TASK_PROC_EXCEPTION
         )
+
+    def test_push_task_output_uses_timeout(self) -> None:
+        """Test that final task output can be bounded during shutdown."""
+        stub = Mock()
+
+        push_task_output(
+            stub=stub,
+            context=None,
+            sub_status="COMPLETED",
+            details="",
+            timeout=1.0,
+        )
+
+        self.assertEqual(stub.PushTaskOutput.call_args.kwargs["timeout"], 1.0)


### PR DESCRIPTION
## What changed

- stop heartbeat workers before final task output in ClientApp, Model, and Connector executors
- disable retries before worker shutdown
- share an absolute cleanup deadline across shutdown steps
- give final `PushTaskOutput` the remaining exit-handler budget

## Why

`PushTaskOutput` revokes the task token. A heartbeat racing after that call can receive `UNAUTHENTICATED` and re-enter process shutdown. Stopping authenticated workers first removes that race while the absolute deadline keeps the whole handler inside the force-exit window.

```mermaid
sequenceDiagram
    participant E as Executor
    participant H as Heartbeat worker
    participant R as Runtime API
    E->>E: Disable retries
    E->>H: Stop within cleanup deadline
    E->>R: PushTaskOutput with remaining deadline
    E->>E: Close transport
```

## Stack

Umbrella/reference: [#7895 — Prevent task executor shutdown deadlock](https://github.com/flwrlabs/flower/pull/7895)

- Previous: [#7918 — Bound task log uploader shutdown](https://github.com/flwrlabs/flower/pull/7918)
- This PR: **#7919 — Stop heartbeat executors before completion**
- Next: [#7920 — Stop logging executors before completion](https://github.com/flwrlabs/flower/pull/7920)

Merge the stack in order. After the previous PR merges, retarget this PR to `main`.

## Validation

- `pytest py/flwr/supernode/runtime/run_clientapp_test.py`
- Ruff and Black on the changed executor modules
- `git diff --check`