### PR TITLE
fix(framework): Restore SuperLink HTTP logging configuration

### DIFF
--- a/framework/py/flwr/supercore/http_logging.py
+++ b/framework/py/flwr/supercore/http_logging.py
@@ -17,7 +17,6 @@
 import logging
 import time
 from typing import Any
-from urllib.parse import urlsplit
 
 HEALTH_CHECK_PATH = "/health"
 LOG_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
@@ -71,7 +70,8 @@ class HealthCheckAccessFilter(logging.Filter):
                 return False
         else:
             return False
-        return urlsplit(raw_path).path == HEALTH_CHECK_PATH and status_code < 400
+        path, _, _ = raw_path.partition("?")
+        return path == HEALTH_CHECK_PATH and status_code < 400
 
 
 def get_uvicorn_log_config(log_level: int) -> dict[str, Any]:

--- a/framework/py/flwr/supercore/http_logging.py
+++ b/framework/py/flwr/supercore/http_logging.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""HTTP server logging configuration."""
+
+import logging
+import time
+from typing import Any
+from urllib.parse import urlsplit
+
+HEALTH_CHECK_PATH = "/health"
+LOG_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
+LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] %(message)s"
+
+
+class UTCFormatter(logging.Formatter):
+    """Format log timestamps as UTC ISO-8601 values."""
+
+    @staticmethod
+    def converter(timestamp: float | None = None) -> time.struct_time:
+        """Convert a timestamp to UTC."""
+        return time.gmtime(timestamp)
+
+    default_time_format = LOG_DATE_FORMAT
+    default_msec_format = "%s.%03dZ"
+
+
+class HealthCheckAccessFilter(logging.Filter):
+    """Hide successful health-check access logs unless debug is enabled."""
+
+    def __init__(self, debug_enabled: bool = False) -> None:
+        super().__init__()
+        self.debug_enabled = debug_enabled
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Return whether the log record should be emitted."""
+        if not self._is_successful_health_check(record):
+            return True
+        if not self.debug_enabled:
+            return False
+        record.levelno = logging.DEBUG
+        record.levelname = "DEBUG"
+        return True
+
+    @staticmethod
+    def _is_successful_health_check(record: logging.LogRecord) -> bool:
+        if record.name != "uvicorn.access":
+            return False
+        if not isinstance(record.args, tuple) or len(record.args) < 5:
+            return False
+
+        raw_path = str(record.args[2])
+        raw_status_code = record.args[4]
+        if isinstance(raw_status_code, int):
+            status_code = raw_status_code
+        elif isinstance(raw_status_code, str):
+            try:
+                status_code = int(raw_status_code)
+            except ValueError:
+                return False
+        else:
+            return False
+        return urlsplit(raw_path).path == HEALTH_CHECK_PATH and status_code < 400
+
+
+def get_uvicorn_log_config(log_level: int) -> dict[str, Any]:
+    """Return Uvicorn logging configuration for the SuperLink HTTP API."""
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "http": {
+                "()": UTCFormatter,
+                "format": LOG_FORMAT,
+            }
+        },
+        "filters": {
+            "health_check_access": {
+                "()": HealthCheckAccessFilter,
+                "debug_enabled": log_level <= logging.DEBUG,
+            }
+        },
+        "handlers": {
+            "default": {
+                "class": "logging.StreamHandler",
+                "formatter": "http",
+                "stream": "ext://sys.stdout",
+            },
+            "access": {
+                "class": "logging.StreamHandler",
+                "filters": ["health_check_access"],
+                "formatter": "http",
+                "stream": "ext://sys.stdout",
+            },
+        },
+        "loggers": {
+            "httpcore": {
+                "level": "WARNING",
+                "propagate": True,
+            },
+            "httpx": {
+                "level": "WARNING",
+                "propagate": True,
+            },
+            "uvicorn": {
+                "handlers": ["default"],
+                "level": log_level,
+                "propagate": False,
+            },
+            "uvicorn.access": {
+                "handlers": ["access"],
+                "level": log_level,
+                "propagate": False,
+            },
+            "uvicorn.error": {
+                "level": log_level,
+            },
+        },
+    }

--- a/framework/py/flwr/supercore/http_logging_test.py
+++ b/framework/py/flwr/supercore/http_logging_test.py
@@ -45,6 +45,7 @@ def _access_record(path: str, status_code: object) -> logging.LogRecord:
         ("/health?probe=readiness", "200", False),
         ("/health", 500, True),
         ("/v1/user/profile", 200, True),
