### PR TITLE
fix(framework): Interrupt Fleet retries during teardown

### DIFF
--- a/framework/py/flwr/client/grpc_rere_client/connection.py
+++ b/framework/py/flwr/client/grpc_rere_client/connection.py
@@ -386,8 +386,9 @@ def grpc_request_response(  # pylint: disable=R0913,R0914,R0915,R0917
     finally:
         try:
             if node is not None:
-                # Disable retrying
-                retry_invoker.max_tries = 1
+                # Interrupt active retries before teardown RPCs. Merely lowering the
+                # attempt limit does not wake a call already waiting in backoff.
+                retry_invoker.disable_retries()
                 deactivate_node()
                 if self_registered:
                     unregister_node()

--- a/framework/py/flwr/client/grpc_rere_client/node_auth_client_interceptor_test.py
+++ b/framework/py/flwr/client/grpc_rere_client/node_auth_client_interceptor_test.py
@@ -196,10 +196,11 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
     def test_client_auth_rpc(self, grpc_call: Callable[[Any], None]) -> None:
         """Test SuperNode authentication during create node."""
         # Execute
+        retry_invoker = Mock(invoke=lambda fn, *args, **kwargs: fn(*args, **kwargs))
         with self._connection(
             self._address,
             True,
-            Mock(invoke=lambda fn, *args, **kwargs: fn(*args, **kwargs)),
+            retry_invoker,
             GRPC_MAX_MESSAGE_LENGTH,
             None,
             (self._client_private_key, self._client_public_key),
@@ -226,3 +227,5 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             assert verify_signature(
                 self._client_public_key, timestamp.encode("ascii"), signature
             )
+
+        retry_invoker.disable_retries.assert_called_once_with()


### PR DESCRIPTION
## What changed

- disable the Fleet retry coordinator before node teardown RPCs
- wake an active heartbeat backoff instead of only lowering its future attempt limit
- verify authenticated connection cleanup invokes retry cancellation

## Why

A Fleet heartbeat already waiting in backoff could survive SIGTERM cleanup and keep connection teardown blocked. Explicit cancellation wakes that wait before deactivation and unregister calls run.

## Stack

Umbrella/reference: [#7895 — Prevent task executor shutdown deadlock](https://github.com/flwrlabs/flower/pull/7895)

- Previous: [#7921 — Preserve output before runtime cleanup](https://github.com/flwrlabs/flower/pull/7921)
- This PR: **#7922 — Interrupt Fleet retries during teardown**
- Next: End of stack

Merge the stack in order. After the previous PR merges, retarget this PR to `main`.

## Validation

- `pytest py/flwr/client/grpc_rere_client/node_auth_client_interceptor_test.py`
- Ruff and Black on the changed connection modules
- `git diff --check`