### PR TITLE
docs(agent): Update agent docs flwr version to 1.35

### DIFF
--- a/agent/docs/source/explanations/agentapp-runtime.md
+++ b/agent/docs/source/explanations/agentapp-runtime.md
@@ -46,7 +46,7 @@ Provider credentials and connector implementations remain outside the FAB.
 ### Model responses
 
 `agent.responses.create(request)` accepts an Open Responses-compatible JSON
-object. The Flower 1.34.0 runtime recognizes:
+object. The Flower 1.35.0 runtime recognizes:
 
 - `model` and `input`
 - `stream`

--- a/agent/docs/source/how-to-guides/connect-accounts.md
+++ b/agent/docs/source/how-to-guides/connect-accounts.md
@@ -9,7 +9,7 @@ The current account connectors are Slack, Notion, GitHub, and Attio. Their
 implemented actions are read-only.
 
 ```{important}
-Flower 1.34.0 supports account connectors only for runs in your personal
+Flower 1.35.0 supports account connectors only for runs in your personal
 workspace. A run that selects account connectors is rejected in a collaborative
 federation. Built-in tools such as `web_search` do not require this connection
 flow.

--- a/agent/docs/source/how-to-guides/create-automations.md
+++ b/agent/docs/source/how-to-guides/create-automations.md
@@ -99,7 +99,7 @@ requested one and understands how to stop it.
 
 ## Understand automation scope
 
-The 1.34.0 runtime builds scheduled runs from the current run request. It keeps
+The 1.35.0 runtime builds scheduled runs from the current run request. It keeps
 the automation's runs in the current run series and federation and replaces
 `agent.input` with the scheduled `input`.
 
@@ -151,7 +151,7 @@ already started. Stop that run separately from its run details or with
 `flwr stop <run-id> supergrid`.
 
 There is no public CLI command for listing or stopping automations in Flower
-1.34.0. Use the automation list in SuperGrid.
+1.35.0. Use the automation list in SuperGrid.
 
 ## Recover from a failed schedule
 

--- a/agent/docs/source/how-to-guides/troubleshoot-agent-runs.md
+++ b/agent/docs/source/how-to-guides/troubleshoot-agent-runs.md
@@ -9,8 +9,8 @@ one controlled change makes the cause easier to identify.
 For a CLI-started run, record the run ID and inspect its status and logs:
 
 ```console
-$ uvx --from flwr==1.34.0 flwr list --run-id <run-id> supergrid
-$ uvx --from flwr==1.34.0 flwr log <run-id> supergrid --show
+$ uvx --from flwr==1.35.0 flwr list --run-id <run-id> supergrid
+$ uvx --from flwr==1.35.0 flwr log <run-id> supergrid --show
 ```
 
 In the browser, keep the conversation open and note the visible federation,
@@ -36,7 +36,7 @@ Preserve other connections and settings. Add only the missing section, then run
 **Symptom:** the CLI fails before opening Flower Chat, or SuperGrid asks you to
 sign in again.
 
-1. Complete `uvx --from flwr==1.34.0 flwr login supergrid` again.
+1. Complete `uvx --from flwr==1.35.0 flwr login supergrid` again.
 1. Ensure the browser flow uses the same Flower account that has Agent access.
 1. Retry one deterministic prompt in a new chat.
 
@@ -131,7 +131,7 @@ In Flower Chat, {kbd}`Ctrl+C` during a response requests a stop. Wait until the
 prompt is idle before submitting again. If the old run remains active, use:
 
 ```console
-$ uvx --from flwr==1.34.0 flwr stop <run-id> supergrid
+$ uvx --from flwr==1.35.0 flwr stop <run-id> supergrid
 ```
 
 Start a new conversation if the interrupted app left incomplete tool state that

--- a/agent/docs/source/how-to-guides/use-agents-and-federations.md
+++ b/agent/docs/source/how-to-guides/use-agents-and-federations.md
@@ -40,8 +40,8 @@ Authenticate first, then ask SuperGrid for the federations visible to your
 account:
 
 ```console
-$ uvx --from flwr==1.34.0 flwr login supergrid
-$ uvx --from flwr==1.34.0 flwr federation list supergrid
+$ uvx --from flwr==1.35.0 flwr login supergrid
+$ uvx --from flwr==1.35.0 flwr federation list supergrid
 ```
 
 Use the full federation ID shown by this command, including its leading `@`, in
@@ -51,7 +51,7 @@ later commands.
 
 The following `uv run` examples use the Flower version installed in your local
 project environment. To stay consistent with the rest of this guide, ensure
-that environment has `flwr==1.34.0` installed.
+that environment has `flwr==1.35.0` installed.
 
 Flower selects the federation in this order:
 
@@ -76,7 +76,7 @@ $ uv run flwr run . supergrid \
 The app can also be a published app spec:
 
 ```console
