### PR TITLE
fix(framework): Avoid race condition in agent publishing

### DIFF
--- a/framework/py/flwr/supercore/task_process/agent/session.py
+++ b/framework/py/flwr/supercore/task_process/agent/session.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import json
 import time
 from collections.abc import Sequence
-from queue import Empty, Full, Queue
+from queue import Empty, Queue
 from threading import Lock, Thread
 from typing import Literal, cast
 
@@ -106,11 +106,8 @@ class RuntimeAgentEvents(AgentEvents):
             self._raise_worker_error()
             return
 
-        try:
-            self._queue.put_nowait(_EVENT_PUBLISH_STOP)
-        except Full:
-            pass  # The worker will still stop due to the `_closed` flag.
         self._closed = True
+        self._queue.put(_EVENT_PUBLISH_STOP)
         self._worker.join(timeout)
         if self._worker.is_alive():
             raise TimeoutError("Timed out waiting for Agent event publisher to stop.")
@@ -127,7 +124,7 @@ class RuntimeAgentEvents(AgentEvents):
 
     def _run(self) -> None:
         """Upload queued events in small batches."""
-        while not self._closed:
+        while True:
             item = self._queue.get()
             if item is _EVENT_PUBLISH_STOP:
                 return

--- a/framework/py/flwr/supercore/task_process/agent/session_test.py
+++ b/framework/py/flwr/supercore/task_process/agent/session_test.py
@@ -69,6 +69,31 @@ def test_emit_event_pushes_task_event() -> None:
     )
 
 
+def test_close_drains_events_before_worker_stops() -> None:
+    """Close should publish queued events before stopping the worker."""
+    stub = Mock()
+    with patch("flwr.supercore.task_process.agent.session.Thread") as thread_cls:
+        thread_cls.return_value.is_alive.return_value = False
+        events = RuntimeAgentEvents(stub)
+        worker_target = thread_cls.call_args.kwargs["target"]
+        thread_cls.return_value.join.side_effect = lambda _timeout: worker_target()
+
+        event: JSONObject = {
+            "type": "response.output_text.delta",
+            "delta": "Hello",
+        }
+        events.emit(event)
+        events.close()
+
+    expected_event = TaskEvent(
+        event="response.output_text.delta",
+        data='{"type":"response.output_text.delta","delta":"Hello"}',
+    )
+    stub.PushTaskEvents.assert_called_once_with(
+        PushTaskEventsRequest(events=[expected_event])
+    )
+
+
 def test_emit_event_requires_type() -> None:
     """Emit should reject events without a valid type."""
     stub = Mock()


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/flwrlabs/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
