### PR TITLE
docs(agent): Backport run operations and Ollama guides to framework 1.35

### DIFF
--- a/agent/docs/source/explanations/agentapp-runtime.md
+++ b/agent/docs/source/explanations/agentapp-runtime.md
@@ -46,7 +46,7 @@ Provider credentials and connector implementations remain outside the FAB.
 ### Model responses
 
 `agent.responses.create(request)` accepts an Open Responses-compatible JSON
-object. The Flower 1.34.0 runtime recognizes:
+object. The Flower 1.35.0 runtime recognizes:
 
 - `model` and `input`
 - `stream`

--- a/agent/docs/source/how-to-guides/connect-accounts.md
+++ b/agent/docs/source/how-to-guides/connect-accounts.md
@@ -9,7 +9,7 @@ The current account connectors are Slack, Notion, GitHub, and Attio. Their
 implemented actions are read-only.
 
 ```{important}
-Flower 1.34.0 supports account connectors only for runs in your personal
+Flower 1.35.0 supports account connectors only for runs in your personal
 workspace. A run that selects account connectors is rejected in a collaborative
 federation. Built-in tools such as `web_search` do not require this connection
 flow.

--- a/agent/docs/source/how-to-guides/create-automations.md
+++ b/agent/docs/source/how-to-guides/create-automations.md
@@ -99,7 +99,7 @@ requested one and understands how to stop it.
 
 ## Understand automation scope
 
-The 1.34.0 runtime builds scheduled runs from the current run request. It keeps
+The 1.35.0 runtime builds scheduled runs from the current run request. It keeps
 the automation's runs in the current run series and federation and replaces
 `agent.input` with the scheduled `input`.
 
@@ -151,7 +151,7 @@ already started. Stop that run separately from its run details or with
 `flwr stop <run-id> supergrid`.
 
 There is no public CLI command for listing or stopping automations in Flower
-1.34.0. Use the automation list in SuperGrid.
+1.35.0. Use the automation list in SuperGrid.
 
 ## Recover from a failed schedule
 

--- a/agent/docs/source/how-to-guides/run-on-supergrid.md
+++ b/agent/docs/source/how-to-guides/run-on-supergrid.md
@@ -1,140 +1,149 @@
 # Run an AgentApp on SuperGrid
 
-Use SuperGrid to submit an AgentApp, follow its progress, inspect its logs, and
-stop it when necessary.
+Submit an AgentApp, choose its federation, follow progress, inspect logs, and
+stop the run when necessary.
 
-If you haven't created an AgentApp yet, start with [Write your first
-AgentApp](../tutorials/write-your-first-agentapp.md).
+Start with [Write your first
+AgentApp](../tutorials/write-your-first-agentapp.md) if you do not have a valid
+AgentApp project. This guide targets Flower 1.35.0.
 
 To run the same app without SuperGrid, see [Run an AgentApp with a local
 SuperLink](run-with-local-superlink.md).
 
 ## Prepare the CLI
 
-Install [uv](https://docs.astral.sh/uv/getting-started/installation/) if you
-haven't already, then authenticate with SuperGrid:
+Install [uv](https://docs.astral.sh/uv/getting-started/installation/) and log in:
 
 ```console
-$ uvx flwr login supergrid
+$ uvx --from flwr==1.35.0 flwr login supergrid
 ```
 
-Your SuperGrid account must have access to the Flower Agent runtime. The
-`supergrid` connection is included in Flower's default CLI configuration.
+Use `uvx --from flwr==1.35.0` for standalone commands. Use `uv run flwr` for
+commands that must load the local project environment.
 
-This guide uses `uvx flwr` for standalone CLI commands and `uv run flwr` for
-commands that need a local project's environment.
+## Validate before submission
 
-If this is your first Flower Agent run, follow [Chat in your
-terminal](../tutorials/get-started-with-flower-agent.md) first. That tutorial
-uses the built-in AgentApp to check your account and CLI setup without a local
-project.
-
-## Run a local AgentApp
-
-To run your own AgentApp, open a terminal in a project whose `pyproject.toml`
-declares an `agentapp` component:
+From the project directory:
 
 ```console
