### PR TITLE
refactor(framework): make HTTP error JSON canonical

### DIFF
--- a/framework/py/flwr/cli/utils_test.py
+++ b/framework/py/flwr/cli/utils_test.py
@@ -36,7 +36,6 @@ from flwr.cli.typing import SuperLinkConnection, SuperLinkSimulationOptions
 from flwr.common.constant import FLWR_DIR
 from flwr.supercore.constant import MAX_DIR_DEPTH, MAX_NAME_LENGTH
 from flwr.supercore.error import ApiErrorCode, FlowerError
-from flwr.supercore.error.catalog import API_ERROR_MAP
 from flwr.supercore.grpc import GRPC_MAX_MESSAGE_LENGTH
 from flwr.supercore.interceptors import RuntimeVersionClientInterceptor
 
@@ -56,29 +55,6 @@ from .utils import (
     validate_federation_name,
     wait_for_control_api_channel,
 )
-
-
-class _GrpcErrorWithDetails:
-    """Test helper object carrying a gRPC-like details string."""
-
-    def __init__(self, details: str) -> None:
-        self._details = details
-
-    def details(self) -> str:
-        """Return the stored gRPC details string."""
-        return self._details
-
-
-def _grpc_error_with_details(details: str) -> grpc.RpcError:
-    """Return a grpc.RpcError-compatible test helper with a details method."""
-    return cast(grpc.RpcError, _GrpcErrorWithDetails(details))
-
-
-def _flower_error_details(code: ApiErrorCode, public_details: str | None = None) -> str:
-    """Return serialized FlowerError details as sent through gRPC."""
-    return FlowerError(code, "internal details", public_details).to_json(
-        API_ERROR_MAP[code].public_message
-    )
 
 
 class TestGetSHA256Hash(unittest.TestCase):

--- a/framework/py/flwr/supercore/error/base.py
+++ b/framework/py/flwr/supercore/error/base.py
@@ -45,8 +45,8 @@ class FlowerError(Exception):
         self.message = message  # Sensitive message
         self.public_details = public_details
 
-    def to_json(self, public_message: str) -> str:
-        """Serialize the client-visible error payload as JSON.
+    def to_json(self, public_message: str) -> dict[str, int | str]:
+        """Return the client-visible HTTP error payload as a JSON dictionary.
 
         Parameters
         ----------
@@ -56,17 +56,17 @@ class FlowerError(Exception):
 
         Returns
         -------
-        str
-            A JSON string containing the error code, the client-visible message,
-            and any client-safe details attached to the error.
+        dict[str, int | str]
+            A JSON dictionary containing the error code and client-visible detail,
+            plus any client-safe extra information attached to the error.
         """
-        return json.dumps(
-            {
-                "code": self.code,
-                "public_message": public_message,
-                "public_details": self.public_details,
-            }
-        )
+        payload: dict[str, int | str] = {
+            "code": self.code,
+            "detail": public_message,
+        }
+        if self.public_details is not None:
+            payload["extra"] = self.public_details
+        return payload
 
     @staticmethod
     def from_json(value: str | None) -> FlowerError | None:

--- a/framework/py/flwr/supercore/error/exceptions.py
+++ b/framework/py/flwr/supercore/error/exceptions.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Concrete API error types."""
 
-
-import json
-
 from .base import ApiErrorCode, FlowerError
 
 
@@ -42,21 +39,8 @@ class EntitlementError(FlowerError):
         )
         self.entitlement_code = entitlement_code
 
-    def to_json(self, public_message: str) -> str:
-        """Serialize the entitlement error payload as JSON.
-
-        Parameters
-        ----------
-        public_message : str
-            Sanitized message that should be exposed to the client together with
-            the entitlement-specific details.
-
-        Returns
-        -------
-        str
-            A JSON string containing the base client-visible error fields plus
-            the entitlement code used for programmatic handling on the client.
-        """
-        base_dict = json.loads(super().to_json(public_message))
-        base_dict["entitlement_code"] = self.entitlement_code
-        return json.dumps(base_dict)
+    def to_json(self, public_message: str) -> dict[str, int | str]:
+        """Return the HTTP error payload with its entitlement code."""
+        payload = super().to_json(public_message)
+        payload["entitlement_code"] = self.entitlement_code
+        return payload

--- a/framework/py/flwr/supercore/error/grpc.py
+++ b/framework/py/flwr/supercore/error/grpc.py
@@ -15,6 +15,7 @@
 """GRPC-specific translation utilities for Flower API errors."""
 
 
+import json
 from collections.abc import Iterator
 from contextlib import contextmanager
 from logging import ERROR
@@ -28,6 +29,19 @@ from .base import FlowerError
 from .catalog import API_ERROR_MAP
 
 INTERNAL_SERVER_ERROR_MESSAGE = "Internal server error."
