### PR TITLE
fix(framework): Preserve output before runtime cleanup

### DIFF
--- a/framework/py/flwr/supercore/exit/exit_handler.py
+++ b/framework/py/flwr/supercore/exit/exit_handler.py
@@ -35,7 +35,9 @@ if hasattr(signal, "SIGQUIT"):
     SIGNAL_TO_EXIT_CODE[signal.SIGQUIT] = ExitCode.GRACEFUL_EXIT_SIGQUIT
 
 
-def add_exit_handler(exit_handler: Callable[[], None]) -> None:
+def add_exit_handler(
+    exit_handler: Callable[[], None], *, run_after_existing: bool = False
+) -> None:
     """Add an exit handler to be called on graceful exit.
 
     This function allows you to register additional exit handlers
@@ -46,14 +48,20 @@ def add_exit_handler(exit_handler: Callable[[], None]) -> None:
     exit_handler : Callable[[], None]
         A callable that takes no arguments and performs cleanup or
         other actions before the application exits.
+    run_after_existing : bool (default: False)
+        If True, run this handler after all handlers currently registered.
 
     Notes
     -----
-    The registered exit handlers will be called in LIFO order, i.e.,
-    the last registered handler will be the first to be called.
+    By default, registered exit handlers are called in LIFO order. A handler
+    added with ``run_after_existing=True`` is placed before existing handlers in
+    the registry so it runs after them when the registry is reversed.
     """
     with _lock_handlers:
-        registered_exit_handlers.append(exit_handler)
+        if run_after_existing:
+            registered_exit_handlers.insert(0, exit_handler)
+        else:
+            registered_exit_handlers.append(exit_handler)
 
 
 def trigger_exit_handlers() -> None:

--- a/framework/py/flwr/supercore/exit/exit_handler_test.py
+++ b/framework/py/flwr/supercore/exit/exit_handler_test.py
@@ -43,6 +43,19 @@ def test_trigger_exit_handlers() -> None:
     assert execution_order == [3, 2, 1]
 
 
+def test_exit_handler_can_run_after_existing_handlers() -> None:
+    """Test that low-priority cleanup runs after existing handlers."""
+    execution_order = []
+
+    add_exit_handler(lambda: execution_order.append(1))
+    add_exit_handler(lambda: execution_order.append(3), run_after_existing=True)
+    add_exit_handler(lambda: execution_order.append(2))
+
+    trigger_exit_handlers()
+
+    assert execution_order == [2, 1, 3]
+
+
 def test_trigger_exit_handlers_clears_list() -> None:
     """Test that trigger_exit_handlers clears the registered handlers."""
     # Prepare

--- a/framework/py/flwr/supercore/superexec/dependency_installer.py
+++ b/framework/py/flwr/supercore/superexec/dependency_installer.py
@@ -245,7 +245,10 @@ def _register_runtime_env_cleanup(runtime_env_dir: Path) -> None:
     def _clean() -> None:
         cleanup_app_runtime_environment(runtime_env_dir)
 
-    add_exit_handler(_clean)
+    # Task executors register their output handlers before dependency installation.
+    # Run environment cleanup afterwards so a slow deletion cannot prevent the final
+    # task status from being reported.
+    add_exit_handler(_clean, run_after_existing=True)
 
 
 def cleanup_app_runtime_environment(runtime_env_dir: Path | None) -> None:


### PR DESCRIPTION
## What changed

- allow an exit callback to run after callbacks that are already registered
- register runtime-environment deletion as low-priority cleanup
- preserve normal LIFO behavior for all other callbacks

## Why

Runtime dependency installation registered filesystem cleanup after the executor output handler. LIFO execution could therefore delete the environment before final task status and context were reported.

## Stack

Umbrella/reference: [#7895 — Prevent task executor shutdown deadlock](https://github.com/flwrlabs/flower/pull/7895)

- Previous: [#7920 — Stop logging executors before completion](https://github.com/flwrlabs/flower/pull/7920)
- This PR: **#7921 — Preserve output before runtime cleanup**
- Next: [#7922 — Interrupt Fleet retries during teardown](https://github.com/flwrlabs/flower/pull/7922)

Merge the stack in order. After the previous PR merges, retarget this PR to `main`.

## Validation

- `pytest py/flwr/supercore/exit/exit_handler_test.py py/flwr/supercore/superexec/dependency_installer_test.py`
- Ruff and Black on the changed modules
- `git diff --check`