### PR TITLE
feat(framework): Add emit events in agentapp API

### DIFF
--- a/framework/py/flwr/agentapp/__init__.py
+++ b/framework/py/flwr/agentapp/__init__.py
@@ -18,12 +18,14 @@
 from .agent_app import AgentApp as AgentApp
 from .agent_app import LoadAgentAppError as LoadAgentAppError
 from .base import AgentConnectors as AgentConnectors
+from .base import AgentEvents as AgentEvents
 from .base import AgentResponses as AgentResponses
 from .base import AgentSession as AgentSession
 
 __all__ = [
     "AgentApp",
     "AgentConnectors",
+    "AgentEvents",
     "AgentResponses",
     "AgentSession",
     "LoadAgentAppError",

--- a/framework/py/flwr/agentapp/base.py
+++ b/framework/py/flwr/agentapp/base.py
@@ -55,6 +55,14 @@ class AgentConnectors(ABC):
         """Execute one model function_call and return a function_call_output item."""
 
 
+class AgentEvents(ABC):
+    """Abstract base class for AgentApp run events."""
+
+    @abstractmethod
+    def emit(self, event: JSONObject) -> None:
+        """Emit one structured run event."""
+
+
 class AgentSession(ABC):
     """Abstract base class for AgentApp runtime capabilities."""
 
@@ -67,6 +75,11 @@ class AgentSession(ABC):
     @abstractmethod
     def connectors(self) -> AgentConnectors:
         """Connector tool schema and execution API."""
+
+    @property
+    @abstractmethod
+    def events(self) -> AgentEvents:
+        """Structured run event API."""
 
 
 AgentAppCallable = Callable[[AgentSession, Context], None]

--- a/framework/py/flwr/supercore/task_process/agent/run_agentapp.py
+++ b/framework/py/flwr/supercore/task_process/agent/run_agentapp.py
@@ -63,7 +63,12 @@ from flwr.supercore.typing import JSONObject
 from flwr.superlink.grid import HttpGrid
 
 from .context_items import append_items
-from .session import RuntimeAgentConnectors, RuntimeAgentResponses, RuntimeAgentSession
+from .session import (
+    RuntimeAgentConnectors,
+    RuntimeAgentEvents,
+    RuntimeAgentResponses,
+    RuntimeAgentSession,
+)
 
 _AGENT_INPUT_KEY = "agent.input"
 
@@ -234,7 +239,10 @@ def run_agentapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
             ),
         )
         connectors = RuntimeAgentConnectors(responses)
-        agent = RuntimeAgentSession(responses=responses, connectors=connectors)
+        events = RuntimeAgentEvents(grid._runtime_client)
+        agent = RuntimeAgentSession(
+            responses=responses, connectors=connectors, events=events
+        )
 
         # Load and run the AgentApp
         agent_app = load_app(agent_app_attr, LoadAgentAppError, app_path)

--- a/framework/py/flwr/supercore/task_process/agent/session.py
+++ b/framework/py/flwr/supercore/task_process/agent/session.py
@@ -98,7 +98,14 @@ class RuntimeAgentEvents(AgentEvents):
 
     def emit(self, event: JSONObject) -> None:
         """Emit one structured run event."""
-        _push_run_events(self._stub, [event])
+        event_type = event.get("type")
+        if not isinstance(event_type, str) or not event_type:
+            raise ValueError("Run event requires a non-empty string 'type' field.")
+        task_event = TaskEvent(
+            event=event_type,
+            data=strict_json_dumps(event, compact=True),
+        )
+        self._stub.PushTaskEvents(PushTaskEventsRequest(events=[task_event]))
 
 
 class RuntimeAgentConnectors(AgentConnectors):
@@ -350,7 +357,16 @@ class RuntimeAgentResponses(AgentResponses):
 
     def push_run_events(self, events: Sequence[JSONObject]) -> None:
         """Push structured run events for `StreamRunEvents` clients."""
-        _push_run_events(self._stub, events)
+        if not events:
+            return
+        task_events = [
+            TaskEvent(
+                event=cast(str, event["type"]),
+                data=strict_json_dumps(event, compact=True),
+            )
+            for event in events
+        ]
+        self._stub.PushTaskEvents(PushTaskEventsRequest(events=task_events))
 
     def append_and_push_run_events(self, events: list[JSONObject]) -> None:
         """Append run events to context and push them to `StreamRunEvents` clients."""
