### PR TITLE
test(framework): Allow additional run metadata

### DIFF
--- a/framework/py/flwr/cli/cli_test.py
+++ b/framework/py/flwr/cli/cli_test.py
@@ -126,9 +126,8 @@ def test_run_command_sends_cli_run_source_metadata() -> None:
             "@flwrlabs/quickstart-numpy",
         )
 
-    assert stub.StartRun.call_args.kwargs["metadata"] == [
-        (run_module.RUN_SOURCE_METADATA_KEY, "cli")
-    ]
+    metadata = stub.StartRun.call_args.kwargs["metadata"]
+    assert (run_module.RUN_SOURCE_METADATA_KEY, "cli") in metadata
 
 
 def test_build_command() -> None:


### PR DESCRIPTION
## Summary

This is a follow-up to #8028. It makes the regression test for CLI run-source metadata resilient to future metadata additions.

The test now checks that the required `(x-flwr-run-source, cli)` entry is present in the `StartRun` metadata, rather than asserting that it is the only entry. This preserves the behavior under test while allowing future authentication, tracing, or other metadata headers to be added.

## Scope

- Test-only change
- No production behavior changes
- Stacked on #8028 and should be merged after #8028

## Validation

- `uv run --no-sync --python=3.11.14 python -m pytest py/flwr/cli/cli_test.py -q`
- `uv run --no-sync --python=3.11.14 python -m ruff check py/flwr/cli/cli_test.py`
- `uv run --no-sync --python=3.11.14 python -m black --check py/flwr/cli/cli_test.py`
- `uv run --no-sync --python=3.11.14 python -m isort --check-only py/flwr/cli/cli_test.py`