-$ uv run flwr run . supergrid
+$ uv sync
+$ uv run flwr build
 ```
 
-Flower validates the project, builds a Flower App Bundle, and submits it with
-the run request. Override configured values for one run with `--run-config`:
+Fix configuration, dependency, and component-reference errors locally before
+starting a remote run.
 
-```console
-$ uv run flwr run . supergrid \
-    --run-config 'agent.input="Compare federated learning and centralized learning."'
-```
-
-An override key must already exist in the app's
-`[tool.flwr.app.config]` configuration.
-
-For a longer set of overrides, put them in a TOML file:
-
-```toml
-# run-config.toml
-[agent]
-input = "Compare federated learning and centralized learning."
-```
-
-Then pass the file to `--run-config`:
-
-```console
-$ uv run flwr run . supergrid --run-config run-config.toml
-```
-
-Don't combine a TOML file with inline `--run-config` values in the same command.
-
-## Run in another federation
-
-Every SuperGrid account has a default federation, and the commands above use it
-automatically. To run in another federation, pass its full ID:
-
-```console
-$ uv run flwr run . supergrid \
-    --federation @<account>/<federation-name> \
-    --run-config 'agent.input="Hello from this federation."'
-```
-
-The account must be a member of the target federation and entitled to start an
-AgentApp run there.
-
-## Observe the run
-
-Once SuperGrid accepts the request, `flwr run` prints a run ID. Keep it handy:
-you can use it to inspect the status and process logs:
-
-```console
-$ uvx flwr list --run-id <run-id> supergrid
-$ uvx flwr log <run-id> supergrid
-```
-
-Add `--stream` to the original run command to follow logs immediately:
+## Run a local AgentApp project
 
 ```console
 $ uv run flwr run . supergrid --stream
 ```
 
-Process logs show app output and exceptions. Open the run in the SuperGrid
-dashboard to inspect structured model responses, connector activity, and the
-persisted agent context.
+Flower builds the project, submits the FAB, prints a run ID, and streams process
+logs. Override a declared configuration value for one run:
+
+```console
+$ uv run flwr run . supergrid \
+    --run-config 'agent.input="Compare federated and centralized AI."' \
+    --stream
+```
+
+An override key must already exist under `[tool.flwr.app.config]`.
+
+For longer overrides, create `run-config.toml`:
+
+```toml
+[agent]
+input = "Compare federated and centralized AI."
+```
+
+Then run:
+
+```console
+$ uv run flwr run . supergrid --run-config run-config.toml --stream
+```
+
+Do not combine a TOML run-config file and inline run-config values.
+
+## Run a published agent
+
+Use its app spec instead of a local directory:
+
+```console
+$ uvx --from flwr==1.35.0 flwr run @publisher/agent supergrid \
+    --run-config 'agent.input="Explain your task."'
+```
+
+SuperGrid resolves the app spec to an available version of the app. Availability
+can depend on the target federation.
+
+## Choose a federation
+
+List the federations visible to your account:
+
+```console
+$ uvx --from flwr==1.35.0 flwr federation list supergrid
+```
+
+Without `--federation`, SuperGrid uses the account default. To choose another
+federation, use its full ID:
+
+```console
+$ uv run flwr run . supergrid \
+    --federation @account/federation-name \
+    --run-config 'agent.input="Hello from this federation."'
+```
+
+The account must be a member and entitled to execute AgentApps there.
+
+```{important}
+Slack, Notion, GitHub, and Attio connector references are currently accepted
+only for personal-workspace runs. Built-in tools selected by the AgentApp do not
+use the account-connector selection flow.
+```
+
+## Observe the run
+
+Use the printed run ID:
+
+```console
+$ uvx --from flwr==1.35.0 flwr list --run-id <run-id> supergrid
+$ uvx --from flwr==1.35.0 flwr log <run-id> supergrid --show
+```
+
+`flwr log` streams by default. Use `--show` to print the available logs once.
+Open the run in SuperGrid to inspect structured model output, connector
+activity, federation, and persisted context.
+
+Process logs are useful for app output and exceptions. Connector activity is a
+better signal than a general **Working** label when diagnosing which child task
+is active.
 
 ## Stop a run
 
-Stop an active run with:
-
 ```console
-$ uvx flwr stop <run-id> supergrid
+$ uvx --from flwr==1.35.0 flwr stop <run-id> supergrid
 ```
 
-Flower sends a stop request to SuperGrid and records the stopped run status.
+Wait for the run to reach a stopped terminal state before submitting a
+replacement that could duplicate external work.
 
-## Troubleshoot a failed run
+Stopping a run does not stop future automation executions. Stop the automation
+separately under **Settings** > **Automations**.
 
-Start with the detailed status and logs:
+## Recover from failure
 
-```console
-$ uvx flwr list --run-id <run-id> supergrid
-$ uvx flwr log <run-id> supergrid --stream
-```
+Use [Troubleshoot AgentApp runs](troubleshoot-agent-runs.md) for authentication,
+agent catalog, connector, heartbeat, interruption, and stuck-run recovery.
 
-Common failures include:
-
-- **Invalid component reference:** confirm that
-  `[tool.flwr.app.components].agentapp` uses `<module>:<attribute>` and resolves
-  to an `AgentApp`.
-- **Invalid run configuration:** define the key under
-  `[tool.flwr.app.config]` before overriding it.
-- **Missing dependency:** add every imported third-party package to
-  `[project].dependencies`.
-- **Unsupported model or connector:** use a model and connector available to
-  the account. Account-backed connectors must be connected and included by the
-  person starting the run.
-- **Federation or entitlement error:** verify the federation ID, membership,
-  and Flower Agent access for the account.
-
-To catch configuration and component-reference errors before submission, run:
+For a custom app, start with:
 
 ```console
 $ uv run flwr build