@@ -414,24 +430,3 @@ class RuntimeAgentResponses(AgentResponses):
 def _is_json_object_list(obj: JSONValue) -> bool:
     """Check if the given object is a list of JSON objects."""
     return isinstance(obj, list) and all(isinstance(item, dict) for item in obj)
-
-
-def _push_run_events(
-    stub: RuntimeHttpClient, events: Sequence[JSONObject]
-) -> None:
-    """Push structured run events through the Runtime API."""
-    if not events:
-        return
-
-    task_events = []
-    for event in events:
-        event_type = event.get("type")
-        if not isinstance(event_type, str) or not event_type:
-            raise ValueError("Run event requires a non-empty string 'type' field.")
-        task_events.append(
-            TaskEvent(
-                event=event_type,
-                data=strict_json_dumps(event, compact=True),
-            )
-        )
-    stub.PushTaskEvents(PushTaskEventsRequest(events=task_events))

--- a/framework/py/flwr/supercore/task_process/agent/session.py
+++ b/framework/py/flwr/supercore/task_process/agent/session.py
@@ -24,7 +24,7 @@ from typing import Literal, cast
 
 from google.protobuf.json_format import ParseDict
 
-from flwr.agentapp import AgentConnectors, AgentResponses, AgentSession
+from flwr.agentapp import AgentConnectors, AgentEvents, AgentResponses, AgentSession
 from flwr.app import Context, Message
 from flwr.common.serde import message_from_proto, message_to_proto
 from flwr.proto.control_pb2 import (  # pylint: disable=E0611
@@ -64,9 +64,15 @@ _DEFAULT_MODEL_REPLY_POLL_INTERVAL = 0.25
 class RuntimeAgentSession(AgentSession):
     """AgentSession bound to one AgentApp task."""
 
-    def __init__(self, responses: AgentResponses, connectors: AgentConnectors) -> None:
+    def __init__(
+        self,
+        responses: AgentResponses,
+        connectors: AgentConnectors,
+        events: AgentEvents,
+    ) -> None:
         self._responses = responses
         self._connectors = connectors
+        self._events = events
 
     @property
     def responses(self) -> AgentResponses:
@@ -77,6 +83,22 @@ class RuntimeAgentSession(AgentSession):
     def connectors(self) -> AgentConnectors:
         """Connector tool schema and execution API."""
         return self._connectors
+
+    @property
+    def events(self) -> AgentEvents:
+        """Structured run event API."""
+        return self._events
+
+
+class RuntimeAgentEvents(AgentEvents):
+    """AgentEvents implementation backed by Runtime task events."""
+
+    def __init__(self, stub: RuntimeHttpClient) -> None:
+        self._stub = stub
+
+    def emit(self, event: JSONObject) -> None:
+        """Emit one structured run event."""
+        _push_run_events(self._stub, [event])
 
 
 class RuntimeAgentConnectors(AgentConnectors):
@@ -328,16 +350,7 @@ class RuntimeAgentResponses(AgentResponses):
 
     def push_run_events(self, events: Sequence[JSONObject]) -> None:
         """Push structured run events for `StreamRunEvents` clients."""
-        if not events:
-            return
-        task_events = [
-            TaskEvent(
-                event=cast(str, event["type"]),
-                data=strict_json_dumps(event, compact=True),
-            )
-            for event in events
-        ]
-        self._stub.PushTaskEvents(PushTaskEventsRequest(events=task_events))
+        _push_run_events(self._stub, events)
 
     def append_and_push_run_events(self, events: list[JSONObject]) -> None:
         """Append run events to context and push them to `StreamRunEvents` clients."""
@@ -401,3 +414,24 @@ class RuntimeAgentResponses(AgentResponses):
 def _is_json_object_list(obj: JSONValue) -> bool:
     """Check if the given object is a list of JSON objects."""
     return isinstance(obj, list) and all(isinstance(item, dict) for item in obj)
+
+
+def _push_run_events(
+    stub: RuntimeHttpClient, events: Sequence[JSONObject]
+) -> None:
+    """Push structured run events through the Runtime API."""
+    if not events:
+        return
+
+    task_events = []
+    for event in events:
+        event_type = event.get("type")
+        if not isinstance(event_type, str) or not event_type:
+            raise ValueError("Run event requires a non-empty string 'type' field.")
+        task_events.append(
+            TaskEvent(
+                event=event_type,
+                data=strict_json_dumps(event, compact=True),
+            )
+        )
+    stub.PushTaskEvents(PushTaskEventsRequest(events=task_events))

--- a/framework/py/flwr/supercore/task_process/agent/session_test.py
+++ b/framework/py/flwr/supercore/task_process/agent/session_test.py
@@ -17,6 +17,8 @@
 
 from unittest.mock import Mock, patch
 
+import pytest
+
 from flwr.common.serde import user_config_to_proto
 from flwr.proto.control_pb2 import (  # pylint: disable=E0611
     StartAutomationRequest,
@@ -28,7 +30,9 @@ from flwr.proto.runtime_pb2 import (  # pylint: disable=E0611
     CreateTaskResponse,
     PullTaskMessageRequest,
     PullTaskMessageResponse,
+    PushTaskEventsRequest,
 )
+from flwr.proto.task_pb2 import TaskEvent  # pylint: disable=E0611
 from flwr.supercore.constant import TaskType
 from flwr.supercore.json_message.connector_message import (
     ConnectorRequest,
@@ -38,7 +42,41 @@ from flwr.supercore.task_process.connector.automation import START_AUTOMATION_TO
 from flwr.supercore.task_process.connector.registry import get_builtin_connector_tool
 from flwr.supercore.typing import JSONObject
 
-from .session import RuntimeAgentConnectors, RuntimeAgentResponses
+from .session import RuntimeAgentConnectors, RuntimeAgentEvents, RuntimeAgentResponses
+
+
+def test_emit_event_pushes_task_event() -> None:
+    """Emit should translate a structured run event to the Runtime API."""
+    stub = Mock()
+    events = RuntimeAgentEvents(stub)
+
+    events.emit({"type": "response.output_text.delta", "delta": "Hello"})
+
+    stub.PushTaskEvents.assert_called_once_with(
+        PushTaskEventsRequest(
+            events=[
+                TaskEvent(
+                    event="response.output_text.delta",
+                    data=(
+                        '{"type":"response.output_text.delta","delta":"Hello"}'
+                    ),
+                )
+            ]
+        )
+    )
+
+
+def test_emit_event_requires_type() -> None:
+    """Emit should reject events without a valid type."""
+    stub = Mock()
+    events = RuntimeAgentEvents(stub)
+
+    with pytest.raises(
+        ValueError, match="Run event requires a non-empty string 'type' field"
+    ):
+        events.emit({"message": "Hello"})
+
+    stub.PushTaskEvents.assert_not_called()
 
 
 def test_pull_task_messages_filters_by_child_task() -> None:

--- a/framework/py/flwr/supercore/task_process/agent/session_test.py
+++ b/framework/py/flwr/supercore/task_process/agent/session_test.py
@@ -52,16 +52,11 @@ def test_emit_event_pushes_task_event() -> None:
 
     events.emit({"type": "response.output_text.delta", "delta": "Hello"})
 
-    stub.PushTaskEvents.assert_called_once_with(
-        PushTaskEventsRequest(
-            events=[
-                TaskEvent(
-                    event="response.output_text.delta",
-                    data=('{"type":"response.output_text.delta","delta":"Hello"}'),
-                )
-            ]
-        )
+    event = TaskEvent(
+        event="response.output_text.delta",
+        data=('{"type":"response.output_text.delta","delta":"Hello"}'),
     )
+    stub.PushTaskEvents.assert_called_once_with(PushTaskEventsRequest(events=[event]))
 
 
 def test_emit_event_requires_type() -> None:

--- a/framework/py/flwr/supercore/task_process/agent/session_test.py
+++ b/framework/py/flwr/supercore/task_process/agent/session_test.py
@@ -57,9 +57,7 @@ def test_emit_event_pushes_task_event() -> None:
             events=[
                 TaskEvent(
                     event="response.output_text.delta",
-                    data=(
-                        '{"type":"response.output_text.delta","delta":"Hello"}'
-                    ),
+                    data=('{"type":"response.output_text.delta","delta":"Hello"}'),
                 )
             ]
         )


### PR DESCRIPTION
Added the new agentapp API:

 ```
 agent.events.emit(
      {
          "type": "response.output_text.delta",
          "delta": "Hello",
      }
  )
```

  Changes include:

  - Public AgentEvents API and AgentSession.events
  - Runtime implementation calling PushTaskEvents
  - Validation requiring a non-empty string type
  - Public export from flwr.agentapp
  - Focused runtime tests