### PR TITLE
ci(framework): Fix ref creation in release workflow

### DIFF
--- a/.github/workflows/framework-release-finalize.yml
+++ b/.github/workflows/framework-release-finalize.yml
@@ -63,19 +63,20 @@ jobs:
             local ref="$1"
             local existing_sha
 
-            existing_sha="$(
+            if existing_sha="$(
               gh api "repos/${GITHUB_REPOSITORY}/git/ref/${ref#refs/}" \
-                --jq '.object.sha' 2>/dev/null || true
-            )"
-            if [[ -z "${existing_sha}" ]]; then
+                --jq '.object.sha' 2>/dev/null
+            )"; then
+              if [[ "${existing_sha}" != "${RELEASE_SOURCE_SHA}" ]]; then
+                echo "${ref} points to ${existing_sha}, expected ${RELEASE_SOURCE_SHA}." >&2
+                exit 1
+              fi
+
+              echo "${ref} already points to ${RELEASE_SOURCE_SHA}; continuing."
+            else
               gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
                 -f ref="${ref}" \
                 -f sha="${RELEASE_SOURCE_SHA}"
-            elif [[ "${existing_sha}" != "${RELEASE_SOURCE_SHA}" ]]; then
-              echo "${ref} points to ${existing_sha}, expected ${RELEASE_SOURCE_SHA}." >&2
-              exit 1
-            else
-              echo "${ref} already points to ${RELEASE_SOURCE_SHA}; continuing."
             fi
           }
 


### PR DESCRIPTION
## What changed

- Branch on the exit status of the GitHub ref lookup.
- Verify that an existing release tag or maintenance branch points to the expected release source SHA.
- Create the ref only when the lookup fails because it is absent.

## Why

The previous command substitution suppressed the lookup status with `|| true` and inferred ref existence from whether stdout was empty. That discarded the API result used to decide between verification and creation.

This keeps framework release finalization retries idempotent while preserving the conflict check for refs that already exist.

## Validation

- `PYTHONPATH=dev "$(uv python find 3.11.14)" -m devtool.check_pr_title 'ci(framework): Fix ref creation in release workflow'`
- `git diff --cached --check`