+$ uvx --from flwr==1.35.0 flwr list --run-id <run-id> supergrid
+$ uvx --from flwr==1.35.0 flwr log <run-id> supergrid --show
 ```
+
+Keep the run ID, series ID when visible, federation ID, app spec, Flower
+version, and exact public error. Never include credentials or private connector
+content in a support report.

--- a/agent/docs/source/how-to-guides/run-with-local-superlink.md
+++ b/agent/docs/source/how-to-guides/run-with-local-superlink.md
@@ -4,6 +4,9 @@ Run an AgentApp locally with Flower's Community Edition runtime. This setup is
 useful while developing an app: it runs SuperLink and the AgentApp processes on
 your machine, without a SuperGrid account or Enterprise services.
 
+This guide targets Flower 1.35.0. Run the CLI and SuperLink from the same
+project environment to avoid protocol mismatches.
+
 If you haven't created an AgentApp yet, start with [Write your first
 AgentApp](../tutorials/write-your-first-agentapp.md).
 
@@ -34,6 +37,10 @@ $ export FLWR_MODEL_API_KEY="<your-provider-api-key>"
 You can omit `FLWR_MODEL_API_KEY` when the custom endpoint does not require
 authentication. The model and AgentApp subprocesses inherit these variables
 from SuperLink.
+
+Account connectors configured in SuperGrid are not available to this local
+unauthenticated runtime. Built-in connectors depend on the local runtime and
+provider configuration.
 
 ## Start SuperLink
 
@@ -106,10 +113,10 @@ $ uv run flwr log <run-id> local-agent --show
 Common problems include:
 
 - **Model API key is not set:** export `FLWR_MODEL_API_KEY` in the SuperLink
-  terminal, then restart SuperLink.
+  terminal, then restart SuperLink
 - **Invalid model endpoint:** `FLWR_MODEL_API_ENDPOINT` must include the full
-  `/responses` path.
+  `/responses` path
 - **Connection refused:** confirm that SuperLink is still running and that the
-  configured address is `127.0.0.1:9093`.
+  configured address is `127.0.0.1:9093`
 - **Version mismatch:** start SuperLink and run the CLI from the same project
-  environment so they use compatible Flower versions.
+  environment so they use compatible Flower versions

--- a/agent/docs/source/how-to-guides/run-with-ollama.md
+++ b/agent/docs/source/how-to-guides/run-with-ollama.md
@@ -1,0 +1,201 @@
+# Run an AgentApp with a local SuperLink and Ollama
+
+Run a Flower AgentApp entirely on your machine with an
+[Ollama](https://ollama.com/) model and a local SuperLink. This setup does not
+require a Flower account or model API key.
+
+This guide builds on [Run an AgentApp with a local
+SuperLink](run-with-local-superlink.md) and targets Flower 1.35.0. The example
+streams responses from `qwen3.5:4b`, but you can use another model that
+supports the required Ollama endpoint.
+
+```{warning}
+This guide disables TLS and is intended for local development only. Do not
+expose the Ollama or SuperLink ports to an untrusted network.
+```
+
+## Install the prerequisites
+
+Install:
+
+- Python 3.11 or newer
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
+- Ollama 0.13.3 or newer
+
+Pull the default model:
+
+```console
+$ ollama pull qwen3.5:4b
+```
+
+Start Ollama if it is not already running through the desktop app:
+
+```console
+$ ollama serve
+```
+
+Ollama listens on `127.0.0.1:11434` by default. Leave this terminal open.
+
+## Create the AgentApp
+
+Create the project structure:
+
+```console
+$ mkdir agent-ollama
+$ cd agent-ollama
+$ mkdir agent
+$ touch agent/__init__.py
+```
+
+Create `agent/agent_app.py`:
+
+```python
+"""A minimal Flower AgentApp backed by a local Ollama model."""
+
+import os
+
+from flwr.agentapp import AgentApp, AgentSession
+from flwr.app import Context
+from openai import OpenAI
+
+app = AgentApp()
+
+
+@app.main()
+def main(agent: AgentSession, context: Context) -> None:
+    """Send the configured input to the configured Ollama model."""
+    prompt = context.run_config.get("agent.input")
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise ValueError("agent.input must be a non-empty string")
+
+    model = context.run_config.get("agent.model")
+    if not isinstance(model, str) or not model.strip():
+        raise ValueError("agent.model must be a non-empty string")
+
+    client = OpenAI(
+        base_url=os.environ["FLWR_RUNTIME_BASE_URL"],
+        api_key=os.environ["FLWR_RUNTIME_API_KEY"],
+        max_retries=0,
+    )
+    stream = client.responses.create(
+        model=model.strip(),
+        input=prompt.strip(),
+        stream=True,
+    )
+
+    output_text: list[str] = []
+    for event in stream:
+        agent.events.emit(event.to_dict())
+        if event.type in {"error", "response.failed"}:
+            raise RuntimeError(f"Model response failed: {event}")
+        if event.type == "response.output_text.delta":
+            output_text.append(event.delta)
+
+    print("".join(output_text))
+```
+
+The app connects to Flower's runtime bridge instead of connecting directly to
+Ollama. Flower supplies `FLWR_RUNTIME_BASE_URL` and `FLWR_RUNTIME_API_KEY` to
+the AgentApp process. Emitting each streamed event makes the response visible
+as structured run activity, while the final `print` also writes the complete
+text to the process log.
+
+Create `pyproject.toml`:
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "agent-ollama"
+version = "0.1.0"
+description = "A local Flower AgentApp backed by Ollama"
+license = "Apache-2.0"
+requires-python = ">=3.11,<4.0"
+dependencies = [
+    "flwr>=1.35.0,<2.0",
+    "openai>=2.16.0,<3.0.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["agent"]
+
+[tool.flwr.app]
+publisher = "local"
+display-name = "Ollama Agent"
+flwr-version-target = "1.35.0"
+fab-include = ["agent/**/*.py"]
+
+[tool.flwr.app.components]
+agentapp = "agent.agent_app:app"
+
+[tool.flwr.app.config.agent]
+model = "qwen3.5:4b"
+input = "Explain why flowers turn toward light."
+```
+
+Install the dependencies and validate the Flower App Bundle (FAB):
+
+```console
+$ uv sync
+$ uv run flwr build
+```
+
+## Connect SuperLink to Ollama
+
+Start an insecure local SuperLink from the `agent-ollama` directory and point
+its model provider at Ollama's OpenAI-compatible Responses endpoint:
+
+```console
+$ export FLWR_MODEL_API_ENDPOINT="http://127.0.0.1:11434/v1/responses"
+$ uv run flower-superlink --insecure
+```
+
+You do not need to set `FLWR_MODEL_API_KEY` because the local Ollama endpoint
+does not require authentication. Leave this terminal open.
+
+## Add the local Flower connection
+
+In another terminal, add the local SuperLink connection to
+`~/.flwr/config.toml`:
+
+```toml
+[superlink.local-agent]
+address = "127.0.0.1:9093"
+insecure = true
+```
+
+The `local-agent` connection does not require `flwr login`.
+
+## Run the app
+
+From the `agent-ollama` directory, submit the app and stream its logs:
+
+```console
+$ uv run flwr run . local-agent --stream
+```
+
+To use another model, pull it before starting the run. Then override both the
+declared model and prompt, for example:
+
+```console
+$ ollama pull qwen3.5:9b
+$ uv run flwr run . local-agent \
+    --run-config 'agent.model="qwen3.5:9b" agent.input="Explain why the sky is blue in one sentence."' \
+    --stream
+```
+
+## Troubleshoot Ollama runs
+
+- **`/v1/responses` returns `404`:** upgrade Ollama to version 0.13.3 or newer.
+- **Port `11434` refuses connections:** start Ollama with `ollama serve`, or
+  confirm that the desktop app is running.
+- **Ollama reports that the model is missing:** run `ollama pull <model>` and
+  retry the Flower run.
+- **Port `9093` refuses connections:** confirm that SuperLink is running and
+  that `local-agent` points to `127.0.0.1:9093`.
+- **The run fails without enough detail:** inspect it with `uv run flwr list --run-id <run-id> local-agent` and `uv run flwr log <run-id> local-agent --show`.
+
+Press {kbd}`Ctrl+C` in the SuperLink and `ollama serve` terminals when you are
+finished.

