### PR TITLE
feat(framework): Add run-started extension hook

### DIFF
--- a/framework/py/flwr/superlink/extensions.py
+++ b/framework/py/flwr/superlink/extensions.py
@@ -14,19 +14,24 @@
 # ==============================================================================
 """SuperLink FastAPI extension hooks."""
 
-
 from collections.abc import Callable, Mapping
 from contextlib import AbstractAsyncContextManager
+from copy import deepcopy
 from importlib import import_module
+from logging import WARNING
 from types import ModuleType
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from fastapi import FastAPI
 from starlette.middleware import Middleware
 
+from flwr.common.logger import log
+from flwr.supercore.run import Run
+
 SuperLinkLifespanContext = Callable[
     [FastAPI], AbstractAsyncContextManager[Mapping[str, Any] | None]
 ]
+RunStartSource = Literal["cli", "web_ui", "automation", "unknown"]
 _SGXT_MODULE = "flwr.ee.superlink.extensions"
 
 
@@ -87,3 +92,32 @@ def get_lifespan_contexts() -> tuple[SuperLinkLifespanContext, ...]:
     if get_sgxt_lifespan_contexts is None:
         return ()
     return get_sgxt_lifespan_contexts()
+
+
+def notify_run_started(run: Run, source: RunStartSource) -> None:
+    """Notify an optional extension after a run has been persisted.
+
+    The callback is synchronous by design. Extensions must keep this hook
+    non-blocking and best effort; the Flower framework does not create a
+    background thread or event loop for it. The run snapshot is copied before
+    handing it to the extension so the callback cannot mutate the object used
+    to build the successful StartRun response.
+    """
+    try:
+        sgxt = _try_import_sgxt()
+        if sgxt is None:
+            return
+
+        on_run_started = cast(
+            Callable[[Run, RunStartSource], None] | None,
+            getattr(sgxt, "on_run_started", None),
+        )
+        if on_run_started is not None:
+            on_run_started(deepcopy(run), source)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log(
+            WARNING,
+            "Run-start extension notification failed: %s.",
+            type(exc).__name__,
+            exc_info=exc,
+        )