-$ uvx --from flwr==1.34.0 flwr run @publisher/agent supergrid \
+$ uvx --from flwr==1.35.0 flwr run @publisher/agent supergrid \
     --federation @account/federation-name \
     --run-config 'agent.input="Summarize this federation task."'
 ```
@@ -147,7 +147,7 @@ series. Use the SuperGrid browser to inspect existing conversations.
 
 Built-in tools such as `web_search` and `web_fetch` are chosen in AgentApp code.
 Slack, Notion, GitHub, and Attio are account connectors selected for a browser
-run. Flower 1.34.0 rejects account-connector references for a collaborative
+run. Flower 1.35.0 rejects account-connector references for a collaborative
 federation; run that task in your personal workspace instead.
 
 See [Connect accounts](connect-accounts.md) for setup and the exact read-only

--- a/agent/docs/source/tutorials/build-a-collaborative-agent.md
+++ b/agent/docs/source/tutorials/build-a-collaborative-agent.md
@@ -71,7 +71,7 @@ version = "0.1.0"
 description = "A bounded public-web research AgentApp"
 license = "Apache-2.0"
 requires-python = ">=3.11"
-dependencies = ["flwr==1.34.0"]
+dependencies = ["flwr==1.35.0"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["research_agent"]
@@ -79,7 +79,7 @@ packages = ["research_agent"]
 [tool.flwr.app]
 publisher = "local"
 display-name = "Research Agent"
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 fab-include = ["research_agent/**/*.py"]
 
 [tool.flwr.app.config.agent]

--- a/agent/docs/source/tutorials/get-started-with-flower-agent.md
+++ b/agent/docs/source/tutorials/get-started-with-flower-agent.md
@@ -7,7 +7,7 @@ groups messages into a conversation.
 Prefer the browser? Start with [Chat in your browser](quickstart.md).
 
 ```{note}
-This tutorial targets Flower 1.34.0. Flower Agent and `flwr chat` are
+This tutorial targets Flower 1.35.0. Flower Agent and `flwr chat` are
 experimental and may change between releases.
 ```
 
@@ -27,8 +27,8 @@ You don't need to provide model credentials for a SuperGrid run.
 Use `uvx` to run the documented version in an isolated environment:
 
 ```console
-$ uvx --from flwr==1.34.0 flwr --version
-flwr, version 1.34.0
+$ uvx --from flwr==1.35.0 flwr --version
+flwr, version 1.35.0
 ```
 
 Running an explicit version keeps every command in this tutorial on the same
@@ -48,7 +48,7 @@ address = "supergrid.flower.ai"
 If you maintain a custom file, ensure that section exists. Then log in:
 
 ```console
-$ uvx --from flwr==1.34.0 flwr login supergrid
+$ uvx --from flwr==1.35.0 flwr login supergrid
 ```
 
 Open the printed authentication link and complete sign-in. The CLI stores the
@@ -57,7 +57,7 @@ resulting account credentials for later SuperGrid commands.
 ## Start a chat
 
 ```console
-$ uvx --from flwr==1.34.0 flwr chat
+$ uvx --from flwr==1.35.0 flwr chat
 ```
 
 ```{figure} ../_static/screenshots/flwr-chat.png

--- a/agent/docs/source/tutorials/write-your-first-agentapp.md
+++ b/agent/docs/source/tutorials/write-your-first-agentapp.md
@@ -5,7 +5,7 @@ it on SuperGrid. The example makes one model request so you can isolate project
 configuration from connector logic.
 
 Complete [Chat in your terminal](get-started-with-flower-agent.md) first. This
-tutorial targets Flower 1.34.0.
+tutorial targets Flower 1.35.0.
 
 ## Create the project
 
@@ -88,7 +88,7 @@ version = "0.1.0"
 description = "My first Flower AgentApp"
 license = "Apache-2.0"
 requires-python = ">=3.11"
-dependencies = ["flwr>=1.34.0,<2.0"]
+dependencies = ["flwr>=1.35.0,<2.0"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["hello_agent"]
@@ -96,7 +96,7 @@ packages = ["hello_agent"]
 [tool.flwr.app]
 publisher = "local"
 display-name = "Hello Agent"
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 fab-include = ["hello_agent/**/*.py"]
 
 [tool.flwr.app.config.agent]


### PR DESCRIPTION
## Summary
This is documentation-only and introduces no behavioral changes. Updates the Flower Agent documentation to reference Flower 1.35.0 instead of 1.34.0, covering CLI commands, dependencies, runtime references, and `flwr-version-target` settings. This keeps all examples aligned with the latest Flower release.

## Why
Flower 1.35.0 is now the current release, but the Flower Agent documentation still referenced 1.34.0. 

## What
- CLI commands and uvx version pins
- Example project dependencies
- flwr-version-target settings
- Runtime and feature-version references