+
+
+def _flower_error_to_grpc_json(err: FlowerError, public_message: str) -> str:
+    """Serialize a FlowerError using the backward-compatible gRPC wire format."""
+    payload = err.to_json(public_message)
+    return json.dumps(
+        {
+            "code": payload.pop("code"),
+            "public_message": payload.pop("detail"),
+            "public_details": payload.pop("extra", None),
+            **payload,
+        }
+    )
 
 
 @contextmanager
@@ -50,7 +64,7 @@ def rpc_error_translator(
         msg = f"[{rpc_name}][ApiError:{err.code}] {err.message}"
         log(ERROR, msg)
         # Return sanitized error to client
-        context.abort(grpc_status, err.to_json(public_message))
+        context.abort(grpc_status, _flower_error_to_grpc_json(err, public_message))
         raise grpc.RpcError() from None  # Unreachable, but satisfies type checker
     except Exception as err:
         # Let pass through if `context.abort()` is called

--- a/framework/py/flwr/supercore/error/grpc_test.py
+++ b/framework/py/flwr/supercore/error/grpc_test.py
@@ -51,30 +51,36 @@ def test_rpc_error_translator_mapped_flower_error() -> None:
     }
 
 
-def test_flower_error_from_json() -> None:
-    """Deserialize the public FlowerError payload on the client side."""
+def test_flower_error_to_json_and_from_json() -> None:
+    """Serialize and deserialize the canonical HTTP FlowerError payload."""
     err = FlowerError(
         ApiErrorCode.RUNTIME_VERSION_INCOMPATIBLE,
         "internal diagnostic message",
         public_details="public details",
     )
 
-    parsed = FlowerError.from_json(err.to_json("public message"))
+    payload = err.to_json("public message")
+    parsed = FlowerError.from_json(json.dumps(payload))
 
+    assert payload == {
+        "code": ApiErrorCode.RUNTIME_VERSION_INCOMPATIBLE,
+        "detail": "public message",
+        "extra": "public details",
+    }
     assert parsed is not None
     assert parsed.code == ApiErrorCode.RUNTIME_VERSION_INCOMPATIBLE
     assert parsed.message == "public message"
     assert parsed.public_details == "public details"
 
 
-def test_flower_error_from_http_json() -> None:
-    """Deserialize the public HTTP FlowerError payload on the client side."""
+def test_flower_error_from_grpc_json() -> None:
+    """Continue to deserialize the legacy gRPC FlowerError payload."""
     parsed = FlowerError.from_json(
         json.dumps(
             {
-                "detail": "public message",
+                "public_message": "public message",
                 "code": ApiErrorCode.RUNTIME_VERSION_INCOMPATIBLE.value,
-                "extra": "public details",
+                "public_details": "public details",
             }
         )
     )
@@ -86,15 +92,22 @@ def test_flower_error_from_http_json() -> None:
 
 
 def test_flower_error_from_json_returns_base_error_for_subclass_call() -> None:
-    """Deserialize public payloads into a base FlowerError."""
+    """Use the base HTTP representation and deserialize into a base FlowerError."""
     err = EntitlementError(
         "internal diagnostic message",
         public_details="public details",
         entitlement_code=123,
     )
 
-    parsed = EntitlementError.from_json(err.to_json("public message"))
+    payload = err.to_json("public message")
+    parsed = EntitlementError.from_json(json.dumps(payload))
 
+    assert payload == {
+        "code": ApiErrorCode.ENTITLEMENT_ERROR,
+        "detail": "public message",
+        "extra": "public details",
+        "entitlement_code": 123,
+    }
     assert isinstance(parsed, FlowerError)
     assert not isinstance(parsed, EntitlementError)
     assert parsed.code == ApiErrorCode.ENTITLEMENT_ERROR

--- a/framework/py/flwr/supercore/error/http.py
+++ b/framework/py/flwr/supercore/error/http.py
@@ -32,19 +32,6 @@ INTERNAL_SERVER_ERROR_MESSAGE = "Internal server error."
 NOT_AUTHENTICATED_DETAIL = "Not authenticated"
 
 
-def _flower_error_content(
-    err: FlowerError, public_message: str
-) -> dict[str, str | int]:
-    """Build the client-visible HTTP payload for a mapped FlowerError."""
-    content: dict[str, str | int] = {
-        "detail": public_message,
-        "code": int(err.code),
-    }
-    if err.public_details is not None:
-        content["extra"] = err.public_details
-    return content
-
-
 class BearerAuthenticationError(HTTPException):
     """Represent failed HTTP Bearer authentication."""
 