--- a/agent/docs/source/how-to-guides/troubleshoot-agent-runs.md
+++ b/agent/docs/source/how-to-guides/troubleshoot-agent-runs.md
@@ -9,8 +9,8 @@ one controlled change makes the cause easier to identify.
 For a CLI-started run, record the run ID and inspect its status and logs:
 
 ```console
-$ uvx --from flwr==1.34.0 flwr list --run-id <run-id> supergrid
-$ uvx --from flwr==1.34.0 flwr log <run-id> supergrid --show
+$ uvx --from flwr==1.35.0 flwr list --run-id <run-id> supergrid
+$ uvx --from flwr==1.35.0 flwr log <run-id> supergrid --show
 ```
 
 In the browser, keep the conversation open and note the visible federation,
@@ -36,7 +36,7 @@ Preserve other connections and settings. Add only the missing section, then run
 **Symptom:** the CLI fails before opening Flower Chat, or SuperGrid asks you to
 sign in again.
 
-1. Complete `uvx --from flwr==1.34.0 flwr login supergrid` again.
+1. Complete `uvx --from flwr==1.35.0 flwr login supergrid` again.
 1. Ensure the browser flow uses the same Flower account that has Agent access.
 1. Retry one deterministic prompt in a new chat.
 
@@ -131,7 +131,7 @@ In Flower Chat, {kbd}`Ctrl+C` during a response requests a stop. Wait until the
 prompt is idle before submitting again. If the old run remains active, use:
 
 ```console
-$ uvx --from flwr==1.34.0 flwr stop <run-id> supergrid
+$ uvx --from flwr==1.35.0 flwr stop <run-id> supergrid
 ```
 
 Start a new conversation if the interrupted app left incomplete tool state that