--- a/framework/py/flwr/superlink/extensions_test.py
+++ b/framework/py/flwr/superlink/extensions_test.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for SuperLink extension notifications."""
+
+from types import ModuleType
+from unittest.mock import Mock
+
+from pytest import MonkeyPatch
+
+from flwr.supercore.run import Run
+
+from . import extensions
+
+
+def test_notify_run_started_passes_a_snapshot_to_the_extension(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Pass a copy of the persisted run to the optional extension."""
+    callback = Mock()
+    module = ModuleType("flwr.ee.superlink.extensions")
+    module.on_run_started = callback  # type: ignore[attr-defined]
+    monkeypatch.setattr(extensions, "_try_import_sgxt", lambda: module)
+    run = Run.create_empty(123)
+
+    extensions.notify_run_started(run, "unknown")
+
+    callback.assert_called_once()
+    notified_run, source = callback.call_args.args
+    assert notified_run == run
+    assert notified_run is not run
+    assert source == "unknown"
+
+
+def test_notify_run_started_skips_missing_extension(monkeypatch: MonkeyPatch) -> None:
+    """Do nothing when the optional extension package is absent."""
+    monkeypatch.setattr(extensions, "_try_import_sgxt", lambda: None)
+
+    extensions.notify_run_started(Run.create_empty(123), "unknown")
+
+
+def test_notify_run_started_isolates_extension_import_failure(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Keep a persisted run successful when extension discovery fails."""
+
+    def fail_import() -> ModuleType | None:
+        raise RuntimeError("extension import failed")
+
+    monkeypatch.setattr(extensions, "_try_import_sgxt", fail_import)
+
+    extensions.notify_run_started(Run.create_empty(123), "unknown")

--- a/framework/py/flwr/superlink/servicer/control/control_handlers.py
+++ b/framework/py/flwr/superlink/servicer/control/control_handlers.py
@@ -164,6 +164,7 @@ from flwr.supercore.utils import (
     resolve_account_ids,
     strict_json_dumps,
 )
+from flwr.superlink import extensions
 from flwr.superlink.artifact_provider import ArtifactProvider
 from flwr.superlink.auth_plugin import ControlAuthnPlugin
 from flwr.superlink.federation.noop_federation_manager import NoOpFederationManager
@@ -466,6 +467,7 @@ def start_run(  # pylint: disable=too-many-branches,too-many-locals,too-many-sta
     account: AccountInfo,
     state: LinkState,
     fleet_api_type: str | None,
+    source: extensions.RunStartSource = "unknown",
 ) -> StartRunResponse:
     """Create run ID."""
     log(INFO, "ControlServicer.StartRun")
@@ -651,9 +653,11 @@ def start_run(  # pylint: disable=too-many-branches,too-many-locals,too-many-sta
 
     log_msg = f"Created run {run_id} in federation {run.federation_id}"
     log(INFO, log_msg)
-    return StartRunResponse(
+    response = StartRunResponse(
         run_id=run_id, note=note, series_id=series_id, federation=run.federation_id
     )
+    extensions.notify_run_started(run, source)
+    return response
 
 
 def stream_logs(
@@ -901,6 +905,7 @@ def dispatch_automation(
             AccountInfo(flwr_aid=flwr_aid, account_name=""),
             state,
             None,
+            source="automation",
         )
     except Exception as exc:  # pylint: disable=broad-exception-caught
         state.finish_automation(

--- a/framework/py/flwr/superlink/servicer/control/control_handlers_test.py
+++ b/framework/py/flwr/superlink/servicer/control/control_handlers_test.py
@@ -108,6 +108,44 @@ class TestControlHandlers(unittest.TestCase):
             [("@flwr/demo", fab_hash, TaskType.SERVER_APP)],
         )
 
+    def test_start_run_notifies_extension_after_persisting_run(self) -> None:
+        """Notify the optional extension with the persisted run snapshot."""
+        fab_content = b"stored FAB"
+        fab_hash = hashlib.sha256(fab_content).hexdigest()
+        self.state.store_app(
+            fab=Fab(fab_hash, fab_content, {}),
+            federation_id=NOOP_FEDERATION_ID,
+            app_id="@flwr/demo",
+            app_type=TaskType.SERVER_APP,
+            added_by=self.account.flwr_aid,
+        )
+
+        with (
+            patch(
+                "flwr.superlink.servicer.control.control_handlers.get_fab_config",
+                return_value={"tool": {"flwr": {"app": {}}}},
+            ),
+            patch(
+                "flwr.superlink.servicer.control.control_handlers"
+                ".get_metadata_from_config",
+                return_value=("flwr/demo", "v0.0.1"),
+            ),
+            patch(
+                "flwr.superlink.servicer.control.control_handlers"
+                ".extensions.notify_run_started"
+            ) as notify_run_started,
+        ):
+            request = StartRunRequest(federation=NOOP_FEDERATION_ID)
+            request.app_spec = "@flwr/demo==0.0.1"
+            request.fab.hash_str = fab_hash
+            response = start_run(request, self.account, self.state, None)
+
+        run = self.state.get_run_info(run_ids=[response.run_id])[0]
+        notify_run_started.assert_called_once()
+        notified_run, source = notify_run_started.call_args.args
+        self.assertEqual(notified_run.run_id, run.run_id)
+        self.assertEqual(source, "unknown")
+
     def test_start_run_rejects_unknown_fab_hash(self) -> None:
         """Test StartRun rejects an unknown FAB hash without an app spec."""
         request = StartRunRequest(federation=NOOP_FEDERATION_ID)


### PR DESCRIPTION
## Summary

- add a small optional `on_run_started` extension hook to SuperLink
- invoke it after a run has been persisted and before the successful `StartRun` response is returned
- keep the hook synchronous, non-blocking, and best effort so the framework does not own a background thread or event loop for optional integrations
- pass a copied `Run` snapshot so an extension cannot mutate the object used to build the response
- report `unknown` for API-created runs and `automation` for Flower-owned scheduled runs

## Design

The existing SuperLink extension bridge already discovers the optional extension package. This change adds one notification function to that bridge and calls it from the authoritative `start_run` handler, which is shared by the HTTP and gRPC Control APIs. Scheduled automation uses the explicit `automation` source; API requests use `unknown` because transport does not identify whether the caller is the CLI or web UI.

The callback is deliberately synchronous at the framework boundary. It is an internal best-effort hook, and implementations must return immediately. The Product Analytics implementation uses this contract to admit work to its own bounded worker without doing database or network work on the StartRun path. Flower does not create daemon threads, executors, event loops, or shutdown coordination for this optional callback.

Extension discovery, callback lookup, snapshot copying, and callback failures are isolated. If the extension is absent or fails, the already-persisted run and successful StartRun response are unaffected.

## Validation

- focused Control handler and extension tests pass
- coverage includes callback invocation after persistence, copied run snapshots, absent extensions, and extension import failures
- Ruff, Black, and strict mypy pass on all touched files
