### PR TITLE
refactor(framework): Simplify agent event publisher lifecycle

### DIFF
--- a/framework/py/flwr/supercore/task_process/agent/session.py
+++ b/framework/py/flwr/supercore/task_process/agent/session.py
@@ -103,59 +103,52 @@ class RuntimeAgentEvents(AgentEvents):
             raise RuntimeError("Agent event publish queue is full.") from exc
         self._raise_worker_error()
 
-    def flush(self) -> None:
-        """Wait until all queued events have been persisted."""
-        self._queue.join()
-        self._raise_worker_error()
-
-    def close(self) -> None:
-        """Flush pending events and stop the background publisher."""
+    def close(self, timeout: float | None = None) -> None:
+        """Publish pending events and stop the background publisher."""
         if self._closed:
             self._raise_worker_error()
             return
-        try:
-            self.flush()
-        finally:
-            self._closed = True
-            self._queue.put(_EVENT_PUBLISH_STOP)
-            self._worker.join()
+
+        self._closed = True
+        self._queue.put(_EVENT_PUBLISH_STOP)
+        self._worker.join(timeout)
+        if self._worker.is_alive():
+            raise TimeoutError("Timed out waiting for Agent event publisher to stop.")
         self._raise_worker_error()
+
+    def _flush(self, batch: list[TaskEvent]) -> None:
+        """Publish one batch of task events."""
+        try:
+            self._stub.PushTaskEvents(PushTaskEventsRequest(events=batch))
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            with self._error_lock:
+                if self._error is None:
+                    self._error = err
 
     def _run(self) -> None:
         """Upload queued events in small batches."""
         while True:
             item = self._queue.get()
             if item is _EVENT_PUBLISH_STOP:
-                self._queue.task_done()
                 return
 
             batch = [cast(TaskEvent, item)]
             deadline = time.monotonic() + _EVENT_PUBLISH_BATCH_WAIT
-            stop_after_batch = False
             while len(batch) < _EVENT_PUBLISH_BATCH_SIZE:
                 try:
-                    next_item = self._queue.get(
+                    item = self._queue.get(
                         timeout=max(0.0, deadline - time.monotonic())
                     )
                 except Empty:
                     break
-                if next_item is _EVENT_PUBLISH_STOP:
-                    self._queue.task_done()
-                    stop_after_batch = True
-                    break
-                batch.append(cast(TaskEvent, next_item))
 
-            try:
-                self._stub.PushTaskEvents(PushTaskEventsRequest(events=batch))
-            except Exception as err:  # pylint: disable=broad-exception-caught
-                with self._error_lock:
-                    if self._error is None:
-                        self._error = err
-            finally:
-                for _ in batch:
-                    self._queue.task_done()
-            if stop_after_batch:
-                return
+                if item is _EVENT_PUBLISH_STOP:
+                    self._flush(batch)
+                    return
+
+                batch.append(cast(TaskEvent, item))
+
+            self._flush(batch)
 
     def _raise_worker_error(self) -> None:
         """Raise a background publication failure in the AgentApp thread."""

--- a/framework/py/flwr/supercore/task_process/agent/session.py
+++ b/framework/py/flwr/supercore/task_process/agent/session.py
@@ -110,7 +110,7 @@ class RuntimeAgentEvents(AgentEvents):
             return
 
         self._closed = True
-        self._queue.put(_EVENT_PUBLISH_STOP)
+        self._queue.put_nowait(_EVENT_PUBLISH_STOP)
         self._worker.join(timeout)
         if self._worker.is_alive():
             raise TimeoutError("Timed out waiting for Agent event publisher to stop.")


### PR DESCRIPTION
## Issue

### Description

RuntimeAgentEvents uses Queue.join/task_done bookkeeping and a separate public flush operation to drain its background publisher. The queue stop sentinel already provides the FIFO ordering needed for shutdown.

### Related issues/PRs

This PR targets the runtime-responses-agentapp-event-control development branch.

## Proposal

### Explanation

- Remove the public flush method and queue completion bookkeeping.
- Drain pending events by enqueueing the stop sentinel and joining the worker.
- Extract batch publication and first-error storage into a private helper.
- Keep batching state local to the worker and flush a partial batch before handling the stop sentinel.
- Preserve bounded, non-blocking event enqueueing and publication error propagation.

### Checklist

- [x] Implement proposed change
- [ ] Write tests
- [ ] Update documentation
- [ ] Address LLM-reviewer comments, if applicable
- [ ] Make CI checks pass
- [ ] Ping maintainers on Slack

### Any other comments?

Verified with the focused RuntimeAgentEvents test module, Ruff, and mypy.