+        ("//[", 200, True),
     ],
 )
 def test_health_check_access_filter(

--- a/framework/py/flwr/supercore/http_logging_test.py
+++ b/framework/py/flwr/supercore/http_logging_test.py
@@ -1,0 +1,96 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""HTTP server logging configuration tests."""
+
+import logging
+
+import pytest
+
+from .http_logging import (
+    LOG_FORMAT,
+    HealthCheckAccessFilter,
+    UTCFormatter,
+    get_uvicorn_log_config,
+)
+
+
+def _access_record(path: str, status_code: object) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=("127.0.0.1:12345", "GET", path, "1.1", status_code),
+        exc_info=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "status_code", "expected"),
+    [
+        ("/health", 200, False),
+        ("/health?probe=readiness", "200", False),
+        ("/health", 500, True),
+        ("/v1/user/profile", 200, True),
+    ],
+)
+def test_health_check_access_filter(
+    path: str, status_code: object, expected: bool
+) -> None:
+    """Filter only successful health-check access records."""
+    assert (
+        HealthCheckAccessFilter().filter(_access_record(path, status_code)) is expected
+    )
+
+
+def test_health_check_access_filter_keeps_health_checks_at_debug() -> None:
+    """Keep successful health checks as debug records in debug mode."""
+    record = _access_record("/health", 200)
+
+    assert HealthCheckAccessFilter(debug_enabled=True).filter(record)
+    assert record.levelno == logging.DEBUG
+    assert record.levelname == "DEBUG"
+
+
+def test_utc_formatter_uses_expected_http_format() -> None:
+    """Format HTTP records with an ISO-8601 UTC timestamp."""
+    record = _access_record("/v1/user/profile", 200)
+    record.created = 0.123
+    record.msecs = 123
+
+    assert UTCFormatter(LOG_FORMAT).format(record) == (
+        "1970-01-01T00:00:00.123Z INFO [uvicorn.access] "
+        '127.0.0.1:12345 - "GET /v1/user/profile HTTP/1.1" 200'
+    )
+
+
+def test_get_uvicorn_log_config_keeps_configuration_scoped() -> None:
+    """Configure Uvicorn and noisy HTTP clients without replacing root logging."""
+    config = get_uvicorn_log_config(logging.INFO)
+
+    assert "root" not in config
+    assert config["handlers"]["default"]["stream"] == "ext://sys.stdout"
+    assert config["loggers"]["uvicorn.access"]["handlers"] == ["access"]
+    assert config["loggers"]["httpx"]["level"] == "WARNING"
+    assert config["loggers"]["httpcore"]["level"] == "WARNING"
+    assert not config["filters"]["health_check_access"]["debug_enabled"]
+
+
+def test_get_uvicorn_log_config_enables_debug_health_checks() -> None:
+    """Pass debug state to the health-check filter."""
+    config = get_uvicorn_log_config(logging.DEBUG)
+
+    assert config["filters"]["health_check_access"]["debug_enabled"]

--- a/framework/py/flwr/superlink/cli/flower_superlink.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink.py
@@ -73,11 +73,12 @@ from flwr.supercore.constant import (
 from flwr.supercore.exit import ExitCode, flwr_exit, register_signal_handlers
 from flwr.supercore.grpc import GRPC_MAX_MESSAGE_LENGTH, generic_create_grpc_server
 from flwr.supercore.grpc_health import add_args_health, run_health_server_grpc_no_tls
+from flwr.supercore.http_logging import get_uvicorn_log_config
 from flwr.supercore.interceptors import (
     RpcErrorTranslationServerInterceptor,
     create_fleet_runtime_version_server_interceptor,
 )
-from flwr.supercore.logger import configure_superlink_log_file
+from flwr.supercore.logger import configure_superlink_log_file, console_handler
 from flwr.supercore.object_store import ObjectStoreFactory
 from flwr.supercore.telemetry import EventType, event
 from flwr.supercore.tls import (
@@ -590,6 +591,7 @@ def _run_superlink_http_api(lifespan_config: SuperLinkLifespanConfig) -> None:
         port=lifespan_config.port,
         reload=False,
         access_log=True,
+        log_config=get_uvicorn_log_config(console_handler.level),
         ssl_keyfile=None if lifespan_config.insecure else lifespan_config.ssl_keyfile,
         ssl_certfile=None if lifespan_config.insecure else lifespan_config.ssl_certfile,
         workers=1,


### PR DESCRIPTION
This PR restores the SuperLink HTTP logging configuration. Successful `/health` access logs are filtered, Uvicorn logs use UTC timestamps, and noisy `httpx` and `httpcore` logs are suppressed. Note that the configuration is applied explicitly when starting Uvicorn without modifying root logging at import time.