### PR TITLE
ci(framework): Fix Docker release tag promotion

### DIFF
--- a/.github/workflows/framework-release-finalize.yml
+++ b/.github/workflows/framework-release-finalize.yml
@@ -151,7 +151,7 @@ jobs:
               tag_suffix="${unstable_tag#"${repository}:unstable"}"
               tag_args+=(-t "${repository}:${VERSION}${tag_suffix}")
 
-              # Add stable aliases to the variants defined by DOCKER_TAG_GROUPS.
+              # Add stable aliases explicitly for the current release variants.
               case "${repository_name}:${tag_suffix}" in
                 "superlink:-py3.13-alpine3.22"|"supernode:-py3.13-alpine3.22")
                   tag_args+=(-t "${repository}:${VERSION}")

--- a/.github/workflows/framework-release-finalize.yml
+++ b/.github/workflows/framework-release-finalize.yml
@@ -139,13 +139,30 @@ jobs:
           # Process each built image recorded in the digest manifest.
           while IFS= read -r image; do
             repository="$(jq -r '.repository' <<< "${image}")"
+            repository_name="${repository##*/}"
             index_digest="$(jq -r '.index_digest' <<< "${image}")"
             tag_args=()
 
-            # Derive stable version tags from every unstable tag variant.
+            # Derive variant-specific stable tags from unstable variant tags.
             while IFS= read -r unstable_tag; do
+              if [[ "${unstable_tag}" != "${repository}:unstable-"* ]]; then
+                continue
+              fi
               tag_suffix="${unstable_tag#"${repository}:unstable"}"
               tag_args+=(-t "${repository}:${VERSION}${tag_suffix}")
+
+              # Add stable aliases to the variants defined by DOCKER_TAG_GROUPS.
+              case "${repository_name}:${tag_suffix}" in
+                "superlink:-py3.13-alpine3.22"|"supernode:-py3.13-alpine3.22")
+                  tag_args+=(-t "${repository}:${VERSION}")
+                  ;;
+                "superlink:-py3.13-ubuntu24.04"|"supernode:-py3.13-ubuntu24.04")
+                  tag_args+=(-t "${repository}:latest")
+                  ;;
+                "superexec:-py3.13-ubuntu24.04")
+                  tag_args+=(-t "${repository}:${VERSION}" -t "${repository}:latest")
+                  ;;
+              esac
             done < <(jq -r '.tags[]' <<< "${image}")
 
             # Promote the immutable multi-platform image without rebuilding it.


### PR DESCRIPTION
## What changed

- Promote only variant-specific `unstable-*` tags to versioned release tags.
- Add the bare release version and `latest` aliases explicitly to the OCI indexes selected by `DOCKER_TAG_GROUPS`.
- Derive the image repository name from the final component of the fully qualified repository path.

## Why

The finalize workflow previously replaced the `unstable` prefix mechanically. Because the Python 3.13 Ubuntu build also carries the bare `unstable` tag, this created `base:<version>`, pointed the SuperLink and SuperNode release aliases at Ubuntu instead of Alpine, and did not update `latest`.

The corrected promotion keeps the existing public Docker tag policy and continues promoting the already-built OCI indexes from `digests.json` without rebuilding images.

## Validation

- Exercised the workflow's promotion script against the complete generated 13-index unstable build matrix.
- Compared all generated promotion targets directly with `DOCKER_TAG_GROUPS` for release `1.34.0`.
- Verified repository detection with a registry hostname containing a port and a nested namespace.
- Parsed the workflow YAML and checked the embedded Bash syntax.
- Ran `git diff --check`.

No Docker README changes are needed because the documented tag policy is unchanged.