### PR TITLE
feat(framework): Change flwr chat default federation

### DIFF
--- a/framework/py/flwr/cli/chat/chat_app_test.py
+++ b/framework/py/flwr/cli/chat/chat_app_test.py
@@ -28,10 +28,11 @@ from flwr.supercore.constant import FLOWER_AGENT_APP_ID
 def test_chat_selects_federation_from_dropdown() -> None:
     """The federation command should offer and apply federation selections."""
     federations = [
-        Federation(name="@flower/flower-agent-execution", description="Default"),
+        Federation(name="@flower/flower-agent-execution", description="Legacy"),
+        Federation(name="@flower/personal", description="Default"),
         Federation(name="@flower/other", description="Other"),
     ]
-    completer = _ChatCompleter(Mock(), federations[0].name, federations)
+    completer = _ChatCompleter(Mock(), federations[1].name, federations)
     completions = list(
         completer.get_completions(Document("/federation @flower/o"), CompleteEvent())
     )
@@ -40,6 +41,7 @@ def test_chat_selects_federation_from_dropdown() -> None:
     application = Mock()
     with patch.object(ChatApplication, "_create_application", return_value=application):
         chat = ChatApplication(Mock(), federations, Mock())
+    assert chat.federation == "@flower/personal"
     chat.input_buffer = Mock()
     event = Mock(app=application)
 

--- a/framework/py/flwr/cli/chat/chat_test.py
+++ b/framework/py/flwr/cli/chat/chat_test.py
@@ -71,7 +71,7 @@ def test_chat_runs_interactive_application() -> None:
     )
     channel = Mock()
     stub = Mock()
-    federations = [Federation(name="@flower/flower-agent-execution")]
+    federations = [Federation(name="@flower/personal")]
     stub.ListFederations.return_value = ListFederationsResponse(federations=federations)
     auth_plugin = Mock()
 

--- a/framework/py/flwr/cli/constant.py
+++ b/framework/py/flwr/cli/constant.py
@@ -47,7 +47,7 @@ FEDERATION_CONFIG_HELP_MESSAGE = CONFIG_HELP_MESSAGE.format(
 )
 
 # Constants for `flwr chat`
-CHAT_DEFAULT_FEDERATION_NAME = "flower-agent-execution"
+CHAT_DEFAULT_FEDERATION_NAME = "personal"
 CHAT_SUPERGRID_CONNECTION_NAME = "supergrid"
 CHAT_AGENT_INPUT_KEY = "agent.input"
 CHAT_AGENTS_API_PATH = "/user/agents"


### PR DESCRIPTION
## Issue

### Description

`flwr chat` currently selects `flower-agent-execution` as its default federation. The default should be the account's `personal` federation instead.

### Related issues/PRs

None.

## Proposal

### Explanation

Change `CHAT_DEFAULT_FEDERATION_NAME` from `flower-agent-execution` to `personal`. Update the chat tests to use the new default and explicitly verify that `ChatApplication` selects `personal` when the legacy federation is also available.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html) (not needed; no user-facing documentation names the old default)
- [ ] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

Focused validation:

- `uv run --no-sync --python=3.11.14 pytest -q py/flwr/cli/chat/chat_app_test.py py/flwr/cli/chat/chat_test.py`
- `uv run --no-sync --python=3.11.14 black --check py/flwr/cli/constant.py py/flwr/cli/chat/chat_app_test.py py/flwr/cli/chat/chat_test.py`
- `uv run --no-sync --python=3.11.14 ruff check py/flwr/cli/constant.py py/flwr/cli/chat/chat_app_test.py py/flwr/cli/chat/chat_test.py`