### PR TITLE
deps: bump monai to 1.6.0 in quickstart-monai example

### DIFF
--- a/examples/quickstart-monai/pyproject.toml
+++ b/examples/quickstart-monai/pyproject.toml
@@ -10,7 +10,7 @@ license = {file = "LICENSE"}
 dependencies = [
     "flwr[simulation]>=1.28.0",
     "flwr-datasets[vision]>=0.6.0",
-    "monai==1.5.2",
+    "monai==1.6.0",
     "filelock==3.20.3",
     "numpy>=2.0.0",
 ]


### PR DESCRIPTION
Updates `monai` to 1.6.0 in the `quickstart-monai` example.

Evidence:
- `examples/quickstart-monai/pyproject.toml` referenced `monai==1.5.2`
- pip-audit reported GHSA-89gg-p5r5-q6r4, GHSA-wg9g-w2j2-8pgr, GHSA-qxq5-qhx6-94qw and GHSA-rghg-q7wp-9767 for `monai 1.5.2`
- updated version: `monai==1.6.0`

Validation:
- pip-audit reports no advisories for `monai 1.6.0`
- TOML parses clean after the change; the repo's `dev/test.sh` TOML formatting step (taplo) was not run locally because taplo is not installed here

Scope: dependency bump only.
