### PR TITLE
feat(framework): Prepare 1.35.0 release

### DIFF
--- a/.github/framework-release.json
+++ b/.github/framework-release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.34.0",
-  "release_source_sha": "29c3fc6d96d3c1555fb94e98d16d5e0a84b34768"
+  "version": "1.35.0",
+  "release_source_sha": "9d6717243d5605bcc5307b31e57d237dab3b8e3a"
 }

--- a/baselines/docs/source/conf.py
+++ b/baselines/docs/source/conf.py
@@ -37,7 +37,7 @@ copyright = f"{datetime.date.today().year} Flower Labs GmbH"
 author = "The Flower Authors"
 
 # The full version, including alpha/beta/rc tags
-release = "1.34.0"
+release = "1.35.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/examples/custom-mods/pyproject.toml
+++ b/examples/custom-mods/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "custom-mods"
-version = "1.1.8"
+version = "1.1.9"
 description = "Custom Flower Mods in Flower Apps"
 license = { file = "LICENSE" }
 dependencies = [
@@ -21,7 +21,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 fab-include = ["custom_mods/**/*.py", "LICENSE"]
 
 [tool.flwr.app.components]

--- a/examples/docs/source/conf.py
+++ b/examples/docs/source/conf.py
@@ -29,7 +29,7 @@ copyright = f"{datetime.date.today().year} Flower Labs GmbH"
 author = "The Flower Authors"
 
 # The full version, including alpha/beta/rc tags
-release = "1.34.0"
+release = "1.35.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/examples/federated-vae/pyproject.toml
+++ b/examples/federated-vae/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "federated-vae"
-version = "1.1.8"
+version = "1.1.9"
 description = "Federated Variational Autoencoder Example with PyTorch and Flower"
 license = { file = "LICENSE" }
 dependencies = [
@@ -21,7 +21,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 fab-include = ["fedvaeexample/**/*.py", "LICENSE"]
 
 [tool.flwr.app.components]

--- a/examples/fl-dp-sa/pyproject.toml
+++ b/examples/fl-dp-sa/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fl-dp-sa"
-version = "1.1.8"
+version = "1.1.9"
 description = "Central Differential Privacy and Secure Aggregation in Flower"
 license = { file = "LICENSE" }
 dependencies = [
@@ -20,7 +20,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "fl_dp_sa.server_app:app"

--- a/examples/fl-tabular/pyproject.toml
+++ b/examples/fl-tabular/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fl-tabular"
-version = "1.1.8"
+version = "1.1.9"
 description = "Adult Census Income Tabular Dataset and Federated Learning in Flower"
 license = { file = "LICENSE" }
 dependencies = [
@@ -20,7 +20,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "fltabular.server_app:app"

--- a/examples/flower-secure-aggregation/pyproject.toml
+++ b/examples/flower-secure-aggregation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flower-secure-aggregation"
-version = "1.1.9"
+version = "1.1.10"
 description = "Secure Aggregation in Flower"
 license = {file = "LICENSE"}
 dependencies = [
@@ -20,7 +20,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "secaggexample.server_app:app"

--- a/examples/flowertune-llm-code/pyproject.toml
+++ b/examples/flowertune-llm-code/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flowertune-llm-code"
-version = "1.2.8"
+version = "1.2.9"
 description = "Base App for the Code challenge in the FlowerTune LLM Leaderboard"
 license = {file = "LICENSE"}
 # Dependencies for your Flower App
@@ -36,7 +36,7 @@ publisher = "flwrlabs"
 # Point to your ServerApp and ClientApp objects
 # Format: "<module>:<object>"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "flowertune_code.server_app:app"

--- a/examples/flowertune-llm-finance/pyproject.toml
+++ b/examples/flowertune-llm-finance/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flowertune-llm-finance"
-version = "1.2.8"
+version = "1.2.9"
 description = "Base App for the Finance challenge in the FlowerTune LLM Leaderboard"
 license = {file = "LICENSE"}
 # Dependencies for your Flower App
@@ -36,7 +36,7 @@ publisher = "flwrlabs"
 # Point to your ServerApp and ClientApp objects
 # Format: "<module>:<object>"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "flowertune_finance.server_app:app"

--- a/examples/flowertune-llm-general-nlp/pyproject.toml
+++ b/examples/flowertune-llm-general-nlp/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flowertune-llm-general-nlp"
-version = "1.2.8"
+version = "1.2.9"
 description = "Base App for the General NLP challenge in the FlowerTune LLM Leaderboard"
 license = {file = "LICENSE"}
 # Dependencies for your Flower App
@@ -36,7 +36,7 @@ publisher = "flwrlabs"
 # Point to your ServerApp and ClientApp objects
 # Format: "<module>:<object>"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "flowertune_generalnlp.server_app:app"

--- a/examples/flowertune-llm-medical/pyproject.toml
+++ b/examples/flowertune-llm-medical/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flowertune-llm-medical"
-version = "1.2.8"
+version = "1.2.9"
 description = "Base App for the Medical challenge in the FlowerTune LLM Leaderboard"
 license = {file = "LICENSE"}
 # Dependencies for your Flower App
@@ -36,7 +36,7 @@ publisher = "flwrlabs"
 # Point to your ServerApp and ClientApp objects
 # Format: "<module>:<object>"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "flowertune_medical.server_app:app"

--- a/examples/opacus/pyproject.toml
+++ b/examples/opacus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opacus-fl"
-version = "1.1.8"
+version = "1.1.9"
 description = "Sample-level Differential Privacy with Opacus in Flower"
 license = {file = "LICENSE"}
 dependencies = [
@@ -21,7 +21,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "opacus_fl.server_app:app"

--- a/examples/quickstart-catboost/pyproject.toml
+++ b/examples/quickstart-catboost/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickstart-catboost"
-version = "1.1.8"
+version = "1.1.9"
 description = "Federated Learning with CatBoost and Flower (Quickstart Example)"
 license = {file = "LICENSE"}
 dependencies = [
@@ -19,7 +19,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "quickstart_catboost.server_app:app"

--- a/examples/quickstart-fastai/pyproject.toml
+++ b/examples/quickstart-fastai/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickstart-fastai"
-version = "1.1.10"
+version = "1.1.11"
 description = "Federated Learning with Fastai and Flower (Quickstart Example)"
 license = {file = "LICENSE"}
 dependencies = [
@@ -21,7 +21,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "fastai_example.server_app:app"

--- a/examples/quickstart-huggingface/pyproject.toml
+++ b/examples/quickstart-huggingface/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickstart-huggingface"
-version = "1.1.10"
+version = "1.1.11"
 description = "Federated Learning with Hugginface Transformers and Flower (Quickstart Example)"
 license = {file = "LICENSE"}
 authors = [
@@ -26,7 +26,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "huggingface_example.server_app:app"

--- a/examples/quickstart-jax/pyproject.toml
+++ b/examples/quickstart-jax/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickstart-jax"
-version = "1.1.10"
+version = "1.1.11"
 description = "Federated Learning with JAX and Flower (Quickstart Example)"
 license = {file = "LICENSE"}
 dependencies = [
@@ -21,7 +21,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "jaxexample.server_app:app"

--- a/examples/quickstart-mlx/pyproject.toml
+++ b/examples/quickstart-mlx/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickstart-mlx"
-version = "1.1.9"
+version = "1.1.10"
 description = "Federated Learning with MLX and Flower (Quickstart Example)"
 license = {file = "LICENSE"}
 dependencies = [
@@ -19,7 +19,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "mlxexample.server_app:app"

--- a/examples/quickstart-monai/pyproject.toml
+++ b/examples/quickstart-monai/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickstart-monai"
-version = "1.1.9"
+version = "1.1.10"
 description = "Federated Learning with MONAI and Flower (Quickstart Example)"
 license = {file = "LICENSE"}
 dependencies = [
@@ -21,7 +21,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "monaiexample.server_app:app"

--- a/examples/quickstart-numpy/pyproject.toml
+++ b/examples/quickstart-numpy/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickstart-numpy"
-version = "1.1.8"
+version = "1.1.9"
 description = "Federated Learning with Numpy and Flower (Quickstart Example)"
 license = {file = "LICENSE"}
 # Dependencies for your Flower App
@@ -27,7 +27,7 @@ publisher = "flwrlabs"
 # Point to your ServerApp and ClientApp objects
 # Format: "<module>:<object>"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "quickstart_numpy.server_app:app"

--- a/examples/quickstart-pandas/pyproject.toml
+++ b/examples/quickstart-pandas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickstart-pandas"
-version = "1.1.7"
+version = "1.1.8"
 description = "Federated Learning with Pandas and Flower (Quickstart Example)"
 license = {file = "LICENSE"}
 authors = [
@@ -24,7 +24,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "pandas_example.server_app:app"

--- a/examples/quickstart-pennylane/pyproject.toml
+++ b/examples/quickstart-pennylane/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickstart-pennylane"
-version = "1.1.10"
+version = "1.1.11"
 description = "Quantum Federated Learning with PennyLane and Flower"
 license = {file = "LICENSE"}
 authors = [
@@ -28,7 +28,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "quickstart_pennylane.server_app:app"

--- a/examples/quickstart-pytorch-lightning/pyproject.toml
+++ b/examples/quickstart-pytorch-lightning/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickstart-pytorch-lightning"
-version = "1.1.9"
+version = "1.1.10"
 description = "Federated Learning with PyTorch Lightning and Flower (Quickstart Example)"
 license = {file = "LICENSE"}
 dependencies = [
@@ -21,7 +21,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "pytorchlightning_example.server_app:app"

--- a/examples/quickstart-pytorch/pyproject.toml
+++ b/examples/quickstart-pytorch/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickstart-pytorch"
-version = "1.1.10"
+version = "1.1.11"
 description = "Federated Learning with PyTorch and Flower (Quickstart Example)"
 license = {file = "LICENSE"}
 dependencies = [
@@ -20,7 +20,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "pytorchexample.server_app:app"

--- a/examples/quickstart-sklearn/pyproject.toml
+++ b/examples/quickstart-sklearn/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickstart-sklearn"
-version = "1.1.8"
+version = "1.1.9"
 description = "Federated Learning with scikit-learn and Flower (Quickstart Example)"
 license = {file = "LICENSE"}
 dependencies = [
@@ -19,7 +19,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "sklearnexample.server_app:app"

--- a/examples/quickstart-tensorflow/pyproject.toml
+++ b/examples/quickstart-tensorflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickstart-tensorflow"
-version = "1.1.10"
+version = "1.1.11"
 description = "Federated Learning with Tensorflow/Keras and Flower (Quickstart Example)"
 license = {file = "LICENSE"}
 dependencies = [
@@ -18,7 +18,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "tfexample.server_app:app"

--- a/examples/quickstart-xgboost/pyproject.toml
+++ b/examples/quickstart-xgboost/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickstart-xgboost"
-version = "1.1.9"
+version = "1.1.10"
 description = "Federated Learning with XGBoost and Flower (Quickstart Example)"
 license = {file = "LICENSE"}
 dependencies = [
@@ -19,7 +19,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "quickstart_xgboost.server_app:app"

--- a/examples/supernode-authentication/pyproject.toml
+++ b/examples/supernode-authentication/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supernode-authentication"
-version = "1.1.8"
+version = "1.1.9"
 description = "Federated Learning with PyTorch and authenticated Flower "
 license = {file = "LICENSE"}
 dependencies = [
@@ -21,7 +21,7 @@ packages = ["."]
 [tool.flwr.app]
 publisher = "flwrlabs"
 fab-format-version = 1
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 
 [tool.flwr.app.components]
 serverapp = "authexample.server_app:app"

--- a/framework/docker/base/README.md
+++ b/framework/docker/base/README.md
@@ -21,8 +21,12 @@
 
 - `unstable`
   - points to the last successful build of the `main` branch
-- `nightly`, `<version>.dev<YYYYMMDD>` e.g. `1.35.0.dev20260819`
+- `nightly`, `<version>.dev<YYYYMMDD>` e.g. `1.36.0.dev20260825`
   - uses Python 3.13 and Ubuntu 24.04
+- `1.35.0-py3.13-alpine3.22`
+- `1.35.0-py3.13-ubuntu24.04`
+- `1.35.0-py3.12-ubuntu24.04`
+- `1.35.0-py3.11-ubuntu24.04`
 - `1.34.0-py3.13-alpine3.22`
 - `1.34.0-py3.13-ubuntu24.04`
 - `1.34.0-py3.12-ubuntu24.04`

--- a/framework/docker/complete/compose.yml
+++ b/framework/docker/complete/compose.yml
@@ -1,7 +1,7 @@
 services:
   # create a SuperLink service
   superlink:
-    image: flwr/superlink:${FLWR_VERSION:-1.35.0}
+    image: flwr/superlink:${FLWR_VERSION:-1.36.0}
     command:
       - --insecure
       - --isolation
@@ -18,7 +18,7 @@ services:
     build:
       context: ${PROJECT_DIR:-.}
       dockerfile_inline: |
-        FROM flwr/superexec:${FLWR_VERSION:-1.35.0}
+        FROM flwr/superexec:${FLWR_VERSION:-1.36.0}
 
         # gcc is required for the fastai quickstart example
         USER root
@@ -46,7 +46,7 @@ services:
 
   # create two SuperNode services with different node configs
   supernode-1:
-    image: flwr/supernode:${FLWR_VERSION:-1.35.0}
+    image: flwr/supernode:${FLWR_VERSION:-1.36.0}
     command:
       - --insecure
       - --superlink
@@ -63,7 +63,7 @@ services:
       - superlink
 
   supernode-2:
-    image: flwr/supernode:${FLWR_VERSION:-1.35.0}
+    image: flwr/supernode:${FLWR_VERSION:-1.36.0}
     command:
       - --insecure
       - --superlink
@@ -82,7 +82,7 @@ services:
   # uncomment to add another SuperNode
   #
   # supernode-3:
-  #   image: flwr/supernode:${FLWR_VERSION:-1.35.0}
+  #   image: flwr/supernode:${FLWR_VERSION:-1.36.0}
   #   command:
   #     - --insecure
   #     - --superlink
@@ -103,7 +103,7 @@ services:
     build:
       context: ${PROJECT_DIR:-.}
       dockerfile_inline: |
-        FROM flwr/superexec:${FLWR_VERSION:-1.35.0}
+        FROM flwr/superexec:${FLWR_VERSION:-1.36.0}
 
         # gcc is required for the fastai quickstart example
         USER root
@@ -137,7 +137,7 @@ services:
     build:
       context: ${PROJECT_DIR:-.}
       dockerfile_inline: |
-        FROM flwr/superexec:${FLWR_VERSION:-1.35.0}
+        FROM flwr/superexec:${FLWR_VERSION:-1.36.0}
 
         # gcc is required for the fastai quickstart example
         USER root
@@ -172,7 +172,7 @@ services:
   #   build:
   #     context: ${PROJECT_DIR:-.}
   #     dockerfile_inline: |
-  #       FROM flwr/superexec:${FLWR_VERSION:-1.35.0}
+  #       FROM flwr/superexec:${FLWR_VERSION:-1.36.0}
 
   #       # gcc is required for the fastai quickstart example
   #       USER root

--- a/framework/docker/distributed/client/compose.yml
+++ b/framework/docker/distributed/client/compose.yml
@@ -1,6 +1,6 @@
 services:
   supernode-1:
-    image: flwr/supernode:${FLWR_VERSION:-1.35.0}
+    image: flwr/supernode:${FLWR_VERSION:-1.36.0}
     command:
       - --superlink
       - ${SUPERLINK_IP:-127.0.0.1}:9092
@@ -19,7 +19,7 @@ services:
         target: /app/certificates/superlink-ca.crt
 
   supernode-2:
-    image: flwr/supernode:${FLWR_VERSION:-1.35.0}
+    image: flwr/supernode:${FLWR_VERSION:-1.36.0}
     command:
       - --superlink
       - ${SUPERLINK_IP:-127.0.0.1}:9092
@@ -40,7 +40,7 @@ services:
   # uncomment to add another SuperNode
   #
   # supernode-3:
-  #   image: flwr/supernode:${FLWR_VERSION:-1.35.0}
+  #   image: flwr/supernode:${FLWR_VERSION:-1.36.0}
   #   command:
   #     - --superlink
   #     - ${SUPERLINK_IP:-127.0.0.1}:9092
@@ -62,7 +62,7 @@ services:
     build:
       context: ${PROJECT_DIR:-.}
       dockerfile_inline: |
-        FROM flwr/superexec:${FLWR_VERSION:-1.35.0}
+        FROM flwr/superexec:${FLWR_VERSION:-1.36.0}
 
         WORKDIR /app
         COPY --chown=app:app pyproject.toml .
@@ -88,7 +88,7 @@ services:
     build:
       context: ${PROJECT_DIR:-.}
       dockerfile_inline: |
-        FROM flwr/superexec:${FLWR_VERSION:-1.35.0}
+        FROM flwr/superexec:${FLWR_VERSION:-1.36.0}
 
         WORKDIR /app
         COPY --chown=app:app pyproject.toml .
@@ -115,7 +115,7 @@ services:
   #   build:
   #     context: ${PROJECT_DIR:-.}
   #     dockerfile_inline: |
-  #       FROM flwr/superexec:${FLWR_VERSION:-1.35.0}
+  #       FROM flwr/superexec:${FLWR_VERSION:-1.36.0}
 
   #       WORKDIR /app
   #       COPY --chown=app:app pyproject.toml .

--- a/framework/docker/distributed/server/compose.yml
+++ b/framework/docker/distributed/server/compose.yml
@@ -1,6 +1,6 @@
 services:
   superlink:
-    image: flwr/superlink:${FLWR_VERSION:-1.35.0}
+    image: flwr/superlink:${FLWR_VERSION:-1.36.0}
     command:
       - --isolation
       - process
@@ -29,7 +29,7 @@ services:
     build:
       context: ${PROJECT_DIR:-.}
       dockerfile_inline: |
-        FROM flwr/superexec:${FLWR_VERSION:-1.35.0}
+        FROM flwr/superexec:${FLWR_VERSION:-1.36.0}
 
         WORKDIR /app
         COPY --chown=app:app pyproject.toml .

--- a/framework/docker/superexec/README.md
+++ b/framework/docker/superexec/README.md
@@ -20,13 +20,16 @@
 ## Supported tags
 
 - `latest`
-  - points to `1.34.0` and `1.34.0-py3.13-ubuntu24.04`
+  - points to `1.35.0` and `1.35.0-py3.13-ubuntu24.04`
   - uses Python 3.13 and Ubuntu 24.04
 - `unstable`
   - points to the last successful build of the `main` branch
-- `nightly`, `<version>.dev<YYYYMMDD>` e.g. `1.35.0.dev20260819`
+- `nightly`, `<version>.dev<YYYYMMDD>` e.g. `1.36.0.dev20260825`
   - uses Python 3.13 and Ubuntu 24.04
-- `1.34.0`, `1.34.0-py3.13-ubuntu24.04`, `latest`
+- `1.35.0`, `1.35.0-py3.13-ubuntu24.04`, `latest`
+- `1.35.0-py3.12-ubuntu24.04`
+- `1.35.0-py3.11-ubuntu24.04`
+- `1.34.0`, `1.34.0-py3.13-ubuntu24.04`
 - `1.34.0-py3.12-ubuntu24.04`
 - `1.34.0-py3.11-ubuntu24.04`
 - `1.33.0`, `1.33.0-py3.13-ubuntu24.04`

--- a/framework/docker/superlink/README.md
+++ b/framework/docker/superlink/README.md
@@ -20,14 +20,16 @@
 ## Supported tags
 
 - `latest`
-  - points to `1.34.0-py3.13-ubuntu24.04`
+  - points to `1.35.0-py3.13-ubuntu24.04`
   - uses Python 3.13 and Ubuntu 24.04
 - `unstable`
   - points to the last successful build of the `main` branch
-- `nightly`, `<version>.dev<YYYYMMDD>` e.g. `1.35.0.dev20260819`
+- `nightly`, `<version>.dev<YYYYMMDD>` e.g. `1.36.0.dev20260825`
   - uses Python 3.13 and Ubuntu 24.04
+- `1.35.0`, `1.35.0-py3.13-alpine3.22`
+- `1.35.0-py3.13-ubuntu24.04`, `latest`
 - `1.34.0`, `1.34.0-py3.13-alpine3.22`
-- `1.34.0-py3.13-ubuntu24.04`, `latest`
+- `1.34.0-py3.13-ubuntu24.04`
 - `1.33.0`, `1.33.0-py3.13-alpine3.22`
 - `1.33.0-py3.13-ubuntu24.04`
 - `1.32.1`, `1.32.1-py3.13-alpine3.22`

--- a/framework/docker/supernode/README.md
+++ b/framework/docker/supernode/README.md
@@ -20,14 +20,18 @@
 ## Supported tags
 
 - `latest`
-  - points to `1.34.0-py3.13-ubuntu24.04`
+  - points to `1.35.0-py3.13-ubuntu24.04`
   - uses Python 3.13 and Ubuntu 24.04
 - `unstable`
   - points to the last successful build of the `main` branch
-- `nightly`, `<version>.dev<YYYYMMDD>` e.g. `1.35.0.dev20260819`
+- `nightly`, `<version>.dev<YYYYMMDD>` e.g. `1.36.0.dev20260825`
   - uses Python 3.13 and Ubuntu 24.04
+- `1.35.0`, `1.35.0-py3.13-alpine3.22`
+- `1.35.0-py3.13-ubuntu24.04`, `latest`
+- `1.35.0-py3.12-ubuntu24.04`
+- `1.35.0-py3.11-ubuntu24.04`
 - `1.34.0`, `1.34.0-py3.13-alpine3.22`
-- `1.34.0-py3.13-ubuntu24.04`, `latest`
+- `1.34.0-py3.13-ubuntu24.04`
 - `1.34.0-py3.12-ubuntu24.04`
 - `1.34.0-py3.11-ubuntu24.04`
 - `1.33.0`, `1.33.0-py3.13-alpine3.22`

--- a/framework/docs/source/changelog/index.md
+++ b/framework/docs/source/changelog/index.md
@@ -4,6 +4,9 @@ orphan: true
 
 # Changelog
 
+```{include} v1.35.0.md
+```
+
 ```{include} v1.34.0.md
 ```
 

--- a/framework/docs/source/changelog/v1.35.0.md
+++ b/framework/docs/source/changelog/v1.35.0.md
@@ -8,10 +8,6 @@ We would like to give our special thanks to all the contributors who made the ne
 
 ### What's new?
 
-- **Run the Runtime API over HTTP** ([#7907](https://github.com/flwrlabs/flower/pull/7907), [#7913](https://github.com/flwrlabs/flower/pull/7913), [#7923](https://github.com/flwrlabs/flower/pull/7923), [#7924](https://github.com/flwrlabs/flower/pull/7924), [#7936](https://github.com/flwrlabs/flower/pull/7936), [#7954](https://github.com/flwrlabs/flower/pull/7954), [#7955](https://github.com/flwrlabs/flower/pull/7955), [#7956](https://github.com/flwrlabs/flower/pull/7956), [#7959](https://github.com/flwrlabs/flower/pull/7959), [#7960](https://github.com/flwrlabs/flower/pull/7960), [#7963](https://github.com/flwrlabs/flower/pull/7963))
-
-  The Runtime API now uses HTTP for communication between SuperLink/SuperNode and SuperExec or `flwr` task processes.
-
 - **Use Open Responses from AgentApps (experimental)** ([#7971](https://github.com/flwrlabs/flower/pull/7971), [#7976](https://github.com/flwrlabs/flower/pull/7976), [#7977](https://github.com/flwrlabs/flower/pull/7977), [#7979](https://github.com/flwrlabs/flower/pull/7979), [#7983](https://github.com/flwrlabs/flower/pull/7983), [#7985](https://github.com/flwrlabs/flower/pull/7985))
 
   AgentApps can now call the Open Responses-compatible `/v1/runtime/responses` endpoint through the OpenAI SDK, with both JSON and SSE streaming responses. Source-task filtering and synchronized context keep parallel calls isolated, while `agent.events.emit(...)` lets apps selectively republish model events to frontends. Configured Runtime root certificates are exposed through `SSL_CERT_FILE`.
@@ -39,6 +35,10 @@ We would like to give our special thanks to all the contributors who made the ne
 - **Configure AgentApp automations** ([#7927](https://github.com/flwrlabs/flower/pull/7927), [#7961](https://github.com/flwrlabs/flower/pull/7961))
 
   New documentation covers AgentApp automations, and one-time automations no longer carry a `fixed_interval`.
+
+- **Run the Runtime API over HTTP** ([#7907](https://github.com/flwrlabs/flower/pull/7907), [#7913](https://github.com/flwrlabs/flower/pull/7913), [#7923](https://github.com/flwrlabs/flower/pull/7923), [#7924](https://github.com/flwrlabs/flower/pull/7924), [#7936](https://github.com/flwrlabs/flower/pull/7936), [#7954](https://github.com/flwrlabs/flower/pull/7954), [#7955](https://github.com/flwrlabs/flower/pull/7955), [#7956](https://github.com/flwrlabs/flower/pull/7956), [#7959](https://github.com/flwrlabs/flower/pull/7959), [#7960](https://github.com/flwrlabs/flower/pull/7960), [#7963](https://github.com/flwrlabs/flower/pull/7963))
+
+  The Runtime API now uses HTTP for communication between SuperLink/SuperNode and SuperExec or `flwr` task processes.
 
 - **Improve Framework release reliability** ([#7935](https://github.com/flwrlabs/flower/pull/7935), [#7940](https://github.com/flwrlabs/flower/pull/7940), [#7952](https://github.com/flwrlabs/flower/pull/7952))
 

--- a/framework/docs/source/changelog/v1.35.0.md
+++ b/framework/docs/source/changelog/v1.35.0.md
@@ -8,7 +8,7 @@ We would like to give our special thanks to all the contributors who made the ne
 
 ### What's new?
 
-- **Run the Runtime API over HTTP** ([#7907](https://github.com/flwrlabs/flower/pull/7907), [#7913](https://github.com/flwrlabs/flower/pull/7913), [#7923](https://github.com/flwrlabs/flower/pull/7923), [#7924](https://github.com/flwrlabs/flower/pull/7924), [#7936](https://github.com/flwrlabs/flower/pull/7936), [#7954](https://github.com/flwrlabs/flower/pull/7954), [#7955](https://github.com/flwrlabs/flower/pull/7955), [#7956](https://github.com/flwrlabs/flower/pull/7956), [#7959](https://github.com/flwrlabs/flower/pull/7959), [#7960](https://github.com/flwrlabs/flower/pull/7960), [#7963](https://github.com/flwrlabs/flower/pull/7963))
+- **Run the Runtime API over HTTP** ([#7907](https://github.com/flwrlabs/flower/pull/7907), [#7913](https://github.com/flwrlabs/flower/pull/7913), [#7923](https://github.com/flwrlabs/flower/pull/7923), [#7924](https://github.com/flwrlabs/flower/pull/7924), [#7936](https://github.com/flwrlabs/flower/pull/7936), [#7954](https://github.com/flwrlabs/flower/pull/7954), [#7956](https://github.com/flwrlabs/flower/pull/7956), [#7959](https://github.com/flwrlabs/flower/pull/7959), [#7960](https://github.com/flwrlabs/flower/pull/7960), [#7963](https://github.com/flwrlabs/flower/pull/7963))
 
   The Runtime API now uses HTTP for communication between SuperLink/SuperNode and SuperExec or `flwr` task processes.
 
@@ -47,3 +47,9 @@ We would like to give our special thanks to all the contributors who made the ne
 - **General improvements** ([#7882](https://github.com/flwrlabs/flower/pull/7882), [#7890](https://github.com/flwrlabs/flower/pull/7890), [#7937](https://github.com/flwrlabs/flower/pull/7937), [#7938](https://github.com/flwrlabs/flower/pull/7938), [#7939](https://github.com/flwrlabs/flower/pull/7939), [#7942](https://github.com/flwrlabs/flower/pull/7942), [#7943](https://github.com/flwrlabs/flower/pull/7943), [#7949](https://github.com/flwrlabs/flower/pull/7949), [#7957](https://github.com/flwrlabs/flower/pull/7957), [#7961](https://github.com/flwrlabs/flower/pull/7961), [#7968](https://github.com/flwrlabs/flower/pull/7968), [#7970](https://github.com/flwrlabs/flower/pull/7970), [#7981](https://github.com/flwrlabs/flower/pull/7981), [#7982](https://github.com/flwrlabs/flower/pull/7982), [#7989](https://github.com/flwrlabs/flower/pull/7989), [#7995](https://github.com/flwrlabs/flower/pull/7995))
 
   As always, many parts of the Flower framework and quality infrastructure were improved and updated.
+
+### Incompatible changes
+
+- **Use a single port for all HTTP APIs** ([#7955](https://github.com/flwrlabs/flower/pull/7955))
+
+  As Flower migrates its APIs from gRPC to HTTP, all API servers on each SuperLink or SuperNode will share a single port. SuperLink uses port `8000` and SuperNode uses port `9094`; currently, the Runtime API is available on these ports.

--- a/framework/docs/source/changelog/v1.35.0.md
+++ b/framework/docs/source/changelog/v1.35.0.md
@@ -50,6 +50,6 @@ We would like to give our special thanks to all the contributors who made the ne
 
 ### Incompatible changes
 
-- **Use the new default Runtime API ports** ([#7955](https://github.com/flwrlabs/flower/pull/7955))
+- **Update the default Runtime API ports** ([#7955](https://github.com/flwrlabs/flower/pull/7955))
 
   As part of the migration from gRPC to HTTP, the Runtime API now defaults to port `8000` on SuperLink and port `9094` on SuperNode. All HTTP APIs on each process share the configured port, which can be changed using `--port`.

--- a/framework/docs/source/changelog/v1.35.0.md
+++ b/framework/docs/source/changelog/v1.35.0.md
@@ -1,0 +1,61 @@
+## v1.35.0 (2026-08-25)
+
+### Thanks to our contributors
+
+We would like to give our special thanks to all the contributors who made the new version of Flower possible (in `git shortlog` order):
+
+`Charles Beauville`, `Daniel J. Beutel`, `Daniel Nata Nugraha`, `Dimitris Stripelis`, `Heng Pan`, `Javier`, `Mohammad Naseri`, `Stephane Moroso`, `Taner Topal`
+
+### What's new?
+
+- **Run the Runtime API over HTTP** ([#7907](https://github.com/flwrlabs/flower/pull/7907), [#7913](https://github.com/flwrlabs/flower/pull/7913), [#7923](https://github.com/flwrlabs/flower/pull/7923), [#7924](https://github.com/flwrlabs/flower/pull/7924), [#7936](https://github.com/flwrlabs/flower/pull/7936), [#7954](https://github.com/flwrlabs/flower/pull/7954), [#7955](https://github.com/flwrlabs/flower/pull/7955), [#7956](https://github.com/flwrlabs/flower/pull/7956), [#7959](https://github.com/flwrlabs/flower/pull/7959), [#7960](https://github.com/flwrlabs/flower/pull/7960), [#7963](https://github.com/flwrlabs/flower/pull/7963))
+
+  Flower processes now communicate through the Runtime API over HTTP across SuperLink, SuperNode, SuperExec, and `flwr-*`. Shared HTTP clients and `HttpGrid` add retries and peer-version validation, while obsolete Runtime gRPC components are removed. Fleet and Control APIs remain on gRPC.
+
+- **Use Open Responses from AgentApps (experimental)** ([#7971](https://github.com/flwrlabs/flower/pull/7971), [#7976](https://github.com/flwrlabs/flower/pull/7976), [#7977](https://github.com/flwrlabs/flower/pull/7977), [#7979](https://github.com/flwrlabs/flower/pull/7979), [#7983](https://github.com/flwrlabs/flower/pull/7983), [#7985](https://github.com/flwrlabs/flower/pull/7985))
+
+  AgentApps can now call the Open Responses-compatible `/v1/runtime/responses` endpoint through the OpenAI SDK, with both JSON and SSE streaming responses. Source-task filtering and synchronized context keep parallel calls isolated, while `agent.events.emit(...)` lets apps selectively republish model events to frontends. Configured Runtime root certificates are exposed through `SSL_CERT_FILE`.
+
+- **Continue conversations across federations in `flwr chat` (experimental)** ([#7836](https://github.com/flwrlabs/flower/pull/7836), [#7933](https://github.com/flwrlabs/flower/pull/7933), [#7964](https://github.com/flwrlabs/flower/pull/7964), [#7965](https://github.com/flwrlabs/flower/pull/7965), [#7972](https://github.com/flwrlabs/flower/pull/7972), [#7992](https://github.com/flwrlabs/flower/pull/7992))
+
+  `flwr chat` can now list prior conversations with `/history`, resume a selected run series, render responses as Markdown, and switch federations with `/federation`. New conversations use the personal federation by default.
+
+- **Manage Flower Apps in federations** ([#7932](https://github.com/flwrlabs/flower/pull/7932), [#7948](https://github.com/flwrlabs/flower/pull/7948), [#7951](https://github.com/flwrlabs/flower/pull/7951), [#7962](https://github.com/flwrlabs/flower/pull/7962), [#7987](https://github.com/flwrlabs/flower/pull/7987))
+
+  Federations can now persist apps and add or remove Hub apps through the Control API. `ListApps` always includes the built-in `@flwrlabs/flwr-agent` and reports whether an app came from Flower Hub, while leaving the provenance of legacy records unspecified.
+
+- **Build AgentApps from a dedicated starter (experimental)** ([#7903](https://github.com/flwrlabs/flower/pull/7903), [#7906](https://github.com/flwrlabs/flower/pull/7906), [#7925](https://github.com/flwrlabs/flower/pull/7925), [#7947](https://github.com/flwrlabs/flower/pull/7947))
+
+  Run `flwr new agent` to create an AgentApp from a minimal template. Refreshed guides explain AgentApp foundations, building a collaborative research app with `web_search` and `web_fetch`, and connecting Slack, Notion, GitHub, and Attio.
+
+- **Track privacy loss in fixed-clipping strategies (research preview)** ([#7934](https://github.com/flwrlabs/flower/pull/7934), [#7958](https://github.com/flwrlabs/flower/pull/7958))
+
+  Fixed-clipping strategies can now use a `PrivacyAccountant` to track cumulative ε and δ for Gaussian releases and prevent the next release from exceeding `max_epsilon`. Accounting currently requires no-amplification sampling and uniform `FedAvg` aggregation weights.
+
+- **Catch invalid Flower Apps when building FABs** ([#7950](https://github.com/flwrlabs/flower/pull/7950), [#7969](https://github.com/flwrlabs/flower/pull/7969))
+
+  `flwr build`, local `flwr run`, and `flwr app publish` now provide actionable errors for paths that exceed the FAB depth limit and exclude `.venv` contents from that check. FAB construction also validates the complete Flower App configuration, including for direct callers such as Hub publishing.
+
+- **Get consistent JSON errors from Flower HTTP APIs** ([#7890](https://github.com/flwrlabs/flower/pull/7890))
+
+  Control and Runtime HTTP APIs now return JSON failures with `detail`, an optional numeric `code`, and optional `extra` details, including on protobuf routes. Successful HTTP responses remain protobuf-encoded, and the production Control gRPC error format remains unchanged.
+
+- **Notify extensions about runs and requested results** ([#7970](https://github.com/flwrlabs/flower/pull/7970), [#7982](https://github.com/flwrlabs/flower/pull/7982))
+
+  Optional SuperLink extensions can now receive best-effort notifications after a run is persisted and when an authenticated user requests logs or AgentApp chat results. Callback failures do not affect the run or the API response.
+
+- **Configure AgentApp automations** ([#7927](https://github.com/flwrlabs/flower/pull/7927), [#7961](https://github.com/flwrlabs/flower/pull/7961))
+
+  New documentation covers AgentApp automations, and one-time automations no longer carry a `fixed_interval`.
+
+- **Improve SuperLink HTTP logging** ([#7937](https://github.com/flwrlabs/flower/pull/7937), [#7939](https://github.com/flwrlabs/flower/pull/7939), [#7942](https://github.com/flwrlabs/flower/pull/7942), [#7949](https://github.com/flwrlabs/flower/pull/7949))
+
+  SuperLink HTTP logs now use UTC timestamps, omit successful `/health` access logs, suppress noisy `httpx` and `httpcore` output, and apply the shared configuration when Uvicorn is launched directly. The logger now resides in SuperCore while its existing `flwr.common` exports remain available.
+
+- **Improve Framework release reliability** ([#7935](https://github.com/flwrlabs/flower/pull/7935), [#7940](https://github.com/flwrlabs/flower/pull/7940), [#7952](https://github.com/flwrlabs/flower/pull/7952))
+
+  Framework release finalization now promotes the intended OCI indexes to versioned and `latest` Docker tags and verifies existing release refs before reusing them. Updated documentation explains the automated preparation and publication process.
+
+- **General improvements** ([#7882](https://github.com/flwrlabs/flower/pull/7882), [#7938](https://github.com/flwrlabs/flower/pull/7938), [#7943](https://github.com/flwrlabs/flower/pull/7943), [#7957](https://github.com/flwrlabs/flower/pull/7957), [#7968](https://github.com/flwrlabs/flower/pull/7968), [#7981](https://github.com/flwrlabs/flower/pull/7981), [#7989](https://github.com/flwrlabs/flower/pull/7989), [#7995](https://github.com/flwrlabs/flower/pull/7995))
+
+  As always, many parts of the Flower framework and quality infrastructure were improved and updated.

--- a/framework/docs/source/changelog/v1.35.0.md
+++ b/framework/docs/source/changelog/v1.35.0.md
@@ -8,6 +8,10 @@ We would like to give our special thanks to all the contributors who made the ne
 
 ### What's new?
 
+- **Run the Runtime API over HTTP** ([#7907](https://github.com/flwrlabs/flower/pull/7907), [#7913](https://github.com/flwrlabs/flower/pull/7913), [#7923](https://github.com/flwrlabs/flower/pull/7923), [#7924](https://github.com/flwrlabs/flower/pull/7924), [#7936](https://github.com/flwrlabs/flower/pull/7936), [#7954](https://github.com/flwrlabs/flower/pull/7954), [#7955](https://github.com/flwrlabs/flower/pull/7955), [#7956](https://github.com/flwrlabs/flower/pull/7956), [#7959](https://github.com/flwrlabs/flower/pull/7959), [#7960](https://github.com/flwrlabs/flower/pull/7960), [#7963](https://github.com/flwrlabs/flower/pull/7963))
+
+  The Runtime API now uses HTTP for communication between SuperLink/SuperNode and SuperExec or `flwr` task processes.
+
 - **Create your first AgentApp with one command (experimental)** ([#7947](https://github.com/flwrlabs/flower/pull/7947))
 
   Run `flwr new @flwrlabs/agent` to scaffold a ready-to-customize AgentApp that sends user input to a configured model and returns its response.
@@ -35,10 +39,6 @@ We would like to give our special thanks to all the contributors who made the ne
 - **Catch invalid Flower Apps when building FABs** ([#7950](https://github.com/flwrlabs/flower/pull/7950), [#7969](https://github.com/flwrlabs/flower/pull/7969))
 
   `flwr build`, local `flwr run`, and `flwr app publish` now provide actionable errors for paths that exceed the FAB depth limit and exclude `.venv` contents from that check. FAB construction also validates the complete Flower App configuration, including for direct callers such as Hub publishing.
-
-- **Run the Runtime API over HTTP** ([#7907](https://github.com/flwrlabs/flower/pull/7907), [#7913](https://github.com/flwrlabs/flower/pull/7913), [#7923](https://github.com/flwrlabs/flower/pull/7923), [#7924](https://github.com/flwrlabs/flower/pull/7924), [#7936](https://github.com/flwrlabs/flower/pull/7936), [#7954](https://github.com/flwrlabs/flower/pull/7954), [#7955](https://github.com/flwrlabs/flower/pull/7955), [#7956](https://github.com/flwrlabs/flower/pull/7956), [#7959](https://github.com/flwrlabs/flower/pull/7959), [#7960](https://github.com/flwrlabs/flower/pull/7960), [#7963](https://github.com/flwrlabs/flower/pull/7963))
-
-  The Runtime API now uses HTTP for communication between SuperLink/SuperNode and SuperExec or `flwr` task processes.
 
 - **Improve Framework release reliability** ([#7935](https://github.com/flwrlabs/flower/pull/7935), [#7940](https://github.com/flwrlabs/flower/pull/7940), [#7952](https://github.com/flwrlabs/flower/pull/7952))
 

--- a/framework/docs/source/changelog/v1.35.0.md
+++ b/framework/docs/source/changelog/v1.35.0.md
@@ -8,7 +8,7 @@ We would like to give our special thanks to all the contributors who made the ne
 
 ### What's new?
 
-- **Run the Runtime API over HTTP** ([#7907](https://github.com/flwrlabs/flower/pull/7907), [#7913](https://github.com/flwrlabs/flower/pull/7913), [#7923](https://github.com/flwrlabs/flower/pull/7923), [#7924](https://github.com/flwrlabs/flower/pull/7924), [#7936](https://github.com/flwrlabs/flower/pull/7936), [#7954](https://github.com/flwrlabs/flower/pull/7954), [#7956](https://github.com/flwrlabs/flower/pull/7956), [#7959](https://github.com/flwrlabs/flower/pull/7959), [#7960](https://github.com/flwrlabs/flower/pull/7960), [#7963](https://github.com/flwrlabs/flower/pull/7963))
+- **Run the Runtime API over HTTP** ([#7907](https://github.com/flwrlabs/flower/pull/7907), [#7913](https://github.com/flwrlabs/flower/pull/7913), [#7923](https://github.com/flwrlabs/flower/pull/7923), [#7924](https://github.com/flwrlabs/flower/pull/7924), [#7954](https://github.com/flwrlabs/flower/pull/7954), [#7956](https://github.com/flwrlabs/flower/pull/7956), [#7959](https://github.com/flwrlabs/flower/pull/7959), [#7960](https://github.com/flwrlabs/flower/pull/7960), [#7963](https://github.com/flwrlabs/flower/pull/7963))
 
   The Runtime API now uses HTTP for communication between SuperLink/SuperNode and SuperExec or `flwr` task processes.
 
@@ -50,6 +50,6 @@ We would like to give our special thanks to all the contributors who made the ne
 
 ### Incompatible changes
 
-- **Update the default Runtime API ports** ([#7955](https://github.com/flwrlabs/flower/pull/7955))
+- **Update Runtime API addresses and CLI options** ([#7936](https://github.com/flwrlabs/flower/pull/7936), [#7955](https://github.com/flwrlabs/flower/pull/7955))
 
-  As part of the migration from gRPC to HTTP, the Runtime API now defaults to port `8000` on SuperLink and port `9094` on SuperNode. All HTTP APIs on each process share the configured port, which can be changed using `--port`.
+  Replace `--serverappio-api-address` on SuperLink and `--clientappio-api-address` on SuperNode with separate `--host` and `--port` options. The default Runtime API addresses change from `0.0.0.0:9091` to `127.0.0.1:8000` on SuperLink and from `0.0.0.0:9094` to `127.0.0.1:9094` on SuperNode. Set `--host 0.0.0.0` when the Runtime API must remain reachable externally.

--- a/framework/docs/source/changelog/v1.35.0.md
+++ b/framework/docs/source/changelog/v1.35.0.md
@@ -10,7 +10,7 @@ We would like to give our special thanks to all the contributors who made the ne
 
 - **Create your first AgentApp with one command (experimental)** ([#7947](https://github.com/flwrlabs/flower/pull/7947))
 
-  Run `flwr new agent` to scaffold a ready-to-customize AgentApp that sends user input to a configured model and returns its response.
+  Run `flwr new @flwrlabs/agent` to scaffold a ready-to-customize AgentApp that sends user input to a configured model and returns its response.
 
 - **Use Open Responses from AgentApps (experimental)** ([#7971](https://github.com/flwrlabs/flower/pull/7971), [#7976](https://github.com/flwrlabs/flower/pull/7976), [#7977](https://github.com/flwrlabs/flower/pull/7977), [#7979](https://github.com/flwrlabs/flower/pull/7979), [#7983](https://github.com/flwrlabs/flower/pull/7983), [#7985](https://github.com/flwrlabs/flower/pull/7985))
 

--- a/framework/docs/source/changelog/v1.35.0.md
+++ b/framework/docs/source/changelog/v1.35.0.md
@@ -10,7 +10,7 @@ We would like to give our special thanks to all the contributors who made the ne
 
 - **Run the Runtime API over HTTP** ([#7907](https://github.com/flwrlabs/flower/pull/7907), [#7913](https://github.com/flwrlabs/flower/pull/7913), [#7923](https://github.com/flwrlabs/flower/pull/7923), [#7924](https://github.com/flwrlabs/flower/pull/7924), [#7936](https://github.com/flwrlabs/flower/pull/7936), [#7954](https://github.com/flwrlabs/flower/pull/7954), [#7955](https://github.com/flwrlabs/flower/pull/7955), [#7956](https://github.com/flwrlabs/flower/pull/7956), [#7959](https://github.com/flwrlabs/flower/pull/7959), [#7960](https://github.com/flwrlabs/flower/pull/7960), [#7963](https://github.com/flwrlabs/flower/pull/7963))
 
-  Flower processes now communicate through the Runtime API over HTTP across SuperLink, SuperNode, SuperExec, and `flwr-*`. Shared HTTP clients and `HttpGrid` add retries and peer-version validation, while obsolete Runtime gRPC components are removed. Fleet and Control APIs remain on gRPC.
+  The Runtime API now uses HTTP for communication between SuperLink/SuperNode and SuperExec or `flwr` task processes.
 
 - **Use Open Responses from AgentApps (experimental)** ([#7971](https://github.com/flwrlabs/flower/pull/7971), [#7976](https://github.com/flwrlabs/flower/pull/7976), [#7977](https://github.com/flwrlabs/flower/pull/7977), [#7979](https://github.com/flwrlabs/flower/pull/7979), [#7983](https://github.com/flwrlabs/flower/pull/7983), [#7985](https://github.com/flwrlabs/flower/pull/7985))
 
@@ -20,9 +20,9 @@ We would like to give our special thanks to all the contributors who made the ne
 
   `flwr chat` can now list prior conversations with `/history`, resume a selected run series, render responses as Markdown, and switch federations with `/federation`. New conversations use the personal federation by default.
 
-- **Manage Flower Apps in federations** ([#7932](https://github.com/flwrlabs/flower/pull/7932), [#7948](https://github.com/flwrlabs/flower/pull/7948), [#7951](https://github.com/flwrlabs/flower/pull/7951), [#7962](https://github.com/flwrlabs/flower/pull/7962), [#7987](https://github.com/flwrlabs/flower/pull/7987))
+- **Manage Flower Apps in federations (experimental)** ([#7932](https://github.com/flwrlabs/flower/pull/7932), [#7948](https://github.com/flwrlabs/flower/pull/7948), [#7951](https://github.com/flwrlabs/flower/pull/7951), [#7962](https://github.com/flwrlabs/flower/pull/7962), [#7987](https://github.com/flwrlabs/flower/pull/7987))
 
-  Federations can now persist apps and add or remove Hub apps through the Control API. `ListApps` always includes the built-in `@flwrlabs/flwr-agent` and reports whether an app came from Flower Hub, while leaving the provenance of legacy records unspecified.
+  Federations can now persist apps and add or remove Hub apps through the Control API.
 
 - **Build AgentApps from a dedicated starter (experimental)** ([#7903](https://github.com/flwrlabs/flower/pull/7903), [#7906](https://github.com/flwrlabs/flower/pull/7906), [#7925](https://github.com/flwrlabs/flower/pull/7925), [#7947](https://github.com/flwrlabs/flower/pull/7947))
 
@@ -36,26 +36,14 @@ We would like to give our special thanks to all the contributors who made the ne
 
   `flwr build`, local `flwr run`, and `flwr app publish` now provide actionable errors for paths that exceed the FAB depth limit and exclude `.venv` contents from that check. FAB construction also validates the complete Flower App configuration, including for direct callers such as Hub publishing.
 
-- **Get consistent JSON errors from Flower HTTP APIs** ([#7890](https://github.com/flwrlabs/flower/pull/7890))
-
-  Control and Runtime HTTP APIs now return JSON failures with `detail`, an optional numeric `code`, and optional `extra` details, including on protobuf routes. Successful HTTP responses remain protobuf-encoded, and the production Control gRPC error format remains unchanged.
-
-- **Notify extensions about runs and requested results** ([#7970](https://github.com/flwrlabs/flower/pull/7970), [#7982](https://github.com/flwrlabs/flower/pull/7982))
-
-  Optional SuperLink extensions can now receive best-effort notifications after a run is persisted and when an authenticated user requests logs or AgentApp chat results. Callback failures do not affect the run or the API response.
-
 - **Configure AgentApp automations** ([#7927](https://github.com/flwrlabs/flower/pull/7927), [#7961](https://github.com/flwrlabs/flower/pull/7961))
 
   New documentation covers AgentApp automations, and one-time automations no longer carry a `fixed_interval`.
-
-- **Improve SuperLink HTTP logging** ([#7937](https://github.com/flwrlabs/flower/pull/7937), [#7939](https://github.com/flwrlabs/flower/pull/7939), [#7942](https://github.com/flwrlabs/flower/pull/7942), [#7949](https://github.com/flwrlabs/flower/pull/7949))
-
-  SuperLink HTTP logs now use UTC timestamps, omit successful `/health` access logs, suppress noisy `httpx` and `httpcore` output, and apply the shared configuration when Uvicorn is launched directly. The logger now resides in SuperCore while its existing `flwr.common` exports remain available.
 
 - **Improve Framework release reliability** ([#7935](https://github.com/flwrlabs/flower/pull/7935), [#7940](https://github.com/flwrlabs/flower/pull/7940), [#7952](https://github.com/flwrlabs/flower/pull/7952))
 
   Framework release finalization now promotes the intended OCI indexes to versioned and `latest` Docker tags and verifies existing release refs before reusing them. Updated documentation explains the automated preparation and publication process.
 
-- **General improvements** ([#7882](https://github.com/flwrlabs/flower/pull/7882), [#7938](https://github.com/flwrlabs/flower/pull/7938), [#7943](https://github.com/flwrlabs/flower/pull/7943), [#7957](https://github.com/flwrlabs/flower/pull/7957), [#7968](https://github.com/flwrlabs/flower/pull/7968), [#7981](https://github.com/flwrlabs/flower/pull/7981), [#7989](https://github.com/flwrlabs/flower/pull/7989), [#7995](https://github.com/flwrlabs/flower/pull/7995))
+- **General improvements** ([#7882](https://github.com/flwrlabs/flower/pull/7882), [#7890](https://github.com/flwrlabs/flower/pull/7890), [#7937](https://github.com/flwrlabs/flower/pull/7937), [#7938](https://github.com/flwrlabs/flower/pull/7938), [#7939](https://github.com/flwrlabs/flower/pull/7939), [#7942](https://github.com/flwrlabs/flower/pull/7942), [#7943](https://github.com/flwrlabs/flower/pull/7943), [#7949](https://github.com/flwrlabs/flower/pull/7949), [#7957](https://github.com/flwrlabs/flower/pull/7957), [#7968](https://github.com/flwrlabs/flower/pull/7968), [#7970](https://github.com/flwrlabs/flower/pull/7970), [#7981](https://github.com/flwrlabs/flower/pull/7981), [#7982](https://github.com/flwrlabs/flower/pull/7982), [#7989](https://github.com/flwrlabs/flower/pull/7989), [#7995](https://github.com/flwrlabs/flower/pull/7995))
 
   As always, many parts of the Flower framework and quality infrastructure were improved and updated.

--- a/framework/docs/source/changelog/v1.35.0.md
+++ b/framework/docs/source/changelog/v1.35.0.md
@@ -50,6 +50,6 @@ We would like to give our special thanks to all the contributors who made the ne
 
 ### Incompatible changes
 
-- **Use a single port for all HTTP APIs** ([#7955](https://github.com/flwrlabs/flower/pull/7955))
+- **Use the new default Runtime API ports** ([#7955](https://github.com/flwrlabs/flower/pull/7955))
 
-  As Flower migrates its APIs from gRPC to HTTP, all API servers on each SuperLink or SuperNode will share a single port. SuperLink uses port `8000` and SuperNode uses port `9094`; currently, the Runtime API is available on these ports.
+  As part of the migration from gRPC to HTTP, the Runtime API now defaults to port `8000` on SuperLink and port `9094` on SuperNode. All HTTP APIs on each process share the configured port, which can be changed using `--port`.

--- a/framework/docs/source/changelog/v1.35.0.md
+++ b/framework/docs/source/changelog/v1.35.0.md
@@ -8,6 +8,10 @@ We would like to give our special thanks to all the contributors who made the ne
 
 ### What's new?
 
+- **Create your first AgentApp with one command (experimental)** ([#7947](https://github.com/flwrlabs/flower/pull/7947))
+
+  Run `flwr new agent` to scaffold a ready-to-customize AgentApp that sends user input to a configured model and returns its response.
+
 - **Use Open Responses from AgentApps (experimental)** ([#7971](https://github.com/flwrlabs/flower/pull/7971), [#7976](https://github.com/flwrlabs/flower/pull/7976), [#7977](https://github.com/flwrlabs/flower/pull/7977), [#7979](https://github.com/flwrlabs/flower/pull/7979), [#7983](https://github.com/flwrlabs/flower/pull/7983), [#7985](https://github.com/flwrlabs/flower/pull/7985))
 
   AgentApps can now call the Open Responses-compatible `/v1/runtime/responses` endpoint through the OpenAI SDK, with both JSON and SSE streaming responses. Source-task filtering and synchronized context keep parallel calls isolated, while `agent.events.emit(...)` lets apps selectively republish model events to frontends. Configured Runtime root certificates are exposed through `SSL_CERT_FILE`.
@@ -20,9 +24,9 @@ We would like to give our special thanks to all the contributors who made the ne
 
   Federations can now persist apps and add or remove Hub apps through the Control API.
 
-- **Build AgentApps from a dedicated starter (experimental)** ([#7903](https://github.com/flwrlabs/flower/pull/7903), [#7906](https://github.com/flwrlabs/flower/pull/7906), [#7925](https://github.com/flwrlabs/flower/pull/7925), [#7947](https://github.com/flwrlabs/flower/pull/7947))
+- **Learn how to build, connect, and automate AgentApps (experimental)** ([#7903](https://github.com/flwrlabs/flower/pull/7903), [#7906](https://github.com/flwrlabs/flower/pull/7906), [#7925](https://github.com/flwrlabs/flower/pull/7925), [#7927](https://github.com/flwrlabs/flower/pull/7927))
 
-  Run `flwr new agent` to create an AgentApp from a minimal template. Refreshed guides explain AgentApp foundations, building a collaborative research app with `web_search` and `web_fetch`, and connecting Slack, Notion, GitHub, and Attio.
+  Flower Agent documentation now guides you through AgentApp foundations and runtime concepts, building a collaborative research app with `web_search` and `web_fetch`, connecting Slack, Notion, GitHub, and Attio, and configuring one-time or recurring automations.
 
 - **Track privacy loss in fixed-clipping strategies (research preview)** ([#7934](https://github.com/flwrlabs/flower/pull/7934), [#7958](https://github.com/flwrlabs/flower/pull/7958))
 
@@ -32,10 +36,6 @@ We would like to give our special thanks to all the contributors who made the ne
 
   `flwr build`, local `flwr run`, and `flwr app publish` now provide actionable errors for paths that exceed the FAB depth limit and exclude `.venv` contents from that check. FAB construction also validates the complete Flower App configuration, including for direct callers such as Hub publishing.
 
-- **Configure AgentApp automations** ([#7927](https://github.com/flwrlabs/flower/pull/7927), [#7961](https://github.com/flwrlabs/flower/pull/7961))
-
-  New documentation covers AgentApp automations, and one-time automations no longer carry a `fixed_interval`.
-
 - **Run the Runtime API over HTTP** ([#7907](https://github.com/flwrlabs/flower/pull/7907), [#7913](https://github.com/flwrlabs/flower/pull/7913), [#7923](https://github.com/flwrlabs/flower/pull/7923), [#7924](https://github.com/flwrlabs/flower/pull/7924), [#7936](https://github.com/flwrlabs/flower/pull/7936), [#7954](https://github.com/flwrlabs/flower/pull/7954), [#7955](https://github.com/flwrlabs/flower/pull/7955), [#7956](https://github.com/flwrlabs/flower/pull/7956), [#7959](https://github.com/flwrlabs/flower/pull/7959), [#7960](https://github.com/flwrlabs/flower/pull/7960), [#7963](https://github.com/flwrlabs/flower/pull/7963))
 
   The Runtime API now uses HTTP for communication between SuperLink/SuperNode and SuperExec or `flwr` task processes.
@@ -44,6 +44,6 @@ We would like to give our special thanks to all the contributors who made the ne
 
   Framework release finalization now promotes the intended OCI indexes to versioned and `latest` Docker tags and verifies existing release refs before reusing them. Updated documentation explains the automated preparation and publication process.
 
-- **General improvements** ([#7882](https://github.com/flwrlabs/flower/pull/7882), [#7890](https://github.com/flwrlabs/flower/pull/7890), [#7937](https://github.com/flwrlabs/flower/pull/7937), [#7938](https://github.com/flwrlabs/flower/pull/7938), [#7939](https://github.com/flwrlabs/flower/pull/7939), [#7942](https://github.com/flwrlabs/flower/pull/7942), [#7943](https://github.com/flwrlabs/flower/pull/7943), [#7949](https://github.com/flwrlabs/flower/pull/7949), [#7957](https://github.com/flwrlabs/flower/pull/7957), [#7968](https://github.com/flwrlabs/flower/pull/7968), [#7970](https://github.com/flwrlabs/flower/pull/7970), [#7981](https://github.com/flwrlabs/flower/pull/7981), [#7982](https://github.com/flwrlabs/flower/pull/7982), [#7989](https://github.com/flwrlabs/flower/pull/7989), [#7995](https://github.com/flwrlabs/flower/pull/7995))
+- **General improvements** ([#7882](https://github.com/flwrlabs/flower/pull/7882), [#7890](https://github.com/flwrlabs/flower/pull/7890), [#7937](https://github.com/flwrlabs/flower/pull/7937), [#7938](https://github.com/flwrlabs/flower/pull/7938), [#7939](https://github.com/flwrlabs/flower/pull/7939), [#7942](https://github.com/flwrlabs/flower/pull/7942), [#7943](https://github.com/flwrlabs/flower/pull/7943), [#7949](https://github.com/flwrlabs/flower/pull/7949), [#7957](https://github.com/flwrlabs/flower/pull/7957), [#7961](https://github.com/flwrlabs/flower/pull/7961), [#7968](https://github.com/flwrlabs/flower/pull/7968), [#7970](https://github.com/flwrlabs/flower/pull/7970), [#7981](https://github.com/flwrlabs/flower/pull/7981), [#7982](https://github.com/flwrlabs/flower/pull/7982), [#7989](https://github.com/flwrlabs/flower/pull/7989), [#7995](https://github.com/flwrlabs/flower/pull/7995))
 
   As always, many parts of the Flower framework and quality infrastructure were improved and updated.

--- a/framework/docs/source/changelog/v1.35.0.md
+++ b/framework/docs/source/changelog/v1.35.0.md
@@ -12,10 +12,6 @@ We would like to give our special thanks to all the contributors who made the ne
 
   The Runtime API now uses HTTP for communication between SuperLink/SuperNode and SuperExec or `flwr` task processes.
 
-- **Create your first AgentApp with one command (experimental)** ([#7947](https://github.com/flwrlabs/flower/pull/7947))
-
-  Run `flwr new @flwrlabs/agent` to scaffold a ready-to-customize AgentApp that sends user input to a configured model and returns its response.
-
 - **Use Open Responses from AgentApps (experimental)** ([#7971](https://github.com/flwrlabs/flower/pull/7971), [#7976](https://github.com/flwrlabs/flower/pull/7976), [#7977](https://github.com/flwrlabs/flower/pull/7977), [#7979](https://github.com/flwrlabs/flower/pull/7979), [#7983](https://github.com/flwrlabs/flower/pull/7983), [#7985](https://github.com/flwrlabs/flower/pull/7985))
 
   AgentApps can now call the Open Responses-compatible `/v1/runtime/responses` endpoint through the OpenAI SDK, with both JSON and SSE streaming responses. Source-task filtering and synchronized context keep parallel calls isolated, while `agent.events.emit(...)` lets apps selectively republish model events to frontends. Configured Runtime root certificates are exposed through `SSL_CERT_FILE`.
@@ -27,6 +23,10 @@ We would like to give our special thanks to all the contributors who made the ne
 - **Manage Flower Apps in federations (experimental)** ([#7932](https://github.com/flwrlabs/flower/pull/7932), [#7948](https://github.com/flwrlabs/flower/pull/7948), [#7951](https://github.com/flwrlabs/flower/pull/7951), [#7962](https://github.com/flwrlabs/flower/pull/7962), [#7987](https://github.com/flwrlabs/flower/pull/7987))
 
   Federations can now persist apps and add or remove Hub apps through the Control API.
+
+- **Create your first AgentApp with one command (experimental)** ([#7947](https://github.com/flwrlabs/flower/pull/7947))
+
+  Run `flwr new @flwrlabs/agent` to scaffold a ready-to-customize AgentApp that sends user input to a configured model and returns its response.
 
 - **Learn how to build, connect, and automate AgentApps (experimental)** ([#7903](https://github.com/flwrlabs/flower/pull/7903), [#7906](https://github.com/flwrlabs/flower/pull/7906), [#7925](https://github.com/flwrlabs/flower/pull/7925), [#7927](https://github.com/flwrlabs/flower/pull/7927))
 

--- a/framework/docs/source/conf.py
+++ b/framework/docs/source/conf.py
@@ -22,10 +22,10 @@ sys.path.insert(0, os.path.dirname(__file__))
 from conf_base import *  # noqa: F403
 
 # The full version of the next release, including alpha/beta/rc tags
-release = "1.35.0"
+release = "1.36.0"
 # The current released version
 rst_prolog = """
-.. |stable_flwr_version| replace:: 1.35.0
+.. |stable_flwr_version| replace:: 1.36.0
 .. The SuperLink Docker image digest is version-independent and does not necessarily track |stable_flwr_version|.
 .. |stable_flwr_superlink_docker_digest| replace:: 4b317d5b6030710b476f4dbfab2c3a33021ad40a0fcfa54d7edd45e0c51d889c
 .. |ubuntu_version| replace:: 24.04

--- a/framework/pyproject.toml
+++ b/framework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "flwr"
-version = "1.35.0"
+version = "1.36.0"
 description = "Flower: A Friendly Federated AI Framework"
 license = "Apache-2.0"
 authors = [{ name = "The Flower Authors", email = "hello@flower.ai" }]

--- a/framework/uv.lock
+++ b/framework/uv.lock
@@ -1478,7 +1478,7 @@ wheels = [
 
 [[package]]
 name = "flwr"
-version = "1.35.0"
+version = "1.36.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Release metadata

This summary is generated from `.github/framework-release.json`.

- Release version: `1.35.0`
- Release source SHA: `9d6717243d5605bcc5307b31e57d237dab3b8e3a`
- Release source commit: [View on GitHub](https://github.com/flwrlabs/flower/commit/9d6717243d5605bcc5307b31e57d237dab3b8e3a)
