### PR TITLE
refactor(framework): Change flwr chat default federation

### DIFF
--- a/framework/py/flwr/cli/chat/chat_app_test.py
+++ b/framework/py/flwr/cli/chat/chat_app_test.py
@@ -28,10 +28,11 @@ from flwr.supercore.constant import FLOWER_AGENT_APP_ID
 def test_chat_selects_federation_from_dropdown() -> None:
     """The federation command should offer and apply federation selections."""
     federations = [
-        Federation(name="@flower/flower-agent-execution", description="Default"),
+        Federation(name="@flower/flower-agent-execution", description="Legacy"),
+        Federation(name="@flower/personal", description="Default"),
         Federation(name="@flower/other", description="Other"),
     ]
-    completer = _ChatCompleter(Mock(), federations[0].name, federations)
+    completer = _ChatCompleter(Mock(), federations[1].name, federations)
     completions = list(
         completer.get_completions(Document("/federation @flower/o"), CompleteEvent())
     )
@@ -40,6 +41,7 @@ def test_chat_selects_federation_from_dropdown() -> None:
     application = Mock()
     with patch.object(ChatApplication, "_create_application", return_value=application):
         chat = ChatApplication(Mock(), federations, Mock())
+    assert chat.federation == "@flower/personal"
     chat.input_buffer = Mock()
     event = Mock(app=application)
 

--- a/framework/py/flwr/cli/chat/chat_app_test.py
+++ b/framework/py/flwr/cli/chat/chat_app_test.py
@@ -28,11 +28,10 @@ from flwr.supercore.constant import FLOWER_AGENT_APP_ID
 def test_chat_selects_federation_from_dropdown() -> None:
     """The federation command should offer and apply federation selections."""
     federations = [
-        Federation(name="@flower/flower-agent-execution", description="Legacy"),
         Federation(name="@flower/personal", description="Default"),
         Federation(name="@flower/other", description="Other"),
     ]
-    completer = _ChatCompleter(Mock(), federations[1].name, federations)
+    completer = _ChatCompleter(Mock(), federations[0].name, federations)
     completions = list(
         completer.get_completions(Document("/federation @flower/o"), CompleteEvent())
     )

--- a/framework/py/flwr/cli/chat/chat_app_test.py
+++ b/framework/py/flwr/cli/chat/chat_app_test.py
@@ -20,15 +20,17 @@ from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
 
 from flwr.cli.chat.chat_app import ChatApplication, _ChatCompleter
-from flwr.cli.constant import CHAT_AGENT_NAME
+from flwr.cli.constant import CHAT_AGENT_NAME, CHAT_DEFAULT_FEDERATION_NAME
 from flwr.proto.federation_pb2 import Federation  # pylint: disable=E0611
 from flwr.supercore.constant import FLOWER_AGENT_APP_ID
+
+_CHAT_FED_ID = f"@flower/{CHAT_DEFAULT_FEDERATION_NAME}"
 
 
 def test_chat_selects_federation_from_dropdown() -> None:
     """The federation command should offer and apply federation selections."""
     federations = [
-        Federation(name="@flower/personal", description="Default"),
+        Federation(name=_CHAT_FED_ID, description="Default"),
         Federation(name="@flower/other", description="Other"),
     ]
     completer = _ChatCompleter(Mock(), federations[0].name, federations)
@@ -40,7 +42,7 @@ def test_chat_selects_federation_from_dropdown() -> None:
     application = Mock()
     with patch.object(ChatApplication, "_create_application", return_value=application):
         chat = ChatApplication(Mock(), federations, Mock())
-    assert chat.federation == "@flower/personal"
+    assert chat.federation == _CHAT_FED_ID
     chat.input_buffer = Mock()
     event = Mock(app=application)
 

--- a/framework/py/flwr/cli/chat/chat_history_test.py
+++ b/framework/py/flwr/cli/chat/chat_history_test.py
@@ -21,6 +21,7 @@ from unittest.mock import Mock, patch
 from flwr.app import ConfigRecord, Context, RecordDict
 from flwr.cli.chat.chat_app import ChatApplication
 from flwr.cli.chat.chat_history import HistoryBlock
+from flwr.cli.constant import CHAT_DEFAULT_FEDERATION_NAME
 from flwr.common.serde import context_to_proto
 from flwr.proto.control_pb2 import (  # pylint: disable=E0611
     GetRunSeriesRequest,
@@ -31,7 +32,7 @@ from flwr.proto.control_pb2 import (  # pylint: disable=E0611
 from flwr.proto.federation_pb2 import Federation  # pylint: disable=E0611
 from flwr.proto.runseries_pb2 import RunSeries  # pylint: disable=E0611
 
-FEDERATION = "@flower/flower-agent-execution"
+FEDERATION = f"@flower/{CHAT_DEFAULT_FEDERATION_NAME}"
 
 
 def _create_chat(stub: Mock) -> ChatApplication:

--- a/framework/py/flwr/cli/chat/chat_test.py
+++ b/framework/py/flwr/cli/chat/chat_test.py
@@ -71,7 +71,7 @@ def test_chat_runs_interactive_application() -> None:
     )
     channel = Mock()
     stub = Mock()
-    federations = [Federation(name="@flower/flower-agent-execution")]
+    federations = [Federation(name="@flower/personal")]
     stub.ListFederations.return_value = ListFederationsResponse(federations=federations)
     auth_plugin = Mock()
 

--- a/framework/py/flwr/cli/chat/chat_test.py
+++ b/framework/py/flwr/cli/chat/chat_test.py
@@ -21,7 +21,10 @@ from unittest.mock import Mock, patch
 import click
 import pytest
 
-from flwr.cli.constant import CHAT_SUPERGRID_CONNECTION_NAME
+from flwr.cli.constant import (
+    CHAT_DEFAULT_FEDERATION_NAME,
+    CHAT_SUPERGRID_CONNECTION_NAME,
+)
 from flwr.cli.typing import SuperLinkConnection
 from flwr.proto.control_pb2 import ListFederationsResponse  # pylint: disable=E0611
 from flwr.proto.federation_pb2 import Federation  # pylint: disable=E0611
@@ -71,7 +74,7 @@ def test_chat_runs_interactive_application() -> None:
     )
     channel = Mock()
     stub = Mock()
-    federations = [Federation(name="@flower/personal")]
+    federations = [Federation(name=f"@flower/{CHAT_DEFAULT_FEDERATION_NAME}")]
     stub.ListFederations.return_value = ListFederationsResponse(federations=federations)
     auth_plugin = Mock()
 

--- a/framework/py/flwr/cli/constant.py
+++ b/framework/py/flwr/cli/constant.py
@@ -47,7 +47,7 @@ FEDERATION_CONFIG_HELP_MESSAGE = CONFIG_HELP_MESSAGE.format(
 )
 
 # Constants for `flwr chat`
-CHAT_DEFAULT_FEDERATION_NAME = "flower-agent-execution"
+CHAT_DEFAULT_FEDERATION_NAME = "personal"
 CHAT_SUPERGRID_CONNECTION_NAME = "supergrid"
 CHAT_AGENT_INPUT_KEY = "agent.input"
 CHAT_AGENTS_API_PATH = "/user/agents"


### PR DESCRIPTION
## Summary
Update the default federation used by flwr chat from flower-agent-execution to personal.

## Why
`flwr chat` should start conversations in each user’s personal federation by default, instead of using the legacy shared agent-execution federation.

## What
- Changes `CHAT_DEFAULT_FEDERATION_NAME` to personal.
- Updates the chat test fixtures to use the new default.
- Adds a regression assertion verifying that personal is selected even when flower-agent-execution is available.