--- a/agent/docs/source/how-to-guides/use-agents-and-federations.md
+++ b/agent/docs/source/how-to-guides/use-agents-and-federations.md
@@ -40,8 +40,8 @@ Authenticate first, then ask SuperGrid for the federations visible to your
 account:
 
 ```console
-$ uvx --from flwr==1.34.0 flwr login supergrid
-$ uvx --from flwr==1.34.0 flwr federation list supergrid
+$ uvx --from flwr==1.35.0 flwr login supergrid
+$ uvx --from flwr==1.35.0 flwr federation list supergrid
 ```
 
 Use the full federation ID shown by this command, including its leading `@`, in
@@ -51,7 +51,7 @@ later commands.
 
 The following `uv run` examples use the Flower version installed in your local
 project environment. To stay consistent with the rest of this guide, ensure
-that environment has `flwr==1.34.0` installed.
+that environment has `flwr==1.35.0` installed.
 
 Flower selects the federation in this order:
 
@@ -76,7 +76,7 @@ $ uv run flwr run . supergrid \
 The app can also be a published app spec:
 
 ```console
-$ uvx --from flwr==1.34.0 flwr run @publisher/agent supergrid \
+$ uvx --from flwr==1.35.0 flwr run @publisher/agent supergrid \
     --federation @account/federation-name \
     --run-config 'agent.input="Summarize this federation task."'
 ```
@@ -86,23 +86,22 @@ AgentApp there.
 
 ## Choose the `flwr chat` federation
 
-`flwr chat` currently has no `--federation` option. It reads the optional
-`federation` value from the `supergrid` connection in `~/.flwr/config.toml`:
+`flwr chat` starts in your `@account/personal` federation. Enter
+`/federation` to open the completion menu, then select a federation visible to
+your account. You can also type its full name:
 
-```toml
-[superlink.supergrid]
-address = "supergrid.flower.ai"
-federation = "@account/federation-name"
+```text
+/federation @account/federation-name
 ```
 
-Omit `federation` to let SuperGrid use the account default. After changing the
-value, restart `flwr chat`. Use `flwr run --federation` when you need to switch
-targets frequently without editing configuration.
+Switching federations clears the transcript, resets the selected agent to
+Flower Agent, and starts a new conversation. Use `flwr run --federation` when
+you want to select the federation in a non-interactive command.
 
 ## Select an agent in Flower Chat
 
 At an empty `flwr chat` prompt, type `@`. The completion menu lists agents
-returned for the configured federation. Choose one and add your request:
+returned for the active federation. Choose one and add your request:
 
 ```text
 @publisher/agent Compare the two proposed approaches.
@@ -113,41 +112,35 @@ that agent for later messages. Selecting a different agent clears the current
 series ID, so the request starts a new run series. Use `/new` to start a new
 series without changing agents.
 
-```{note}
-The completion list is not a persistent federation Agent-management interface.
-Adding or removing the agents assigned to a federation remains planned.
-```
-
 ## Select an agent in SuperGrid
 
