### PR TITLE
fix(framework): Fix Control API teardown flakiness

### DIFF
--- a/framework/e2e/test_control_api.sh
+++ b/framework/e2e/test_control_api.sh
@@ -77,6 +77,31 @@ background_pids=()
 cleanup() {
   if [ "${#background_pids[@]}" -gt 0 ]; then
     kill "${background_pids[@]}" 2>/dev/null || true
+
+    # Give the services a short grace period to run their shutdown handlers. A
+    # stuck child must not hold the whole CI job until the workflow timeout.
+    cleanup_timeout=15
+    cleanup_deadline=$((SECONDS + cleanup_timeout))
+    while [ "$SECONDS" -lt "$cleanup_deadline" ]; do
+      running=false
+      for pid in "${background_pids[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+          running=true
+          break
+        fi
+      done
+
+      if [ "$running" = false ]; then
+        break
+      fi
+      sleep 1
+    done
+
+    if [ "$running" = true ]; then
+      echo "Timed out after ${cleanup_timeout}s; force-killing background services."
+      kill -KILL "${background_pids[@]}" 2>/dev/null || true
+    fi
+
     wait "${background_pids[@]}" 2>/dev/null || true
   fi
 }

--- a/framework/py/flwr/client/grpc_rere_client/connection.py
+++ b/framework/py/flwr/client/grpc_rere_client/connection.py
@@ -386,8 +386,9 @@ def grpc_request_response(  # pylint: disable=R0913,R0914,R0915,R0917
     finally:
         try:
             if node is not None:
-                # Disable retrying
-                retry_invoker.max_tries = 1
+                # Interrupt active retries before teardown RPCs. Merely lowering the
+                # attempt limit does not wake a call already waiting in backoff.
+                retry_invoker.disable_retries()
                 deactivate_node()
                 if self_registered:
                     unregister_node()

--- a/framework/py/flwr/client/grpc_rere_client/node_auth_client_interceptor_test.py
+++ b/framework/py/flwr/client/grpc_rere_client/node_auth_client_interceptor_test.py
@@ -196,10 +196,11 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
     def test_client_auth_rpc(self, grpc_call: Callable[[Any], None]) -> None:
         """Test SuperNode authentication during create node."""
         # Execute
+        retry_invoker = Mock(invoke=lambda fn, *args, **kwargs: fn(*args, **kwargs))
         with self._connection(
             self._address,
             True,
-            Mock(invoke=lambda fn, *args, **kwargs: fn(*args, **kwargs)),
+            retry_invoker,
             GRPC_MAX_MESSAGE_LENGTH,
             None,
             (self._client_private_key, self._client_public_key),
@@ -226,3 +227,5 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             assert verify_signature(
                 self._client_public_key, timestamp.encode("ascii"), signature
             )
+
+        retry_invoker.disable_retries.assert_called_once_with()

--- a/framework/py/flwr/supercore/exit/exit_handler.py
+++ b/framework/py/flwr/supercore/exit/exit_handler.py
@@ -37,7 +37,9 @@ class _RegisteredExitHandler:
 
 
 registered_exit_handlers: list[_RegisteredExitHandler] = []
-_lock_handlers = threading.Lock()
+# Python signal handlers run synchronously on the main thread and can interrupt this
+# critical section, so nested exit handling must be able to reacquire the lock.
+_lock_handlers = threading.RLock()
 
 # SIGQUIT is not available on Windows
 if hasattr(signal, "SIGQUIT"):
@@ -61,11 +63,13 @@ def add_exit_handler(
         other actions before the application exits.
     run_before_force_exit : bool (default: False)
         Whether to execute the handler before starting the force-exit timer.
+        Handlers in this phase must be short and non-blocking because the
+        watchdog has not started yet.
 
     Notes
     -----
-    The registered exit handlers will be called in LIFO order, i.e.,
-    the last registered handler will be the first to be called.
+    Handlers are called in LIFO order within each phase. Pre-force handlers
+    run before the watchdog starts; regular handlers run after it starts.
     """
     with _lock_handlers:
         registered_exit_handlers.append(
@@ -74,7 +78,16 @@ def add_exit_handler(
 
 
 def trigger_exit_handlers(*, run_before_force_exit: bool) -> None:
-    """Trigger one phase of registered exit handlers in LIFO order."""
+    """Trigger one phase of registered exit handlers in LIFO order.
+
+    The pre-force phase runs before the force-exit watchdog starts and must only
+    contain short, non-blocking operations. The regular phase runs after the
+    watchdog starts and is bounded by that watchdog.
+
+    Handlers selected for this phase are removed before execution, so each is
+    invoked at most once. Handlers registered while callbacks run remain for a
+    subsequent trigger.
+    """
     with _lock_handlers:
         handlers = []
         remaining_handlers = []
@@ -85,6 +98,8 @@ def trigger_exit_handlers(*, run_before_force_exit: bool) -> None:
                 remaining_handlers.append(registered_handler)
         registered_exit_handlers[:] = remaining_handlers
 
+    # Run callbacks without holding the registry lock. Callbacks may block or
+    # register additional handlers.
     for exit_handler in reversed(handlers):
         try:
             exit_handler()

--- a/framework/py/flwr/supercore/exit/exit_handler_test.py
+++ b/framework/py/flwr/supercore/exit/exit_handler_test.py
@@ -20,6 +20,7 @@ from collections.abc import Iterator
 import pytest
 
 from .exit_handler import (
+    _lock_handlers,
     add_exit_handler,
     registered_exit_handlers,
     trigger_exit_handlers,
@@ -112,3 +113,30 @@ def test_trigger_exit_handlers_ignores_exceptions() -> None:
 
     # Assert - all handlers should have been called in LIFO order
     assert execution_order == [3, 2, 1]
+
+
+def test_trigger_exit_handlers_does_not_run_handler_twice() -> None:
+    """A nested trigger does not invoke an already-snapshotted handler again."""
+    execution_order = []
+
+    def handler() -> None:
+        execution_order.append(1)
+        trigger_exit_handlers(run_before_force_exit=False)
+        execution_order.append(2)
+
+    add_exit_handler(handler)
+
+    trigger_exit_handlers(run_before_force_exit=False)
+
+    assert execution_order == [1, 2]
+
+
+def test_exit_handler_registry_lock_is_reentrant() -> None:
+    """The registry lock supports same-thread re-entry."""
+    with _lock_handlers:
+        # pylint: disable-next=consider-using-with
+        reacquired = _lock_handlers.acquire(blocking=False)
+        if reacquired:
+            _lock_handlers.release()
+
+    assert reacquired

--- a/framework/py/flwr/supercore/exit/signal_handler.py
+++ b/framework/py/flwr/supercore/exit/signal_handler.py
@@ -17,7 +17,7 @@
 
 import signal
 from collections.abc import Callable
-from threading import Lock, Thread
+from threading import RLock, Thread
 from types import FrameType
 
 from grpc import Server
@@ -65,7 +65,10 @@ def register_signal_handlers(
     """
     default_handlers: dict[int, Callable[[int, FrameType], None]] = {}
     is_exiting = False
-    lock = Lock()
+    # Python runs signal handlers on the main thread between bytecode instructions.
+    # A second signal can therefore re-enter this handler while its first invocation
+    # still holds the guard; an RLock prevents that same thread from deadlocking.
+    lock = RLock()
 
     def _wait_to_stop() -> None:
         if grpc_servers is not None:

--- a/framework/py/flwr/supercore/exit/signal_handler_test.py
+++ b/framework/py/flwr/supercore/exit/signal_handler_test.py
@@ -17,6 +17,7 @@
 
 import os
 import signal
+import threading
 import unittest
 from unittest.mock import Mock, patch
 
@@ -35,6 +36,10 @@ class TestExitHandlers(unittest.TestCase):
 
     def setUp(self) -> None:
         """Clear all exit handlers before each test."""
+        registered_exit_handlers.clear()
+
+    def tearDown(self) -> None:
+        """Clear all exit handlers after each test."""
         registered_exit_handlers.clear()
 
     @patch("flwr.supercore.exit.signal_handler.flwr_exit")
@@ -66,3 +71,31 @@ class TestExitHandlers(unittest.TestCase):
         # Assert
         self.assertEqual(registered_exit_handlers[0].exit_handler, handler)
         self.assertFalse(registered_exit_handlers[0].run_before_force_exit)
+
+    def test_signal_handler_reenters_exiting_guard(self) -> None:
+        """A nested signal inside the guard must not deadlock shutdown."""
+        guard = threading.RLock()
+        with (
+            patch("flwr.supercore.exit.signal_handler.RLock", return_value=guard),
+            patch("flwr.supercore.exit.signal_handler.signal.signal") as mock_signal,
+            patch("flwr.supercore.exit.signal_handler.flwr_exit") as mock_flwr_exit,
+        ):
+            register_signal_handlers(EventType.PING)
+            graceful_exit_handler = mock_signal.call_args_list[0].args[1]
+            thread_finished = threading.Event()
+
+            def invoke_while_locked() -> None:
+                with guard:
+                    graceful_exit_handler(signal.SIGTERM, Mock())
+                thread_finished.set()
+
+            thread = threading.Thread(target=invoke_while_locked, daemon=True)
+            thread.start()
+            self.assertTrue(
+                thread_finished.wait(timeout=5.0),
+                "Signal handler did not finish while re-entering its guard",
+            )
+            thread.join()
+
+        self.assertFalse(thread.is_alive())
+        mock_flwr_exit.assert_called_once()

--- a/framework/py/flwr/supercore/retry/grpc_retry.py
+++ b/framework/py/flwr/supercore/retry/grpc_retry.py
@@ -32,16 +32,64 @@ from flwr.supercore.run import RunNotRunningException
 from .retry_invoker import RetryInvoker, RetryState, exponential
 
 
+class _RetryWaitState:
+    """Coordinate retry health and cancellation with reentrant synchronization."""
+
+    def __init__(self) -> None:
+        self._condition = threading.Condition(threading.RLock())
+        self._system_healthy = True
+        self._cancelled = False
+
+    @property
+    def cancelled(self) -> bool:
+        """Return whether retry waits have been cancelled."""
+        with self._condition:
+            return self._cancelled
+
+    def mark_healthy(self) -> None:
+        """Mark the system healthy and wake waiting invocations."""
+        with self._condition:
+            self._system_healthy = True
+            self._condition.notify_all()
+
+    def mark_unhealthy(self) -> None:
+        """Mark the system unhealthy unless shutdown already cancelled retries."""
+        with self._condition:
+            if not self._cancelled:
+                self._system_healthy = False
+
+    def wait_until_healthy_or_cancelled(self, timeout: float) -> None:
+        """Wait until another invocation succeeds, shutdown starts, or timeout."""
+        with self._condition:
+            self._condition.wait_for(
+                lambda: self._system_healthy or self._cancelled,
+                timeout=timeout,
+            )
+
+    def wait_until_cancelled(self, timeout: float) -> None:
+        """Wait until shutdown cancels retries or timeout expires."""
+        with self._condition:
+            self._condition.wait_for(lambda: self._cancelled, timeout=timeout)
+
+    def cancel(self) -> None:
+        """Cancel retry waits permanently and wake all current waiters."""
+        with self._condition:
+            self._cancelled = True
+            self._system_healthy = True
+            self._condition.notify_all()
+
+
 def make_simple_grpc_retry_invoker() -> RetryInvoker:
     """Create a simple gRPC retry invoker."""
     lock = threading.Lock()
-    shutdown_lock = threading.Lock()
+    retry_wait_state = _RetryWaitState()
+    # Signal handlers can synchronously re-enter authentication failure handling.
+    shutdown_lock = threading.RLock()
     shutdown_requested = False
-    system_healthy = threading.Event()
-    system_healthy.set()  # Initially, the connection is healthy
+    retry_invoker: RetryInvoker
 
     def _on_success(retry_state: RetryState) -> None:
-        system_healthy.set()
+        retry_wait_state.mark_healthy()
         if retry_state.tries > 1:
             log(
                 INFO,
@@ -51,13 +99,13 @@ def make_simple_grpc_retry_invoker() -> RetryInvoker:
             )
 
     def _on_backoff(retry_state: RetryState) -> None:
-        system_healthy.clear()
+        retry_wait_state.mark_unhealthy()
         log(
             DEBUG, "Connection attempt failed with exception: %s", retry_state.exception
         )
 
     def _on_giveup(retry_state: RetryState) -> None:
-        system_healthy.clear()
+        retry_wait_state.mark_unhealthy()
         if retry_state.tries > 1:
             log(
                 WARN,
@@ -71,6 +119,11 @@ def make_simple_grpc_retry_invoker() -> RetryInvoker:
         if e.code() == grpc.StatusCode.PERMISSION_DENIED:  # type: ignore
             raise RunNotRunningException
         if e.code() == grpc.StatusCode.UNAUTHENTICATED:  # type: ignore
+            # Exit handlers disable retries before stopping background RPC workers.
+            # A late response from one of those workers must not interrupt the final
+            # task-output RPC with a nested shutdown signal.
+            if retry_invoker.retries_disabled:
+                return True
             # Authentication failures should trigger shutdown rather than retrying
             # This can occur, for example, when the user runs `flwr stop`
             # Note: On Windows, `os.kill` terminates the process abruptly, not ideal
@@ -82,7 +135,7 @@ def make_simple_grpc_retry_invoker() -> RetryInvoker:
                     return True
                 shutdown_requested = True
             os.kill(os.getpid(), signal.SIGINT)
-            time.sleep(FORCE_EXIT_TIMEOUT_SECONDS + 1)
+            retry_wait_state.wait_until_cancelled(FORCE_EXIT_TIMEOUT_SECONDS + 1)
             return False
         if e.code() == grpc.StatusCode.UNAVAILABLE:  # type: ignore
             # Check if this is an SSL handshake failure - these should fail fast
@@ -94,9 +147,15 @@ def make_simple_grpc_retry_invoker() -> RetryInvoker:
         return True
 
     def _wait(wait_time: float) -> None:
+        if retry_wait_state.cancelled:
+            return
+
         # Use a lock to prevent multiple gRPC calls from retrying concurrently,
         # which is unnecessary since they are all likely to fail.
         with lock:
+            if retry_wait_state.cancelled:
+                return
+
             # Log the wait time
             log(
                 WARN,
@@ -106,13 +165,21 @@ def make_simple_grpc_retry_invoker() -> RetryInvoker:
 
             start = time.monotonic()
             # Avoid sequential waits if the system is healthy
-            system_healthy.wait(wait_time)
+            retry_wait_state.wait_until_healthy_or_cancelled(wait_time)
+
+        if retry_wait_state.cancelled:
+            return
 
         remaining_time = wait_time - (time.monotonic() - start)
         if remaining_time > 0:
-            time.sleep(remaining_time)
+            retry_wait_state.wait_until_cancelled(remaining_time)
 
-    return RetryInvoker(
+    def _cancel_wait() -> None:
+        # Keep the state healthy after cancellation so all current and future
+        # waiters return, even if another invocation gives up concurrently.
+        retry_wait_state.cancel()
+
+    retry_invoker = RetryInvoker(
         wait_gen_factory=lambda: exponential(max_delay=MAX_RETRY_DELAY),
         recoverable_exceptions=grpc.RpcError,
         max_tries=None,
@@ -122,7 +189,9 @@ def make_simple_grpc_retry_invoker() -> RetryInvoker:
         on_giveup=_on_giveup,
         should_giveup=_should_giveup_fn,
         wait_function=_wait,
+        cancel_wait_function=_cancel_wait,
     )
+    return retry_invoker
 
 
 def wrap_stub(

--- a/framework/py/flwr/supercore/retry/grpc_retry_test.py
+++ b/framework/py/flwr/supercore/retry/grpc_retry_test.py
@@ -1,0 +1,176 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for gRPC retry utilities."""
+
+
+import threading
+from unittest.mock import Mock, patch
+
+import grpc
+import pytest
+
+from .grpc_retry import make_simple_grpc_retry_invoker
+from .retry_invoker import RetryState
+
+
+class _UnauthenticatedError(grpc.RpcError):  # type: ignore[misc]
+    """gRPC error reporting an authentication failure."""
+
+    def code(self) -> grpc.StatusCode:
+        """Return the gRPC status code."""
+        return grpc.StatusCode.UNAUTHENTICATED
+
+
+class _UnavailableError(grpc.RpcError):  # type: ignore[misc]
+    """gRPC error reporting an unavailable endpoint."""
+
+    def code(self) -> grpc.StatusCode:
+        """Return the gRPC status code."""
+        return grpc.StatusCode.UNAVAILABLE
+
+
+@patch("flwr.supercore.retry.grpc_retry.os.kill")
+def test_unauthenticated_does_not_signal_when_retries_disabled(
+    mock_kill: Mock,
+) -> None:
+    """Late background RPC failures must not interrupt graceful shutdown."""
+    retry_invoker = make_simple_grpc_retry_invoker()
+    retry_invoker.disable_retries()
+
+    with pytest.raises(_UnauthenticatedError):
+        retry_invoker.invoke(Mock(side_effect=_UnauthenticatedError()))
+
+    mock_kill.assert_not_called()
+
+
+@patch("flwr.supercore.retry.grpc_retry.os.kill")
+def test_unauthenticated_signals_when_max_tries_is_one(
+    mock_kill: Mock,
+) -> None:
+    """A configured one-attempt limit must not look like executor shutdown."""
+    retry_invoker = make_simple_grpc_retry_invoker()
+    retry_invoker.max_tries = 1
+    mock_kill.side_effect = lambda *_args: retry_invoker.disable_retries()
+
+    with pytest.raises(_UnauthenticatedError):
+        retry_invoker.invoke(Mock(side_effect=_UnauthenticatedError()))
+
+    mock_kill.assert_called_once()
+
+
+def test_disable_retries_interrupts_grpc_backoff() -> None:
+    """Executor shutdown must not wait for an active gRPC retry backoff."""
+    retry_invoker = make_simple_grpc_retry_invoker()
+    target_called = threading.Event()
+    invocation_finished = threading.Event()
+    errors: list[grpc.RpcError] = []
+
+    def target() -> None:
+        target_called.set()
+        raise _UnavailableError
+
+    def invoke() -> None:
+        try:
+            retry_invoker.invoke(target)
+        except grpc.RpcError as err:
+            errors.append(err)
+        finally:
+            invocation_finished.set()
+
+    thread = threading.Thread(target=invoke)
+    thread.start()
+    assert target_called.wait(timeout=5.0), "Retry target was not called"
+
+    retry_invoker.disable_retries()
+    assert invocation_finished.wait(
+        timeout=5.0
+    ), "gRPC retry invocation did not stop after cancellation"
+    thread.join()
+
+    assert not thread.is_alive()
+    assert len(errors) == 1
+
+
+def test_disable_retries_interrupts_all_grpc_backoffs() -> None:
+    """Shutdown must wake every invocation sharing the retry coordinator."""
+    retry_invoker = make_simple_grpc_retry_invoker()
+    retry_invoker.jitter = lambda _wait_time: 60.0
+    backoff_barrier = threading.Barrier(3)
+    errors: list[grpc.RpcError] = []
+    original_on_backoff = retry_invoker.on_backoff
+    assert original_on_backoff is not None
+
+    def on_backoff(retry_state: RetryState) -> None:
+        original_on_backoff(retry_state)
+        backoff_barrier.wait(timeout=5.0)
+
+    retry_invoker.on_backoff = on_backoff
+
+    def target() -> None:
+        raise _UnavailableError
+
+    def invoke(invocation_finished: threading.Event) -> None:
+        try:
+            retry_invoker.invoke(target)
+        except grpc.RpcError as err:
+            errors.append(err)
+        finally:
+            invocation_finished.set()
+
+    invocation_finished_events = [threading.Event() for _ in range(2)]
+    threads = [
+        threading.Thread(target=invoke, args=(invocation_finished,))
+        for invocation_finished in invocation_finished_events
+    ]
+    for thread in threads:
+        thread.start()
+    backoff_barrier.wait(timeout=5.0)
+
+    retry_invoker.disable_retries()
+    for invocation_finished in invocation_finished_events:
+        assert invocation_finished.wait(
+            timeout=5.0
+        ), "Concurrent gRPC retry invocation did not stop after cancellation"
+    for thread in threads:
+        thread.join()
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(errors) == 2
+
+
+def test_disable_retries_is_reentrant_from_retry_callback() -> None:
+    """A signal during a retry callback must not deadlock shutdown."""
+    retry_wait_lock = threading.RLock()
+    with patch(
+        "flwr.supercore.retry.grpc_retry.threading.RLock",
+        return_value=retry_wait_lock,
+    ):
+        retry_invoker = make_simple_grpc_retry_invoker()
+    thread_finished = threading.Event()
+
+    def disable_while_locked() -> None:
+        # Simulate SIGINT while a retry callback owns the state condition.
+        with retry_wait_lock:
+            retry_invoker.disable_retries()
+        thread_finished.set()
+
+    thread = threading.Thread(target=disable_while_locked, daemon=True)
+    thread.start()
+    assert thread_finished.wait(
+        timeout=5.0
+    ), "Retry cancellation did not finish while re-entering the wait-state lock"
+    thread.join()
+
+    assert not thread.is_alive()

--- a/framework/py/flwr/supercore/retry/retry_invoker.py
+++ b/framework/py/flwr/supercore/retry/retry_invoker.py
@@ -17,6 +17,7 @@
 
 import itertools
 import random
+import threading
 import time
 from collections.abc import Callable, Generator, Iterable
 from dataclasses import dataclass
@@ -153,6 +154,8 @@ class RetryInvoker:
         for different execution environments. If set to `None`, the `wait_function`
         defaults to `time.sleep`, which is ideal for synchronous operations. Custom
         functions should manage execution flow to prevent blocking or interference.
+    cancel_wait_function: Optional[Callable[[], None]] (default: None)
+        A function that interrupts an active retry wait when retries are disabled.
 
     Examples
     --------
@@ -181,7 +184,10 @@ class RetryInvoker:
         jitter: Callable[[float], float] | None = full_jitter,
         should_giveup: Callable[[Exception], bool] | None = None,
         wait_function: Callable[[float], None] | None = None,
+        cancel_wait_function: Callable[[], None] | None = None,
     ) -> None:
+        # Signals can synchronously re-enter `disable_retries` on the main thread.
+        self._state_lock = threading.RLock()
         self.wait_gen_factory = wait_gen_factory
         self.recoverable_exceptions = recoverable_exceptions
         self.max_tries = max_tries
@@ -191,9 +197,26 @@ class RetryInvoker:
         self.on_giveup = on_giveup
         self.jitter = jitter
         self.should_giveup = should_giveup
+        self.cancel_wait_function = cancel_wait_function
+        self._retries_disabled = False
         if wait_function is None:
             wait_function = time.sleep
         self.wait_function = wait_function
+
+    @property
+    def retries_disabled(self) -> bool:
+        """Return whether retries have been disabled."""
+        with self._state_lock:
+            return self._retries_disabled
+
+    def disable_retries(self) -> None:
+        """Disable further retries and interrupt an active retry wait."""
+        with self._state_lock:
+            self._retries_disabled = True
+            self.max_tries = 1
+            cancel_wait = self.cancel_wait_function
+        if cancel_wait is not None:
+            cancel_wait()
 
     # pylint: disable-next=too-many-locals
     def invoke(
@@ -267,7 +290,9 @@ class RetryInvoker:
             except self.recoverable_exceptions as err:
                 state.exception = err
                 # Check if giveup event should be triggered
-                max_tries_exceeded = try_cnt == self.max_tries
+                with self._state_lock:
+                    max_tries = self.max_tries
+                max_tries_exceeded = max_tries is not None and try_cnt >= max_tries
                 max_time_exceeded = (
                     self.max_time is not None and elapsed_time >= self.max_time
                 )
@@ -299,6 +324,13 @@ class RetryInvoker:
 
                 # Sleep
                 self.wait_function(state.actual_wait)
+
+                # `disable_retries` can lower the limit while the wait is active.
+                with self._state_lock:
+                    max_tries = self.max_tries
+                if max_tries is not None and try_cnt >= max_tries:
+                    try_call_event_handler(self.on_giveup)
+                    raise err
             else:
                 # Trigger success event
                 try_call_event_handler(self.on_success)

--- a/framework/py/flwr/supercore/retry/retry_invoker_test.py
+++ b/framework/py/flwr/supercore/retry/retry_invoker_test.py
@@ -15,6 +15,7 @@
 """Tests for `RetryInvoker`."""
 
 
+import threading
 from collections.abc import Generator
 from unittest.mock import MagicMock, Mock, patch
 
@@ -126,6 +127,71 @@ def test_max_tries(mock_sleep: MagicMock) -> None:
         invoker.invoke(failing_function)
     # Assert 1 sleep call due to the max_tries being set to 2
     mock_sleep.assert_called_once_with(0.1)
+
+
+def test_disable_retries_interrupts_wait() -> None:
+    """Disabling retries should stop waiting and cap an active invocation."""
+    target = Mock(side_effect=[ValueError("first"), TypeError])
+    invoker: RetryInvoker
+
+    def disable_retries(_wait_time: float) -> None:
+        invoker.disable_retries()
+
+    invoker = RetryInvoker(
+        lambda: constant(0.1),
+        ValueError,
+        max_tries=3,
+        max_time=None,
+        wait_function=disable_retries,
+    )
+
+    with pytest.raises(ValueError, match="first"):
+        invoker.invoke(target)
+
+    assert target.call_count == 1
+
+
+def test_disable_retries_calls_wait_canceller() -> None:
+    """Disabling retries should interrupt a wait already in progress."""
+    cancel_wait = Mock()
+    invoker = RetryInvoker(
+        lambda: constant(0.1),
+        ValueError,
+        max_tries=None,
+        max_time=None,
+        cancel_wait_function=cancel_wait,
+    )
+
+    invoker.disable_retries()
+
+    assert invoker.max_tries == 1
+    cancel_wait.assert_called_once_with()
+
+
+def test_disable_retries_reenters_state_update() -> None:
+    """A signal during a retry-state update must not deadlock shutdown."""
+    invoker = RetryInvoker(
+        lambda: constant(0.1),
+        ValueError,
+        max_tries=None,
+        max_time=None,
+    )
+    thread_finished = threading.Event()
+
+    def disable_while_locked() -> None:
+        with invoker._state_lock:  # pylint: disable=protected-access
+            invoker.disable_retries()
+        thread_finished.set()
+
+    thread = threading.Thread(target=disable_while_locked, daemon=True)
+    thread.start()
+    assert thread_finished.wait(
+        timeout=5.0
+    ), "Retry cancellation did not finish while re-entering its state lock"
+    thread.join()
+
+    assert not thread.is_alive()
+    assert invoker.retries_disabled
 
 
 def test_max_time(mock_time: MagicMock, mock_sleep: MagicMock) -> None:


### PR DESCRIPTION
## Problem

The `Control API / Python 3.11 / secure / client-auth / deployment-engine` E2E job can report `Training worked correctly!` and then hang during process teardown until the 10-minute job timeout.

## Cause

Shutdown races with active Fleet retry calls. A retry can remain asleep in backoff while exit handlers are re-entered by a second signal. The test script also waited indefinitely for background services, so one stuck SuperNode/SuperExec process could hold the entire job open.

## Changes

- Make exit-handler registry and signal guards reentrant, and snapshot handlers before invoking them.
- Add cancellable retry waits and stop active gRPC Fleet retries before deactivation/unregistration RPCs.
- Prevent late authentication failures from triggering nested shutdown after retries are disabled.
- Bound Control API E2E cleanup to 15 seconds, then force-kill remaining background services.

## Validation

- Focused exit/retry pytest suite: 50 passed.
- Ruff and Black checks passed.
- Targeted mypy: no issues in 5 source files.
- Exact secure/client-auth/deployment-engine Control API scenario passed locally, including teardown.