### PR TITLE
fix(framework) Allow commas in FAB file names

### DIFF
--- a/framework/py/flwr/cli/install.py
+++ b/framework/py/flwr/cli/install.py
@@ -228,7 +228,7 @@ def _verify_hashes(list_content: str, tmpdir: Path) -> bool:
         True if all file hashes match, False otherwise.
     """
     for line in list_content.strip().split("\n"):
-        rel_path, hash_expected, _ = line.split(",")
+        rel_path, hash_expected, _ = line.rsplit(",", maxsplit=2)
         file_path = tmpdir / rel_path
         if not file_path.exists() or get_sha256_hash(file_path) != hash_expected:
             return False

--- a/framework/py/flwr/cli/install_test.py
+++ b/framework/py/flwr/cli/install_test.py
@@ -15,6 +15,7 @@
 """Tests for Flower command line interface `install` command."""
 
 
+import hashlib
 import io
 import zipfile
 from pathlib import Path
@@ -23,7 +24,7 @@ import click
 import pytest
 
 from .archive_utils import safe_extract_zip
-from .install import install_from_fab
+from .install import _verify_hashes, install_from_fab
 
 
 def _zip_bytes(entries: list[tuple[str, bytes]]) -> bytes:
@@ -63,6 +64,17 @@ def test_safe_extract_zip_rejects_absolute_paths(tmp_path: Path) -> None:
     with zipfile.ZipFile(io.BytesIO(zip_bytes), "r") as zf:
         with pytest.raises(click.ClickException, match="Unsafe path in FAB archive"):
             safe_extract_zip(zf, tmp_path)
+
+
+def test_verify_hashes_accepts_comma_in_file_name(tmp_path: Path) -> None:
+    """Hash verification should preserve commas in manifest file paths."""
+    file_name = "metrics,round=1.json"
+    file_content = b"{}"
+    (tmp_path / file_name).write_bytes(file_content)
+    file_hash = hashlib.sha256(file_content).hexdigest()
+    content_manifest = f"{file_name},{file_hash},{len(file_content) * 8}"
+
+    assert _verify_hashes(content_manifest, tmp_path)
 
 
 def test_install_from_fab_rejects_zip_slip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Issue

### Description

FAB installation fails when an app contains a file whose name includes a comma. The CONTENT manifest parser splits every comma, so the file path is parsed as multiple fields and raises `ValueError`.

### Related issues/PRs

Fixes #7944.

## Proposal

### Explanation

Parse each CONTENT manifest entry from the right with two splits. The hash and size fields remain fixed, while any commas in the preceding relative path are preserved.

Add a regression test that verifies the hash of a file named `metrics,round=1.json`.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [ ] Update documentation (not needed; this restores supported file handling)
- [x] Address LLM-reviewer comments, if applicable (review completed with no comments)
- [x] Make local checks pass
- [ ] Make CI checks pass
- [ ] Ping maintainers on Slack (channel `#contributions`)

### Any other comments?

Local verification:

- `python -m pytest py/flwr/cli/install_test.py`
- `python -m ruff check py/flwr/cli/install.py py/flwr/cli/install_test.py --no-respect-gitignore`
- `uv run --no-sync --python=3.11.14 ./dev/test.sh false`
