### PR TITLE
fix(framework): Stop logging executors before completion

### DIFF
--- a/framework/py/flwr/simulation/app.py
+++ b/framework/py/flwr/simulation/app.py
@@ -18,6 +18,7 @@
 import argparse
 import importlib.util
 import os
+import time
 from dataclasses import replace
 from logging import DEBUG, ERROR, INFO, WARNING
 from queue import Queue
@@ -37,10 +38,10 @@ from flwr.common.config import (
 from flwr.common.constant import (
     RUNTIME_DEPENDENCY_INSTALL,
     SUPERLINK_RUNTIME_API_DEFAULT_CLIENT_ADDRESS,
+    TASK_WORKER_CALL_TIMEOUT,
     SubStatus,
 )
 from flwr.common.logger import (
-    flush_logs,
     log,
     mirror_output_to_queue,
     restore_output,
@@ -64,7 +65,11 @@ from flwr.server.superlink.fleet.vce.metrics import VceMetrics
 from flwr.simulation.run_simulation import _run_simulation
 from flwr.simulation.simulationio_connection import SimulationIoConnection
 from flwr.supercore.app_utils import start_parent_process_monitor
-from flwr.supercore.constant import NOOP_FEDERATION_ID
+from flwr.supercore.constant import (
+    EXIT_HANDLER_CLEANUP_TIMEOUT_SECONDS,
+    EXIT_HANDLER_TIMEOUT_SECONDS,
+    NOOP_FEDERATION_ID,
+)
 from flwr.supercore.exit import ExitCode, flwr_exit, register_signal_handlers
 from flwr.supercore.heartbeat import HeartbeatSender, make_task_heartbeat_fn_grpc
 from flwr.supercore.superexec.dependency_installer import (
@@ -180,13 +185,23 @@ def run_simulation_process(  # pylint: disable=R0913, R0914, R0915, R0917, W0212
     def on_exit() -> None:
         log(DEBUG, "[flwr-simulation] Will push Simulation task output")
 
-        # Set Grpc max retries to 1 to avoid blocking on exit
-        conn._retry_invoker.max_tries = 1
+        # Disable retries and interrupt active backoff before bounded shutdown.
+        conn._retry_invoker.disable_retries()
+        started_at = time.monotonic()
+        cleanup_deadline = started_at + EXIT_HANDLER_CLEANUP_TIMEOUT_SECONDS
+        exit_deadline = started_at + EXIT_HANDLER_TIMEOUT_SECONDS
 
-        # Upload any remaining logs before pushing final output
+        # Stop authenticated background workers before pushing final output.
+        if heartbeat_sender and heartbeat_sender.is_running:
+            heartbeat_sender.stop(timeout=max(0.0, cleanup_deadline - time.monotonic()))
+
+        # Drain queued logs and stop the uploader within the cleanup budget.
         if log_uploader:
-            flush_logs(log_queue)
-
+            stop_log_uploader(
+                log_queue,
+                log_uploader,
+                timeout=max(0.0, cleanup_deadline - time.monotonic()),
+            )
         # Push final status and context (if available)
         out_req = PushTaskOutputRequest(
             context=context_to_proto(context) if context else None,
@@ -195,17 +210,14 @@ def run_simulation_process(  # pylint: disable=R0913, R0914, R0915, R0917, W0212
             clientapp_runtime=metrics.clientapp_runtime,
         )
         try:
-            conn._stub.PushTaskOutput(out_req)
+            # Do not use the one-second worker deadline: give this critical final
+            # write the remaining exit-handler budget.
+            conn._stub.PushTaskOutput(
+                out_req,
+                timeout=max(0.0, exit_deadline - time.monotonic()),
+            )
         except grpc.RpcError as err:
             log(ERROR, "Failed to push task output: %s", str(err))
-
-        # Stop log uploader for this run and upload final logs
-        if log_uploader:
-            stop_log_uploader(log_queue, log_uploader)
-
-        # Stop heartbeat sender
-        if heartbeat_sender and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
 
         # Close the gRPC connection
         conn._disconnect()
@@ -220,7 +232,10 @@ def run_simulation_process(  # pylint: disable=R0913, R0914, R0915, R0917, W0212
 
     try:
         # Set up heartbeat sender
-        heartbeat_sender = HeartbeatSender(make_task_heartbeat_fn_grpc(conn._stub))
+        heartbeat_sender = HeartbeatSender(
+            make_task_heartbeat_fn_grpc(conn._stub),
+            call_timeout=TASK_WORKER_CALL_TIMEOUT,
+        )
         heartbeat_sender.start()
 
         # Pull SimulationInputs from LinkState

--- a/framework/py/flwr/supercore/task_process/agent/run_agentapp.py
+++ b/framework/py/flwr/supercore/task_process/agent/run_agentapp.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Flower AgentApp process."""
 
-
+import time
 from logging import DEBUG, ERROR
 from pathlib import Path
 from queue import Queue
@@ -32,8 +32,12 @@ from flwr.common.config import (
     get_project_config,
     get_project_dir,
 )
-from flwr.common.constant import RUNTIME_DEPENDENCY_INSTALL, SubStatus
-from flwr.common.logger import flush_logs, log, start_log_uploader, stop_log_uploader
+from flwr.common.constant import (
+    RUNTIME_DEPENDENCY_INSTALL,
+    TASK_WORKER_CALL_TIMEOUT,
+    SubStatus,
+)
+from flwr.common.logger import log, start_log_uploader, stop_log_uploader
 from flwr.common.serde import (
     context_from_proto,
     context_to_proto,
@@ -49,6 +53,10 @@ from flwr.proto.runtime_pb2 import (  # pylint: disable=E0611
     PushTaskOutputRequest,
 )
 from flwr.supercore.app_utils import start_parent_process_monitor
+from flwr.supercore.constant import (
+    EXIT_HANDLER_CLEANUP_TIMEOUT_SECONDS,
+    EXIT_HANDLER_TIMEOUT_SECONDS,
+)
 from flwr.supercore.exit import ExitCode, flwr_exit, register_signal_handlers
 from flwr.supercore.heartbeat import HeartbeatSender, make_task_heartbeat_fn_grpc
 from flwr.supercore.object_ref import load_app
@@ -101,26 +109,37 @@ def run_agentapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
     def on_exit() -> None:
         log(DEBUG, "[flwr-agentapp] Will push AgentApp task output")
 
-        grid._retry_invoker.max_tries = 1
+        # Disable retries and interrupt active backoff before bounded shutdown.
+        grid._retry_invoker.disable_retries()
+        started_at = time.monotonic()
+        cleanup_deadline = started_at + EXIT_HANDLER_CLEANUP_TIMEOUT_SECONDS
+        exit_deadline = started_at + EXIT_HANDLER_TIMEOUT_SECONDS
 
+        if heartbeat_sender and heartbeat_sender.is_running:
+            heartbeat_sender.stop(timeout=max(0.0, cleanup_deadline - time.monotonic()))
+
+        # Drain queued logs and stop the uploader within the cleanup budget.
         if log_uploader:
-            flush_logs(log_queue)
-
+            stop_log_uploader(
+                log_queue,
+                log_uploader,
+                timeout=max(0.0, cleanup_deadline - time.monotonic()),
+            )
+        # Push the task output last because finishing the task revokes its token.
         pushoutput_req = PushTaskOutputRequest(
             context=context_to_proto(context) if context else None,
             sub_status=sub_status,
             details=details,
         )
         try:
-            grid._stub.PushTaskOutput(pushoutput_req)
+            # Do not use the one-second worker deadline: give this critical final
+            # write the remaining exit-handler budget.
+            grid._stub.PushTaskOutput(
+                pushoutput_req,
+                timeout=max(0.0, exit_deadline - time.monotonic()),
+            )
         except grpc.RpcError as err:
             log(ERROR, "Failed to push task output: %s", str(err))
-
-        if log_uploader:
-            stop_log_uploader(log_queue, log_uploader)
-
-        if heartbeat_sender and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
 
         grid.close()
 
@@ -133,7 +152,10 @@ def run_agentapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
     )
 
     try:
-        heartbeat_sender = HeartbeatSender(make_task_heartbeat_fn_grpc(grid._stub))
+        heartbeat_sender = HeartbeatSender(
+            make_task_heartbeat_fn_grpc(grid._stub),
+            call_timeout=TASK_WORKER_CALL_TIMEOUT,
+        )
         heartbeat_sender.start()
 
         log(DEBUG, "[flwr-agentapp] Pull task input")

--- a/framework/py/flwr/superlink/runtime/run_serverapp.py
+++ b/framework/py/flwr/superlink/runtime/run_serverapp.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Flower ServerApp runtime."""
 
-
+import time
 from logging import DEBUG, ERROR
 from pathlib import Path
 from queue import Queue
@@ -31,8 +31,12 @@ from flwr.common.config import (
     get_project_config,
     get_project_dir,
 )
-from flwr.common.constant import RUNTIME_DEPENDENCY_INSTALL, SubStatus
-from flwr.common.logger import flush_logs, log, start_log_uploader, stop_log_uploader
+from flwr.common.constant import (
+    RUNTIME_DEPENDENCY_INSTALL,
+    TASK_WORKER_CALL_TIMEOUT,
+    SubStatus,
+)
+from flwr.common.logger import log, start_log_uploader, stop_log_uploader
 from flwr.common.serde import (
     context_from_proto,
     context_to_proto,
@@ -46,6 +50,10 @@ from flwr.proto.runtime_pb2 import (  # pylint: disable=E0611
 )
 from flwr.server.run_serverapp import run as run_
 from flwr.supercore.app_utils import start_parent_process_monitor
+from flwr.supercore.constant import (
+    EXIT_HANDLER_CLEANUP_TIMEOUT_SECONDS,
+    EXIT_HANDLER_TIMEOUT_SECONDS,
+)
 from flwr.supercore.exit import ExitCode, flwr_exit, register_signal_handlers
 from flwr.supercore.heartbeat import HeartbeatSender, make_task_heartbeat_fn_grpc
 from flwr.supercore.superexec.dependency_installer import (
@@ -93,13 +101,23 @@ def run_serverapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
     def on_exit() -> None:
         log(DEBUG, "[flwr-serverapp] Will push ServerApp task output")
 
-        # Set Grpc max retries to 1 to avoid blocking on exit
-        grid._retry_invoker.max_tries = 1
+        # Disable retries and interrupt active backoff before bounded shutdown.
+        grid._retry_invoker.disable_retries()
+        started_at = time.monotonic()
+        cleanup_deadline = started_at + EXIT_HANDLER_CLEANUP_TIMEOUT_SECONDS
+        exit_deadline = started_at + EXIT_HANDLER_TIMEOUT_SECONDS
 
-        # Upload any remaining logs before pushing final output
+        # Stop authenticated background workers before pushing final output.
+        if heartbeat_sender and heartbeat_sender.is_running:
+            heartbeat_sender.stop(timeout=max(0.0, cleanup_deadline - time.monotonic()))
+
+        # Drain queued logs and stop the uploader within the cleanup budget.
         if log_uploader:
-            flush_logs(log_queue)
-
+            stop_log_uploader(
+                log_queue,
+                log_uploader,
+                timeout=max(0.0, cleanup_deadline - time.monotonic()),
+            )
         # Push final status and context (if available)
         pushoutput_req = PushTaskOutputRequest(
             context=context_to_proto(context) if context else None,
@@ -107,17 +125,14 @@ def run_serverapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
             details=details,
         )
         try:
-            grid._stub.PushTaskOutput(pushoutput_req)
+            # Do not use the one-second worker deadline: give this critical final
+            # write the remaining exit-handler budget.
+            grid._stub.PushTaskOutput(
+                pushoutput_req,
+                timeout=max(0.0, exit_deadline - time.monotonic()),
+            )
         except grpc.RpcError as err:
             log(ERROR, "Failed to push task output: %s", str(err))
-
-        # Stop log uploader for this run and upload final logs
-        if log_uploader:
-            stop_log_uploader(log_queue, log_uploader)
-
-        # Stop heartbeat sender
-        if heartbeat_sender and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
 
         # Close the Grpc connection
         grid.close()
@@ -134,7 +149,10 @@ def run_serverapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
 
     try:
         # Set up heartbeat sender
-        heartbeat_sender = HeartbeatSender(make_task_heartbeat_fn_grpc(grid._stub))
+        heartbeat_sender = HeartbeatSender(
+            make_task_heartbeat_fn_grpc(grid._stub),
+            call_timeout=TASK_WORKER_CALL_TIMEOUT,
+        )
         heartbeat_sender.start()
 
         # Pull task input from SuperLink

--- a/framework/py/flwr/superlink/runtime/run_serverapp_test.py
+++ b/framework/py/flwr/superlink/runtime/run_serverapp_test.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the ServerApp runtime."""
+
+
+from queue import Queue
+from unittest.mock import Mock, patch
+
+import pytest
+
+from .run_serverapp import run_serverapp
+
+
+# pylint: disable=protected-access
+def test_exit_stops_background_workers_before_task_output() -> None:
+    """Test that shutdown preserves time for final task output."""
+    log_queue: Queue[str | None] = Queue()
+    grid = Mock()
+    grid._stub.PullTaskInput.return_value = Mock()
+    heartbeat_sender = Mock(is_running=True)
+    log_uploader = Mock()
+    run = Mock(run_id=123)
+    fab = Mock(content=b"fab")
+    call_order = []
+
+    with (
+        patch("flwr.superlink.runtime.run_serverapp.GrpcGrid", return_value=grid),
+        patch(
+            "flwr.superlink.runtime.run_serverapp.HeartbeatSender",
+            return_value=heartbeat_sender,
+        ),
+        patch(
+            "flwr.superlink.runtime.run_serverapp.context_from_proto",
+            return_value=None,
+        ),
+        patch(
+            "flwr.superlink.runtime.run_serverapp.run_from_proto",
+            return_value=run,
+        ),
+        patch(
+            "flwr.superlink.runtime.run_serverapp.fab_from_proto",
+            return_value=fab,
+        ),
+        patch(
+            "flwr.superlink.runtime.run_serverapp.get_sha256_hash",
+            return_value="hash",
+        ),
+        patch(
+            "flwr.superlink.runtime.run_serverapp.start_log_uploader",
+            return_value=log_uploader,
+        ),
+        patch(
+            "flwr.superlink.runtime.run_serverapp.install_from_fab",
+            side_effect=RuntimeError("stop after background workers start"),
+        ),
+        patch(
+            "flwr.superlink.runtime.run_serverapp.register_signal_handlers"
+        ) as register_signal_handlers,
+        patch("flwr.superlink.runtime.run_serverapp.flwr_exit"),
+        patch(
+            "flwr.superlink.runtime.run_serverapp.stop_log_uploader"
+        ) as stop_log_uploader,
+        patch(
+            "flwr.superlink.runtime.run_serverapp.cleanup_app_runtime_environment"
+        ) as cleanup_runtime_environment,
+        patch(
+            "flwr.superlink.runtime.run_serverapp.time.monotonic",
+            side_effect=[10.0, 10.5, 10.75, 11.0],
+        ),
+    ):
+        grid._retry_invoker.disable_retries.side_effect = lambda: call_order.append(
+            "disable_retries"
+        )
+        stop_log_uploader.side_effect = lambda *args, **kwargs: call_order.append(
+            "stop_logs"
+        )
+        heartbeat_sender.stop.side_effect = lambda *args, **kwargs: call_order.append(
+            "stop_heartbeat"
+        )
+        grid._stub.PushTaskOutput.side_effect = lambda *args, **kwargs: (
+            call_order.append("push_output")
+        )
+        grid.close.side_effect = lambda: call_order.append("close")
+        cleanup_runtime_environment.side_effect = (
+            lambda *_args, **_kwargs: call_order.append("cleanup")
+        )
+
+        run_serverapp(
+            runtime_api_address="127.0.0.1:9091",
+            log_queue=log_queue,
+            token="token",
+            insecure=True,
+        )
+        exit_handler = register_signal_handlers.call_args.kwargs["exit_handlers"][0]
+        exit_handler()
+
+    assert call_order == [
+        "disable_retries",
+        "stop_heartbeat",
+        "stop_logs",
+        "push_output",
+        "close",
+        "cleanup",
+    ]
+    assert heartbeat_sender.stop.call_args.kwargs["timeout"] == pytest.approx(2.0)
+    assert stop_log_uploader.call_args.kwargs["timeout"] == pytest.approx(1.75)
+    assert grid._stub.PushTaskOutput.call_args.kwargs["timeout"] == pytest.approx(3.5)


### PR DESCRIPTION
## What changed

- stop heartbeat workers before task completion in AgentApp, ServerApp, and Simulation executors
- drain and stop log uploaders within the same cleanup budget
- send final task output with only the remaining exit-handler time
- close the runtime connection after the final output attempt

## Why

These executors have two authenticated background workers. Both must stop before task completion revokes the token, but their sequential cleanup must not consume the time reserved for final task output.

```mermaid
sequenceDiagram
    participant E as Executor
    participant H as Heartbeat worker
    participant L as Log uploader
    participant R as Runtime API
    E->>E: Disable retries
    E->>H: Stop
    E->>L: Drain and stop
    Note over H,L: Shared 2.5s cleanup deadline
    E->>R: PushTaskOutput with remaining deadline
    E->>E: Close transport
```

## Stack

Umbrella/reference: [#7895 — Prevent task executor shutdown deadlock](https://github.com/flwrlabs/flower/pull/7895)

- Previous: [#7919 — Stop heartbeat executors before completion](https://github.com/flwrlabs/flower/pull/7919)
- This PR: **#7920 — Stop logging executors before completion**
- Next: [#7921 — Preserve output before runtime cleanup](https://github.com/flwrlabs/flower/pull/7921)

Merge the stack in order. After the previous PR merges, retarget this PR to `main`.

## Validation

- `pytest py/flwr/superlink/runtime/run_serverapp_test.py py/flwr/simulation/app_test.py`
- Ruff and Black on the changed executor modules
- `git diff --check`