-Open [Flower Agent](https://flower.ai/app) and start a new chat. Use the agent
-selector above the prompt before submitting your first message. The page shows
-the federation used for the run in its header or breadcrumb.
+Open [Flower Agent](https://flower.ai/app). The sidebar pins your personal
+federation and lists the other federations visible to your account. Select a
+federation, open **New chat**, and choose one of its assigned agents above the
+prompt.
 
-The current browser Agent flow uses the account's Agent execution workspace.
-Federation navigation lets you inspect other federation activity, but it is not
-yet a complete persistent add/remove/select management workflow for arbitrary
-collaborative federations. Use `flwr run --federation` when you need an explicit
-CLI target.
+The selected federation owns the run and its conversation. Recent AgentApp
+conversations appear below that federation in the sidebar, where you can open
+them again. Flower excludes non-AgentApp run series from this chat history.
 
 ## Know when a new series starts
 
-| Action                                       | Result                               |
-| -------------------------------------------- | ------------------------------------ |
-| Send another message with the selected agent | Reuse the current run series         |
-| Enter `/new` in Flower Chat                  | The next message starts a new series |
-| Select a different leading `@agent`          | Start a new series with that agent   |
-| Select **New chat** in SuperGrid             | Start a new browser conversation     |
-| Run `flwr run` without a series ID           | Start an independent run or series   |
-
-The CLI does not currently offer interactive restoration of a previous chat
-series. Use the SuperGrid browser to inspect existing conversations.
+| Action                                       | Result                                |
+| -------------------------------------------- | ------------------------------------- |
+| Send another message with the selected agent | Reuse the current run series          |
+| Enter `/new` in Flower Chat                  | The next message starts a new series  |
+| Select a different leading `@agent`          | Start a new series with that agent    |
+| Enter `/history` in Flower Chat              | Select and continue an older series   |
+| Switch federations in Flower Chat            | Start a new series in that federation |
+| Select **New chat** in SuperGrid             | Start a new browser conversation      |
+| Select a browser conversation                | Continue its existing run series      |
+| Run `flwr run` without a series ID           | Start an independent run or series    |
 
 ## Use connectors in the right workspace
 
 Built-in tools such as `web_search` and `web_fetch` are chosen in AgentApp code.
 Slack, Notion, GitHub, and Attio are account connectors selected for a browser
-run. Flower 1.34.0 rejects account-connector references for a collaborative
+run. Flower 1.35.0 rejects account-connector references for a collaborative
 federation; run that task in your personal workspace instead.
 
 See [Connect accounts](connect-accounts.md) for setup and the exact read-only

--- a/agent/docs/source/index.md
+++ b/agent/docs/source/index.md
@@ -80,6 +80,5 @@ reference](https://flower.ai/docs/framework/ref-api/flwr.agentapp.html) remains
 in the Flower framework documentation.
 
 Design proposals and partially implemented paths aren't documented as current
-capabilities. Persistent federation Agent management, Hub publishing of
-first-class AgentApps, persistent CLI conversation history, and a public Open
-Responses-compatible runtime endpoint aren't available yet.
+capabilities. The documentation describes behavior available in the Flower
+framework and SuperGrid interfaces rather than planned product work.

--- a/agent/docs/source/index.md
+++ b/agent/docs/source/index.md
@@ -62,6 +62,7 @@ how-to-guides/create-automations
 how-to-guides/run-on-supergrid
 how-to-guides/troubleshoot-agent-runs
 how-to-guides/run-with-local-superlink
+how-to-guides/run-with-ollama
 ```
 
 ```{toctree}

--- a/agent/docs/source/tutorials/build-a-collaborative-agent.md
+++ b/agent/docs/source/tutorials/build-a-collaborative-agent.md
@@ -71,7 +71,7 @@ version = "0.1.0"
 description = "A bounded public-web research AgentApp"
 license = "Apache-2.0"
 requires-python = ">=3.11"
-dependencies = ["flwr==1.34.0"]
+dependencies = ["flwr==1.35.0"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["research_agent"]
@@ -79,7 +79,7 @@ packages = ["research_agent"]
 [tool.flwr.app]
 publisher = "local"
 display-name = "Research Agent"
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 fab-include = ["research_agent/**/*.py"]
 
 [tool.flwr.app.config.agent]

--- a/agent/docs/source/tutorials/get-started-with-flower-agent.md
+++ b/agent/docs/source/tutorials/get-started-with-flower-agent.md
@@ -1,13 +1,13 @@
 # Chat in your terminal
 
 Use Flower Chat to run AgentApps from your terminal. In this tutorial, you'll
-sign in to SuperGrid, stream a response, switch agents, and see how Flower
-groups messages into a conversation.
+sign in to SuperGrid, stream a response, switch federations and agents, and
+continue an earlier conversation.
 
 Prefer the browser? Start with [Chat in your browser](quickstart.md).
 
 ```{note}
-This tutorial targets Flower 1.34.0. Flower Agent and `flwr chat` are
+This tutorial targets Flower 1.35.0. Flower Agent and `flwr chat` are
 experimental and may change between releases.
 ```
 
@@ -15,10 +15,10 @@ experimental and may change between releases.
 
 You'll need:
 
-- [uv](https://docs.astral.sh/uv/getting-started/installation/);
-- Python 3.11 or newer;
-- a Flower account with Flower Agent access; and
-- a terminal that can open the browser-based login flow.
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
+- Python 3.11 or newer
+- a Flower account with Flower Agent access
+- a terminal that can open the browser-based login flow
 
 You don't need to provide model credentials for a SuperGrid run.
 
@@ -27,8 +27,8 @@ You don't need to provide model credentials for a SuperGrid run.
 Use `uvx` to run the documented version in an isolated environment:
 
 ```console
-$ uvx --from flwr==1.34.0 flwr --version
-flwr, version 1.34.0
+$ uvx --from flwr==1.35.0 flwr --version
+flwr, version 1.35.0
 ```
 
 Running an explicit version keeps every command in this tutorial on the same
@@ -48,7 +48,7 @@ address = "supergrid.flower.ai"
 If you maintain a custom file, ensure that section exists. Then log in:
 
 ```console
-$ uvx --from flwr==1.34.0 flwr login supergrid
+$ uvx --from flwr==1.35.0 flwr login supergrid
 ```
 
 Open the printed authentication link and complete sign-in. The CLI stores the
@@ -57,7 +57,7 @@ resulting account credentials for later SuperGrid commands.
 ## Start a chat
 
 ```console
-$ uvx --from flwr==1.34.0 flwr chat
+$ uvx --from flwr==1.35.0 flwr chat
 ```
 
 ```{figure} ../_static/screenshots/flwr-chat.png
@@ -67,15 +67,17 @@ Flower Chat shows the selected agent above the prompt.
 ```
 
 Flower verifies your stored login before opening the full-screen interface. At
-the `❯` prompt, ask:
+startup, it selects your `@account/personal` federation. At the `❯` prompt,
+ask:
 
 ```text
 Explain Flower Agent in one sentence.
 ```
 
 The selected AgentApp starts a SuperGrid run. Its response, reasoning summary,
-and supported tool activity can stream into the transcript. When the run
-finishes, the prompt becomes available again.
+and supported tool activity can stream into the transcript. Completed
+responses render as Markdown. When the run finishes, the prompt becomes
+available again.
 
 If the interface does not open, follow [Troubleshoot AgentApp
 runs](../how-to-guides/troubleshoot-agent-runs.md) before changing your project
@@ -97,8 +99,8 @@ the model access to earlier messages.
 ## Select another agent
 
 Type `@` at the start of an empty prompt. The completion menu lists agents
-available in the federation configured for the `supergrid` connection. Select
-one, add a request, and press {kbd}`Enter`:
+available in the active federation. Select one, add a request, and press
+{kbd}`Enter`:
 
 ```text
 @publisher/agent Describe what you can help me with.
@@ -112,31 +114,49 @@ If no agent appears, verify the current federation and account entitlement in
 [Use agents and
 federations](../how-to-guides/use-agents-and-federations.md).
 
+## Switch federations
+
+Enter `/federation` to open the federation completion menu. Select a federation
+visible to your account, or type its full name:
+
+```text
+/federation @account/federation-name
+```
+
+Flower clears the current transcript, selects the default Flower Agent, and
+starts a new conversation in that federation. Agent completion then lists the
+agents assigned to the new federation.
+
 ## Use chat commands
 
 Type `/` to open the command menu:
 
-- `/help` lists available commands;
-- `/new` makes the next message start a new run series; and
-- `/quit` leaves Flower Chat.
+- `/help` lists available commands
+- `/new` makes the next message start a new run series
+- `/federation` selects a federation and starts a new conversation there
+- `/history` shows conversations from the active federation
+- `/quit` leaves Flower Chat
+
+After entering `/history`, use the arrow keys to select a conversation, press
+{kbd}`Enter` to continue it, or press {kbd}`Esc` to close the list. Flower
+restores its user and assistant messages in the transcript and sends the next
+message in the selected run series.
 
 You can also press {kbd}`Ctrl+C`:
 
-- during a run, it requests the run to stop;
-- with a draft, it clears the prompt; and
-- from an empty idle prompt, it exits.
-
-The CLI does not currently restore an older run series interactively after you
-leave. Use the SuperGrid browser to inspect saved conversations.
+- during a run, it requests the run to stop
+- while viewing history, it closes the history list
+- with a draft, it clears the prompt
+- from an empty idle prompt, it exits
 
 ## What happened
 
 Each submitted message started one `AgentApp` run. SuperGrid supplied:
 
-- an `AgentSession` for model and connector calls;
-- a Flower `Context` containing run configuration and persistent series state;
-- the selected AgentApp, resolved from its app spec or FAB hash; and
-- a federation in which the run and its series are stored.
+- an `AgentSession` for model and connector calls
+- a Flower `Context` containing run configuration and persistent series state
+- the selected AgentApp, resolved from its app spec or FAB hash
+- a federation in which the run and its series are stored
 
 Read [Use agents and
 federations](../how-to-guides/use-agents-and-federations.md) for the full mental
@@ -144,11 +164,11 @@ model.
 
 ## Next steps
 
-- [Write your first AgentApp](write-your-first-agentapp.md).
-- [Build a collaborative research agent](build-a-collaborative-agent.md).
-- [Use connectors](../explanations/use-connectors.md).
+- [Write your first AgentApp](write-your-first-agentapp.md)
+- [Build a collaborative research agent](build-a-collaborative-agent.md)
+- [Use connectors](../explanations/use-connectors.md)
 - [Run an AgentApp on
-  SuperGrid](../how-to-guides/run-on-supergrid.md).
+  SuperGrid](../how-to-guides/run-on-supergrid.md)
 
 ```{tip}
 If you get stuck, join the Flower community on [Flower

--- a/agent/docs/source/tutorials/quickstart.md
+++ b/agent/docs/source/tutorials/quickstart.md
@@ -11,10 +11,10 @@ The browser interface is experimental and may change between releases.
 
 Confirm that you have:
 
-- a Flower account with Flower Agent access;
-- access to the email or identity provider used to sign in;
-- a current desktop browser; and
-- a reliable network connection.
+- a Flower account with Flower Agent access
+- access to the email or identity provider used to sign in
+- a current desktop browser
+- a reliable network connection
 
 If you plan to use Slack, Notion, GitHub, or Attio later, make sure you can
 authorize the relevant account. Account connectors work only in your personal
@@ -24,10 +24,10 @@ Flower workspace, and you won't need one for this quickstart.
 
 Go to [flower.ai/app](https://flower.ai/app), select **Sign in**, and complete
 the authentication flow. When you return, you should see **New chat**, a prompt
-field, and an agent selector.
+field, an agent selector, and your federations in the sidebar.
 
-The federation shown in the page header or breadcrumb is where this
-conversation's runs will execute.
+Flower starts in your `@account/personal` federation. The federation shown in
+the page header or breadcrumb is where this conversation's runs will execute.
 
 ```{figure} ../_static/screenshots/browser-new-chat.png
 :alt: Flower Agent new-chat screen with an empty prompt and Flower Agent selected.
@@ -92,6 +92,10 @@ completed.
 
 Select **New chat** before starting an unrelated task.
 
+The conversation appears below the personal federation in the sidebar. Select
+it there when you want to return to it. You can also select another federation
+in the sidebar and start a chat with one of the agents assigned to it.
+
 ## What happened
 
 Each submitted message starts one **run** of the selected **AgentApp**. Flower
@@ -108,12 +112,12 @@ pieces fit together.
 
 If it fails, try these steps in order:
 
-1. Confirm that you are signed in and have Flower Agent access.
-1. Refresh the browser.
-1. Start a new chat and retry the deterministic prompt once.
-1. Record the visible error, time, app spec, and federation name.
+1. Confirm that you are signed in and have Flower Agent access
+1. Refresh the browser
+1. Start a new chat and retry the deterministic prompt once
+1. Record the visible error, time, app spec, and federation name
 1. Follow [Troubleshoot AgentApp
-   runs](../how-to-guides/troubleshoot-agent-runs.md).
+   runs](../how-to-guides/troubleshoot-agent-runs.md)
 
 Never include access tokens, OAuth callback URLs, connector credentials, or
 private source content in a support report.
@@ -121,8 +125,8 @@ private source content in a support report.
 ## Next steps
 
 - Prefer a terminal workflow? [Chat in your
-  terminal](get-started-with-flower-agent.md) introduces `flwr chat`.
-- [Write your first AgentApp](write-your-first-agentapp.md).
-- [Build a collaborative research agent](build-a-collaborative-agent.md).
+  terminal](get-started-with-flower-agent.md) introduces `flwr chat`
+- [Write your first AgentApp](write-your-first-agentapp.md)
+- [Build a collaborative research agent](build-a-collaborative-agent.md)
 - [Connect accounts](../how-to-guides/connect-accounts.md) only if your project
-  needs account data.
+  needs account data

--- a/agent/docs/source/tutorials/write-your-first-agentapp.md
+++ b/agent/docs/source/tutorials/write-your-first-agentapp.md
@@ -5,7 +5,7 @@ it on SuperGrid. The example makes one model request so you can isolate project
 configuration from connector logic.
 
 Complete [Chat in your terminal](get-started-with-flower-agent.md) first. This
-tutorial targets Flower 1.34.0.
+tutorial targets Flower 1.35.0.
 
 ## Create the project
 
@@ -88,7 +88,7 @@ version = "0.1.0"
 description = "My first Flower AgentApp"
 license = "Apache-2.0"
 requires-python = ">=3.11"
-dependencies = ["flwr>=1.34.0,<2.0"]
+dependencies = ["flwr>=1.35.0,<2.0"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["hello_agent"]
@@ -96,7 +96,7 @@ packages = ["hello_agent"]
 [tool.flwr.app]
 publisher = "local"
 display-name = "Hello Agent"
-flwr-version-target = "1.34.0"
+flwr-version-target = "1.35.0"
 fab-include = ["hello_agent/**/*.py"]
 
 [tool.flwr.app.config.agent]


### PR DESCRIPTION
## Issue

### Description

The Flower Agent run operations guidance and local Ollama guide merged on `main` are not yet available on the `release/framework-1.35` branch.

### Related issues/PRs

Backports #7928 and #8002.

## Proposal

### Explanation

Cherry-pick the merged commits from #7928 and #8002 onto `release/framework-1.35`, preserving their original order.

### Checklist

- [x] Implement proposed change
- [x] Write tests (not applicable; documentation-only backport)
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

Validated with:

```bash
uv run --project agent --locked --python=3.11.14 agent/dev/build-agent-docs.sh
```
