### PR TITLE
refactor(framework): Load federation manager from SGXT extension

### DIFF
--- a/framework/py/flwr/superlink/config_loader.py
+++ b/framework/py/flwr/superlink/config_loader.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 """Load SuperLink configuration and config-driven components."""
 
-
 import os
 import sys
 from dataclasses import dataclass
@@ -31,7 +30,6 @@ from flwr.superlink.federation import FederationManager, NoOpFederationManager
 try:
     from flwr.ee import (
         get_control_authn_ee_plugins,
-        get_ee_federation_manager,
         get_ee_linkstate_factory,
         get_ee_objectstore_factory,
     )
@@ -40,10 +38,6 @@ except ImportError:
     def get_control_authn_ee_plugins() -> dict[str, type[ControlAuthnPlugin]]:
         """Return all Control API authentication plugins for EE."""
         return {}
-
-    def get_ee_federation_manager() -> FederationManager:
-        """Return the EE FederationManager."""
-        raise NotImplementedError("No federation manager is currently supported.")
 
     def get_ee_objectstore_factory(database: str) -> ObjectStoreFactory:
         """Return an EE ObjectStoreFactory for supported non-SQLite database URLs."""
@@ -56,6 +50,17 @@ except ImportError:
     ) -> LinkStateFactory:
         """Return an EE LinkStateFactory for supported non-SQLite database URLs."""
         raise NotImplementedError("No additional state backends are supported.")
+
+
+try:
+    from flwr.sgxt import get_sgxt_federation_manager
+except ModuleNotFoundError as exc:
+    if exc.name != "flwr.sgxt":
+        raise
+
+    def get_sgxt_federation_manager() -> FederationManager:
+        """Return the SGXT FederationManager."""
+        raise NotImplementedError("No federation manager is currently supported.")
 
 
 @dataclass
@@ -122,7 +127,7 @@ def load_control_event_log_plugin() -> EventLogWriterPlugin:
 def get_federation_manager(is_simulation: bool = False) -> FederationManager:
     """Return the FederationManager."""
     try:
-        federation_manager: FederationManager = get_ee_federation_manager()
+        federation_manager: FederationManager = get_sgxt_federation_manager()
         return federation_manager
     except NotImplementedError:
         return NoOpFederationManager(simulation=is_simulation)


### PR DESCRIPTION
## Summary

- Resolve the optional federation manager through flwr.sgxt
- Keep the existing NoOpFederationManager fallback when SGXT is unavailable
- Leave the remaining EE extension hooks unchanged

This keeps the Flower framework independent of the implementation location while allowing SGXT to own the federation manager.

## Validation

- Focused config_loader tests pass
- Ruff check and format check pass
- git diff --check passes