@@ -73,23 +60,22 @@ async def http_error_translator(
     except FlowerError as err:
         try:
             error_spec = API_ERROR_MAP[err.code]
-            http_status = error_spec.http_status_code
-            content = _flower_error_content(err, error_spec.public_message)
-            http_headers = error_spec.http_headers
+            response = JSONResponse(
+                content=err.to_json(error_spec.public_message),
+                status_code=error_spec.http_status_code,
+                headers=error_spec.http_headers,
+            )
         except (ValueError, KeyError):
-            http_status = status.HTTP_500_INTERNAL_SERVER_ERROR
-            content = {"detail": INTERNAL_SERVER_ERROR_MESSAGE}
-            http_headers = None
+            response = JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={"detail": INTERNAL_SERVER_ERROR_MESSAGE},
+            )
 
         # Log error as is
         msg = f"[{request.url.path}][ApiError:{err.code}] {err.message}"
         log(ERROR, msg)
         # Return sanitized error to client
-        return JSONResponse(
-            status_code=http_status,
-            content=content,
-            headers=http_headers,
-        )
+        return response
     except HTTPException as err:
         return await http_exception_handler(request, err)
     except Exception as err:  # pylint: disable=broad-exception-caught

--- a/framework/py/flwr/supercore/error/http_test.py
+++ b/framework/py/flwr/supercore/error/http_test.py
@@ -23,7 +23,6 @@ from starlette.datastructures import State
 
 from .base import ApiErrorCode, FlowerError
 from .catalog import API_ERROR_MAP
-from .exceptions import EntitlementError
 from .http import (
     INTERNAL_SERVER_ERROR_MESSAGE,
     BearerAuthenticationError,
@@ -138,33 +137,6 @@ def test_http_error_translator_unmapped_flower_error() -> None:
         response,
         status.HTTP_500_INTERNAL_SERVER_ERROR,
         {"detail": INTERNAL_SERVER_ERROR_MESSAGE},
-    )
-    assert b"internal diagnostic message" not in response.body
-
-
-def test_http_error_translator_entitlement_error() -> None:
-    """Expose entitlement details and its application-level code."""
-    error_message = "Entitlement check failed: plan does not allow this action."
-    entitlement_code = 101
-
-    response = _run_translator(
-        EntitlementError(
-            "internal diagnostic message",
-            public_details=error_message,
-            entitlement_code=entitlement_code,
-        )
-    )
-
-    spec = API_ERROR_MAP[ApiErrorCode.ENTITLEMENT_ERROR]
-    _assert_json_response(
-        response,
-        spec.http_status_code,
-        {
-            "detail": spec.public_message,
-            "code": ApiErrorCode.ENTITLEMENT_ERROR,
-            "extra": error_message,
-            "entitlement_code": entitlement_code,
-        },
     )
     assert b"internal diagnostic message" not in response.body
 

--- a/framework/py/flwr/supercore/error/http_test.py
+++ b/framework/py/flwr/supercore/error/http_test.py
@@ -143,7 +143,7 @@ def test_http_error_translator_unmapped_flower_error() -> None:
 
 
 def test_http_error_translator_entitlement_error() -> None:
-    """Expose entitlement details without its entitlement code."""
+    """Expose entitlement details and its application-level code."""
     error_message = "Entitlement check failed: plan does not allow this action."
     entitlement_code = 101
 
@@ -161,8 +161,9 @@ def test_http_error_translator_entitlement_error() -> None:
         spec.http_status_code,
         {
             "detail": spec.public_message,
-            "code": ApiErrorCode.ENTITLEMENT_ERROR.value,
+            "code": ApiErrorCode.ENTITLEMENT_ERROR,
             "extra": error_message,
+            "entitlement_code": entitlement_code,
         },
     )
     assert b"internal diagnostic message" not in response.body

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor_test.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor_test.py
@@ -126,11 +126,13 @@ def _make_runtime_rpc_error(
     rpc_error = grpc.RpcError()
     rpc_error.trailing_metadata = Mock(return_value=())
     rpc_error.details = Mock(
-        return_value=FlowerError(
-            code,
-            "internal diagnostic message",
-            public_details="runtime mismatch",
-        ).to_json("Runtime version compatibility check failed.")
+        return_value=json.dumps(
+            FlowerError(
+                code,
+                "internal diagnostic message",
+                public_details="runtime mismatch",
+            ).to_json("Runtime version compatibility check failed.")
+        )
     )
     rpc_error.add_callback = Mock(return_value=False)
     return rpc_error


### PR DESCRIPTION
## Summary

- make FlowerError.to_json return the canonical HTTP error dictionary
- translate canonical HTTP keys to the backward-compatible gRPC wire format
- preserve application-level entitlement codes across HTTP and gRPC

## Testing

- targeted HTTP, gRPC, and runtime-version error tests
- Ruff, mypy, and pylint

This PR builds on #7890 and targets its json-errors branch.