### PR TITLE
feat(framework) Add selectors to stop command

### DIFF
--- a/framework/py/flwr/cli/stop.py
+++ b/framework/py/flwr/cli/stop.py
@@ -15,9 +15,10 @@
 """Flower command line interface `stop` command."""
 
 
-from typing import Annotated, Literal
+from typing import Annotated, Literal, cast
 
 import click
+import grpc
 import typer
 
 from flwr.cli.config_migration import migrate, warn_if_federation_config_overrides
@@ -31,6 +32,7 @@ from flwr.proto.control_pb2 import (  # pylint: disable=E0611
     StopRunResponse,
 )
 from flwr.proto.control_pb2_grpc import ControlStub
+from flwr.supercore.error import ApiErrorCode, FlowerError
 
 from .utils import (
     cli_output_handler,
@@ -136,7 +138,12 @@ def _stop_runs(
     for run_id in run_ids:
         typer.secho(f"✋ Stopping run ID {run_id}...", fg=typer.colors.GREEN)
         try:
-            _stop_run(stub=stub, run_id=run_id, is_json=is_json and not stop_all)
+            _stop_run(
+                stub=stub,
+                run_id=run_id,
+                is_json=is_json and not stop_all,
+                ignore_finished=stop_all,
+            )
         except click.ClickException as err:
             if not stop_all:
                 raise
@@ -154,7 +161,12 @@ def _stop_runs(
         )
 
 
-def _stop_run(stub: ControlStub, run_id: int, is_json: bool) -> None:
+def _stop_run(
+    stub: ControlStub,
+    run_id: int,
+    is_json: bool,
+    ignore_finished: bool = False,
+) -> None:
     """Stop a run and display the result.
 
     Parameters
@@ -165,9 +177,28 @@ def _stop_run(stub: ControlStub, run_id: int, is_json: bool) -> None:
         The unique identifier of the run to stop.
     is_json : bool
         Whether JSON output format is requested.
+    ignore_finished : bool (default: False)
+        Whether an already-finished run should be treated as successfully stopped.
     """
-    with flwr_cli_grpc_exc_handler():
-        response: StopRunResponse = stub.StopRun(request=StopRunRequest(run_id=run_id))
+
+    def raise_if_already_finished(error: grpc.RpcError) -> None:
+        details = cast(str, error.details())  # pylint: disable=E1101
+        flower_error = FlowerError.from_json(details)
+        if (
+            ignore_finished
+            and flower_error is not None
+            and flower_error.code == ApiErrorCode.RUN_ALREADY_FINISHED
+        ):
+            raise _RunAlreadyFinishedError
+
+    try:
+        with flwr_cli_grpc_exc_handler(custom_handler=raise_if_already_finished):
+            response: StopRunResponse = stub.StopRun(
+                request=StopRunRequest(run_id=run_id)
+            )
+    except _RunAlreadyFinishedError:
+        typer.secho(f"ℹ️ Run {run_id} already finished.", fg=typer.colors.YELLOW)
+        return
     if response.success:
         typer.secho(f"✅ Run {run_id} successfully stopped.", fg=typer.colors.GREEN)
         if is_json:
@@ -179,3 +210,7 @@ def _stop_run(stub: ControlStub, run_id: int, is_json: bool) -> None:
             )
     else:
         raise click.ClickException(f"Run {run_id} couldn't be stopped.")
+
+
+class _RunAlreadyFinishedError(Exception):
+    """Signal that a batch stop target has already finished."""

--- a/framework/py/flwr/cli/stop.py
+++ b/framework/py/flwr/cli/stop.py
@@ -41,6 +41,8 @@ from .utils import (
     print_json_to_stdout,
 )
 
+RunSelector = Literal["latest", "all"]
+
 
 def stop(  # pylint: disable=R0914
     ctx: typer.Context,
@@ -75,6 +77,8 @@ def stop(  # pylint: disable=R0914
     SuperLink via the Control API.
     """
     with cli_output_handler(output_format=output_format) as is_json:
+        parsed_run_id = _parse_run_id(run_id)
+
         # Warn `--federation-config` is ignored
         warn_if_federation_config_overrides(federation_config_overrides)
 
@@ -88,28 +92,37 @@ def stop(  # pylint: disable=R0914
             channel = init_channel_from_connection(superlink_connection)
             stub = ControlStub(channel)  # pylint: disable=unused-variable # noqa: F841
 
-            run_ids = _resolve_run_ids(stub, run_id)
-            stop_all = run_id.lower() == "all"
-            _stop_runs(stub, run_ids, is_json, stop_all)
+            run_ids = _resolve_run_ids(stub, parsed_run_id)
+            selector = parsed_run_id if isinstance(parsed_run_id, str) else None
+            _stop_runs(stub, run_ids, is_json, selector)
 
         finally:
             if channel:
                 channel.close()
 
 
-def _resolve_run_ids(stub: ControlStub, run_id: str) -> list[int]:
-    """Resolve a numeric run ID or a selector to active run IDs."""
+def _parse_run_id(run_id: str) -> int | RunSelector:
+    """Parse a numeric run ID or supported selector."""
     selector = run_id.lower()
-    if selector not in ("latest", "all"):
-        try:
-            resolved_run_id = int(run_id)
-        except ValueError:
-            raise click.ClickException(
-                "RUN_ID must be an integer, 'latest', or 'all'."
-            ) from None
-        if resolved_run_id < 0:
-            raise click.ClickException("RUN_ID must be a non-negative integer.")
-        return [resolved_run_id]
+    if selector == "latest":
+        return "latest"
+    if selector == "all":
+        return "all"
+    try:
+        resolved_run_id = int(run_id)
+    except ValueError:
+        raise click.ClickException(
+            "RUN_ID must be an integer, 'latest', or 'all'."
+        ) from None
+    if resolved_run_id < 0:
+        raise click.ClickException("RUN_ID must be a non-negative integer.")
+    return resolved_run_id
+
+
+def _resolve_run_ids(stub: ControlStub, run_id: int | RunSelector) -> list[int]:
+    """Resolve a parsed run ID or selector to active run IDs."""
+    if isinstance(run_id, int):
+        return [run_id]
 
     with flwr_cli_grpc_exc_handler():
         response: ListRunsResponse = stub.ListRuns(ListRunsRequest())
@@ -125,15 +138,19 @@ def _resolve_run_ids(stub: ControlStub, run_id: str) -> list[int]:
     if not active_runs:
         raise click.ClickException("No active runs found.")
 
-    if selector == "latest":
+    if run_id == "latest":
         return [active_runs[0].run_id]
     return [run.run_id for run in active_runs]
 
 
 def _stop_runs(
-    stub: ControlStub, run_ids: list[int], is_json: bool, stop_all: bool
+    stub: ControlStub,
+    run_ids: list[int],
+    is_json: bool,
+    selector: RunSelector | None,
 ) -> None:
     """Stop resolved run IDs and display the result."""
+    stop_all = selector == "all"
     failures = []
     for run_id in run_ids:
         typer.secho(f"✋ Stopping run ID {run_id}...", fg=typer.colors.GREEN)
@@ -142,7 +159,7 @@ def _stop_runs(
                 stub=stub,
                 run_id=run_id,
                 is_json=is_json and not stop_all,
-                ignore_finished=stop_all,
+                ignore_finished=selector is not None,
             )
         except click.ClickException as err:
             if not stop_all:
@@ -197,7 +214,7 @@ def _stop_run(
                 request=StopRunRequest(run_id=run_id)
             )
     except _RunAlreadyFinishedError:
-        typer.secho(f"ℹ️ Run {run_id} already finished.", fg=typer.colors.YELLOW)
+        _print_already_finished(run_id, is_json)
         return
     if response.success:
         typer.secho(f"✅ Run {run_id} successfully stopped.", fg=typer.colors.GREEN)
@@ -208,8 +225,25 @@ def _stop_run(
                     "run-id": f"{run_id}",
                 }
             )
+    elif ignore_finished and _is_run_finished(stub, run_id):
+        _print_already_finished(run_id, is_json)
     else:
         raise click.ClickException(f"Run {run_id} couldn't be stopped.")
+
+
+def _is_run_finished(stub: ControlStub, run_id: int) -> bool:
+    """Check whether a run finished during a stop request."""
+    with flwr_cli_grpc_exc_handler():
+        response: ListRunsResponse = stub.ListRuns(ListRunsRequest(run_id=run_id))
+    run = response.run_dict.get(run_id)
+    return run is not None and run.status.status == Status.FINISHED
+
+
+def _print_already_finished(run_id: int, is_json: bool) -> None:
+    """Display that a run already reached the requested finished state."""
+    typer.secho(f"ℹ️ Run {run_id} already finished.", fg=typer.colors.YELLOW)
+    if is_json:
+        print_json_to_stdout({"success": True, "run-id": f"{run_id}"})
 
 
 class _RunAlreadyFinishedError(Exception):

--- a/framework/py/flwr/cli/stop.py
+++ b/framework/py/flwr/cli/stop.py
@@ -88,25 +88,7 @@ def stop(  # pylint: disable=R0914
 
             run_ids = _resolve_run_ids(stub, run_id)
             stop_all = run_id.lower() == "all"
-            for resolved_run_id in run_ids:
-                typer.secho(
-                    f"✋ Stopping run ID {resolved_run_id}...",
-                    fg=typer.colors.GREEN,
-                )
-                _stop_run(
-                    stub=stub,
-                    run_id=resolved_run_id,
-                    is_json=is_json and not stop_all,
-                )
-            if is_json and stop_all:
-                print_json_to_stdout(
-                    {
-                        "success": True,
-                        "run-ids": [
-                            str(resolved_run_id) for resolved_run_id in run_ids
-                        ],
-                    }
-                )
+            _stop_runs(stub, run_ids, is_json, stop_all)
 
         finally:
             if channel:
@@ -144,6 +126,32 @@ def _resolve_run_ids(stub: ControlStub, run_id: str) -> list[int]:
     if selector == "latest":
         return [active_runs[0].run_id]
     return [run.run_id for run in active_runs]
+
+
+def _stop_runs(
+    stub: ControlStub, run_ids: list[int], is_json: bool, stop_all: bool
+) -> None:
+    """Stop resolved run IDs and display the result."""
+    failures = []
+    for run_id in run_ids:
+        typer.secho(f"✋ Stopping run ID {run_id}...", fg=typer.colors.GREEN)
+        try:
+            _stop_run(stub=stub, run_id=run_id, is_json=is_json and not stop_all)
+        except click.ClickException as err:
+            if not stop_all:
+                raise
+            failures.append(f"Run {run_id}: {err.format_message()}")
+
+    if failures:
+        raise click.ClickException("Failed to stop all runs:\n" + "\n".join(failures))
+
+    if is_json and stop_all:
+        print_json_to_stdout(
+            {
+                "success": True,
+                "run-ids": [str(run_id) for run_id in run_ids],
+            }
+        )
 
 
 def _stop_run(stub: ControlStub, run_id: int, is_json: bool) -> None:

--- a/framework/py/flwr/cli/stop.py
+++ b/framework/py/flwr/cli/stop.py
@@ -23,8 +23,10 @@ import typer
 from flwr.cli.config_migration import migrate, warn_if_federation_config_overrides
 from flwr.cli.constant import FEDERATION_CONFIG_HELP_MESSAGE
 from flwr.cli.flower_config import read_superlink_connection
-from flwr.common.constant import CliOutputFormat
+from flwr.common.constant import CliOutputFormat, Status
 from flwr.proto.control_pb2 import (  # pylint: disable=E0611
+    ListRunsRequest,
+    ListRunsResponse,
     StopRunRequest,
     StopRunResponse,
 )
@@ -41,8 +43,8 @@ from .utils import (
 def stop(  # pylint: disable=R0914
     ctx: typer.Context,
     run_id: Annotated[  # pylint: disable=unused-argument
-        int,
-        typer.Argument(help="The Flower run ID to stop"),
+        str,
+        typer.Argument(help="The Flower run ID to stop, or 'latest' or 'all'"),
     ],
     superlink: Annotated[
         str | None,
@@ -84,12 +86,64 @@ def stop(  # pylint: disable=R0914
             channel = init_channel_from_connection(superlink_connection)
             stub = ControlStub(channel)  # pylint: disable=unused-variable # noqa: F841
 
-            typer.secho(f"✋ Stopping run ID {run_id}...", fg=typer.colors.GREEN)
-            _stop_run(stub=stub, run_id=run_id, is_json=is_json)
+            run_ids = _resolve_run_ids(stub, run_id)
+            stop_all = run_id.lower() == "all"
+            for resolved_run_id in run_ids:
+                typer.secho(
+                    f"✋ Stopping run ID {resolved_run_id}...",
+                    fg=typer.colors.GREEN,
+                )
+                _stop_run(
+                    stub=stub,
+                    run_id=resolved_run_id,
+                    is_json=is_json and not stop_all,
+                )
+            if is_json and stop_all:
+                print_json_to_stdout(
+                    {
+                        "success": True,
+                        "run-ids": [
+                            str(resolved_run_id) for resolved_run_id in run_ids
+                        ],
+                    }
+                )
 
         finally:
             if channel:
                 channel.close()
+
+
+def _resolve_run_ids(stub: ControlStub, run_id: str) -> list[int]:
+    """Resolve a numeric run ID or a selector to active run IDs."""
+    selector = run_id.lower()
+    if selector not in ("latest", "all"):
+        try:
+            resolved_run_id = int(run_id)
+        except ValueError:
+            raise click.ClickException(
+                "RUN_ID must be an integer, 'latest', or 'all'."
+            ) from None
+        if resolved_run_id < 0:
+            raise click.ClickException("RUN_ID must be a non-negative integer.")
+        return [resolved_run_id]
+
+    with flwr_cli_grpc_exc_handler():
+        response: ListRunsResponse = stub.ListRuns(ListRunsRequest())
+    active_runs = sorted(
+        (
+            run
+            for run in response.run_dict.values()
+            if run.status.status != Status.FINISHED
+        ),
+        key=lambda run: run.pending_at,
+        reverse=True,
+    )
+    if not active_runs:
+        raise click.ClickException("No active runs found.")
+
+    if selector == "latest":
+        return [active_runs[0].run_id]
+    return [run.run_id for run in active_runs]
 
 
 def _stop_run(stub: ControlStub, run_id: int, is_json: bool) -> None:

--- a/framework/py/flwr/cli/stop_test.py
+++ b/framework/py/flwr/cli/stop_test.py
@@ -15,16 +15,20 @@
 """Tests for Flower command line interface `stop` command."""
 
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call, patch
 
 import click
 import pytest
 
-from flwr.common.constant import Status
-from flwr.proto.control_pb2 import ListRunsResponse  # pylint: disable=E0611
+from flwr.common.constant import CliOutputFormat, Status
+from flwr.proto.control_pb2 import (  # pylint: disable=E0611
+    ListRunsResponse,
+    StopRunRequest,
+    StopRunResponse,
+)
 from flwr.proto.run_pb2 import Run, RunStatus  # pylint: disable=E0611
 
-from .stop import _resolve_run_ids
+from .stop import _resolve_run_ids, _stop_runs, stop
 
 
 def _run(run_id: int, status: str, pending_at: str) -> Run:
@@ -89,3 +93,49 @@ def test_resolve_run_ids_rejects_selector_without_active_runs() -> None:
 
     with pytest.raises(click.ClickException, match="No active runs found"):
         _resolve_run_ids(stub, "all")
+
+
+def test_stop_all_calls_each_run_and_prints_one_json_response() -> None:
+    """The all selector should stop each active run and emit one JSON document."""
+    stub = MagicMock()
+    stub.ListRuns.return_value = ListRunsResponse(
+        run_dict={
+            1: _run(1, Status.RUNNING, "2026-08-20T10:00:00+00:00"),
+            3: _run(3, Status.STARTING, "2026-08-20T11:00:00+00:00"),
+        }
+    )
+    stub.StopRun.return_value = StopRunResponse(success=True)
+    channel = MagicMock()
+
+    with (
+        patch("flwr.cli.stop.warn_if_federation_config_overrides"),
+        patch("flwr.cli.stop.migrate"),
+        patch("flwr.cli.stop.read_superlink_connection"),
+        patch("flwr.cli.stop.init_channel_from_connection", return_value=channel),
+        patch("flwr.cli.stop.ControlStub", return_value=stub),
+        patch("flwr.cli.stop.print_json_to_stdout") as print_json,
+    ):
+        stop(MagicMock(args=[]), "all", output_format=CliOutputFormat.JSON)
+
+    assert stub.StopRun.call_args_list == [
+        call(request=StopRunRequest(run_id=3)),
+        call(request=StopRunRequest(run_id=1)),
+    ]
+    print_json.assert_called_once_with({"success": True, "run-ids": ["3", "1"]})
+    channel.close.assert_called_once()
+
+
+def test_stop_all_continues_after_failure() -> None:
+    """A failed stop should not prevent attempts for later runs in the batch."""
+    stub = MagicMock()
+    with patch(
+        "flwr.cli.stop._stop_run",
+        side_effect=[click.ClickException("already finished"), None],
+    ) as stop_run:
+        with pytest.raises(click.ClickException, match="already finished"):
+            _stop_runs(stub, [3, 1], is_json=False, stop_all=True)
+
+    assert stop_run.call_args_list == [
+        call(stub=stub, run_id=3, is_json=False),
+        call(stub=stub, run_id=1, is_json=False),
+    ]

--- a/framework/py/flwr/cli/stop_test.py
+++ b/framework/py/flwr/cli/stop_test.py
@@ -15,9 +15,11 @@
 """Tests for Flower command line interface `stop` command."""
 
 
+import json
 from unittest.mock import MagicMock, call, patch
 
 import click
+import grpc
 import pytest
 
 from flwr.common.constant import CliOutputFormat, Status
@@ -27,6 +29,7 @@ from flwr.proto.control_pb2 import (  # pylint: disable=E0611
     StopRunResponse,
 )
 from flwr.proto.run_pb2 import Run, RunStatus  # pylint: disable=E0611
+from flwr.supercore.error import ApiErrorCode
 
 from .stop import _resolve_run_ids, _stop_runs, stop
 
@@ -136,6 +139,35 @@ def test_stop_all_continues_after_failure() -> None:
             _stop_runs(stub, [3, 1], is_json=False, stop_all=True)
 
     assert stop_run.call_args_list == [
-        call(stub=stub, run_id=3, is_json=False),
-        call(stub=stub, run_id=1, is_json=False),
+        call(stub=stub, run_id=3, is_json=False, ignore_finished=True),
+        call(stub=stub, run_id=1, is_json=False, ignore_finished=True),
+    ]
+
+
+def test_stop_all_ignores_run_that_finished_after_selection() -> None:
+    """A concurrently finished run should not make a batch stop fail."""
+
+    class AlreadyFinishedRpcError(grpc.RpcError):  # type: ignore[misc]
+        """Represent an already-finished API error from the Control API."""
+
+        def details(self) -> str:
+            """Return the serialized Flower error."""
+            return json.dumps(
+                {
+                    "code": ApiErrorCode.RUN_ALREADY_FINISHED,
+                    "detail": "Run already finished.",
+                }
+            )
+
+    stub = MagicMock()
+    stub.StopRun.side_effect = [
+        AlreadyFinishedRpcError(),
+        StopRunResponse(success=True),
+    ]
+
+    _stop_runs(stub, [3, 1], is_json=False, stop_all=True)
+
+    assert stub.StopRun.call_args_list == [
+        call(request=StopRunRequest(run_id=3)),
+        call(request=StopRunRequest(run_id=1)),
     ]

--- a/framework/py/flwr/cli/stop_test.py
+++ b/framework/py/flwr/cli/stop_test.py
@@ -24,14 +24,32 @@ import pytest
 
 from flwr.common.constant import CliOutputFormat, Status
 from flwr.proto.control_pb2 import (  # pylint: disable=E0611
+    ListRunsRequest,
     ListRunsResponse,
     StopRunRequest,
     StopRunResponse,
 )
 from flwr.proto.run_pb2 import Run, RunStatus  # pylint: disable=E0611
 from flwr.supercore.error import ApiErrorCode
+from typer.testing import CliRunner
 
-from .stop import _resolve_run_ids, _stop_runs, stop
+from .app import app
+from .stop import _parse_run_id, _resolve_run_ids, _stop_runs, stop
+
+runner = CliRunner()
+
+
+class _AlreadyFinishedRpcError(grpc.RpcError):  # type: ignore[misc]
+    """Represent an already-finished API error from the Control API."""
+
+    def details(self) -> str:
+        """Return the serialized Flower error."""
+        return json.dumps(
+            {
+                "code": ApiErrorCode.RUN_ALREADY_FINISHED,
+                "detail": "Run already finished.",
+            }
+        )
 
 
 def _run(run_id: int, status: str, pending_at: str) -> Run:
@@ -46,7 +64,7 @@ def test_resolve_run_ids_returns_numeric_id_without_listing_runs() -> None:
     """A numeric run ID should not require a ListRuns request."""
     stub = MagicMock()
 
-    assert _resolve_run_ids(stub, "123") == [123]
+    assert _resolve_run_ids(stub, 123) == [123]
     stub.ListRuns.assert_not_called()
 
 
@@ -79,10 +97,25 @@ def test_resolve_run_ids_returns_all_active_runs_newest_first() -> None:
 
 
 @pytest.mark.parametrize("run_id", ["newest", "-1"])
-def test_resolve_run_ids_rejects_invalid_run_id(run_id: str) -> None:
+def test_parse_run_id_rejects_invalid_run_id(run_id: str) -> None:
     """Unknown selectors and negative run IDs should be rejected clearly."""
     with pytest.raises(click.ClickException):
-        _resolve_run_ids(MagicMock(), run_id)
+        _parse_run_id(run_id)
+
+
+def test_stop_command_rejects_invalid_selector_before_setup() -> None:
+    """Invalid selectors should fail before migration or connection setup."""
+    with (
+        patch("flwr.cli.app.warn_if_flwr_update_available"),
+        patch("flwr.cli.stop.migrate") as migrate,
+        patch("flwr.cli.stop.init_channel_from_connection") as init_channel,
+    ):
+        result = runner.invoke(app, ["stop", "lates"])
+
+    assert result.exit_code == 1
+    assert "RUN_ID must be an integer, 'latest', or 'all'" in result.output
+    migrate.assert_not_called()
+    init_channel.assert_not_called()
 
 
 def test_resolve_run_ids_rejects_selector_without_active_runs() -> None:
@@ -136,7 +169,7 @@ def test_stop_all_continues_after_failure() -> None:
         side_effect=[click.ClickException("already finished"), None],
     ) as stop_run:
         with pytest.raises(click.ClickException, match="already finished"):
-            _stop_runs(stub, [3, 1], is_json=False, stop_all=True)
+            _stop_runs(stub, [3, 1], is_json=False, selector="all")
 
     assert stop_run.call_args_list == [
         call(stub=stub, run_id=3, is_json=False, ignore_finished=True),
@@ -146,28 +179,38 @@ def test_stop_all_continues_after_failure() -> None:
 
 def test_stop_all_ignores_run_that_finished_after_selection() -> None:
     """A concurrently finished run should not make a batch stop fail."""
-
-    class AlreadyFinishedRpcError(grpc.RpcError):  # type: ignore[misc]
-        """Represent an already-finished API error from the Control API."""
-
-        def details(self) -> str:
-            """Return the serialized Flower error."""
-            return json.dumps(
-                {
-                    "code": ApiErrorCode.RUN_ALREADY_FINISHED,
-                    "detail": "Run already finished.",
-                }
-            )
-
     stub = MagicMock()
     stub.StopRun.side_effect = [
-        AlreadyFinishedRpcError(),
+        _AlreadyFinishedRpcError(),
         StopRunResponse(success=True),
     ]
 
-    _stop_runs(stub, [3, 1], is_json=False, stop_all=True)
+    _stop_runs(stub, [3, 1], is_json=False, selector="all")
 
     assert stub.StopRun.call_args_list == [
         call(request=StopRunRequest(run_id=3)),
         call(request=StopRunRequest(run_id=1)),
     ]
+
+
+def test_stop_latest_ignores_run_that_finished_after_selection() -> None:
+    """The latest selector should accept a target finishing before its stop RPC."""
+    stub = MagicMock()
+    stub.StopRun.side_effect = _AlreadyFinishedRpcError()
+
+    _stop_runs(stub, [3], is_json=False, selector="latest")
+
+
+def test_stop_selector_rechecks_unsuccessful_response() -> None:
+    """A false stop response should succeed if the selected run is now finished."""
+    stub = MagicMock()
+    stub.StopRun.return_value = StopRunResponse(success=False)
+    stub.ListRuns.return_value = ListRunsResponse(
+        run_dict={
+            3: _run(3, Status.FINISHED, "2026-08-20T11:00:00+00:00"),
+        }
+    )
+
+    _stop_runs(stub, [3], is_json=False, selector="all")
+
+    stub.ListRuns.assert_called_once_with(ListRunsRequest(run_id=3))

--- a/framework/py/flwr/cli/stop_test.py
+++ b/framework/py/flwr/cli/stop_test.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for Flower command line interface `stop` command."""
+
+
+from unittest.mock import MagicMock
+
+import click
+import pytest
+
+from flwr.common.constant import Status
+from flwr.proto.control_pb2 import ListRunsResponse  # pylint: disable=E0611
+from flwr.proto.run_pb2 import Run, RunStatus  # pylint: disable=E0611
+
+from .stop import _resolve_run_ids
+
+
+def _run(run_id: int, status: str, pending_at: str) -> Run:
+    return Run(
+        run_id=run_id,
+        status=RunStatus(status=status),
+        pending_at=pending_at,
+    )
+
+
+def test_resolve_run_ids_returns_numeric_id_without_listing_runs() -> None:
+    """A numeric run ID should not require a ListRuns request."""
+    stub = MagicMock()
+
+    assert _resolve_run_ids(stub, "123") == [123]
+    stub.ListRuns.assert_not_called()
+
+
+def test_resolve_run_ids_returns_latest_active_run() -> None:
+    """The latest selector should skip newer finished runs."""
+    stub = MagicMock()
+    stub.ListRuns.return_value = ListRunsResponse(
+        run_dict={
+            1: _run(1, Status.RUNNING, "2026-08-20T10:00:00+00:00"),
+            2: _run(2, Status.FINISHED, "2026-08-20T12:00:00+00:00"),
+            3: _run(3, Status.PENDING, "2026-08-20T11:00:00+00:00"),
+        }
+    )
+
+    assert _resolve_run_ids(stub, "latest") == [3]
+
+
+def test_resolve_run_ids_returns_all_active_runs_newest_first() -> None:
+    """The all selector should return active runs ordered by creation time."""
+    stub = MagicMock()
+    stub.ListRuns.return_value = ListRunsResponse(
+        run_dict={
+            1: _run(1, Status.RUNNING, "2026-08-20T10:00:00+00:00"),
+            2: _run(2, Status.FINISHED, "2026-08-20T12:00:00+00:00"),
+            3: _run(3, Status.STARTING, "2026-08-20T11:00:00+00:00"),
+        }
+    )
+
+    assert _resolve_run_ids(stub, "all") == [3, 1]
+
+
+@pytest.mark.parametrize("run_id", ["newest", "-1"])
+def test_resolve_run_ids_rejects_invalid_run_id(run_id: str) -> None:
+    """Unknown selectors and negative run IDs should be rejected clearly."""
+    with pytest.raises(click.ClickException):
+        _resolve_run_ids(MagicMock(), run_id)
+
+
+def test_resolve_run_ids_rejects_selector_without_active_runs() -> None:
+    """Selectors should fail clearly if all runs have finished."""
+    stub = MagicMock()
+    stub.ListRuns.return_value = ListRunsResponse(
+        run_dict={
+            1: _run(1, Status.FINISHED, "2026-08-20T10:00:00+00:00"),
+        }
+    )
+
+    with pytest.raises(click.ClickException, match="No active runs found"):
+        _resolve_run_ids(stub, "all")

--- a/framework/py/flwr/cli/stop_test.py
+++ b/framework/py/flwr/cli/stop_test.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, call, patch
 import click
 import grpc
 import pytest
+from typer.testing import CliRunner
 
 from flwr.common.constant import CliOutputFormat, Status
 from flwr.proto.control_pb2 import (  # pylint: disable=E0611
@@ -31,7 +32,6 @@ from flwr.proto.control_pb2 import (  # pylint: disable=E0611
 )
 from flwr.proto.run_pb2 import Run, RunStatus  # pylint: disable=E0611
 from flwr.supercore.error import ApiErrorCode
-from typer.testing import CliRunner
 
 from .app import app
 from .stop import _parse_run_id, _resolve_run_ids, _stop_runs, stop


### PR DESCRIPTION
## Issue

### Description

Stopping a recent run currently requires listing runs, copying an ID, and passing that numeric ID to `flwr stop`. Stopping every active run requires repeating the process.

### Related issues/PRs

Fixes #7945.

## Proposal

### Explanation

Allow the `flwr stop` argument to be either a numeric run ID or one of two selectors:

- `latest` stops the newest unfinished run.
- `all` stops all unfinished runs, newest first.

Unfinished includes pending, starting, and running runs, which ensures a pending run can also be stopped. Existing numeric-ID behavior remains unchanged. The JSON response for `all` contains a single `run-ids` list instead of emitting multiple JSON documents.

Arguments are validated before configuration migration or connection setup. Batch execution attempts every selected run before reporting partial failures. A run selected by either `latest` or `all` that finishes concurrently is treated as already satisfying the stop request, including when the stop RPC returns an unsuccessful response instead of an API error. Unrelated failures remain visible after the rest of an `all` batch is attempted.

Add focused tests for numeric IDs, active-run filtering and ordering, real CLI validation before setup, negative IDs, the no-active-runs case, both concurrent-completion response forms, batch failure continuation, RPC order, and JSON output.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [ ] Update documentation (the CLI help text documents the new argument values)
- [x] Address LLM-reviewer comments, if applicable
- [x] Make local checks pass
- [ ] Make CI checks pass
- [ ] Ping maintainers on Slack (channel `#contributions`)

### Any other comments?

Local verification:

- `python -m pytest py/flwr/cli/stop_test.py py/flwr/cli/cli_test.py -k stop`
- `python -m ruff check py/flwr/cli/stop.py py/flwr/cli/stop_test.py --no-respect-gitignore`
- `python -m mypy py/flwr/cli/stop.py py/flwr/cli/stop_test.py`
- `python -m pylint py/flwr/cli/stop.py py/flwr/cli/stop_test.py`
- `uv run --no-sync --python=3.11.14 ./dev/test.sh false`
