### PR TITLE
ci(framework:skip): Update CI actions to Node 24

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -144,12 +144,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ inputs.image-repository }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Validate Docker registry credentials
         env:
@@ -167,14 +167,14 @@ jobs:
           fi
 
       - name: Login to Docker registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ inputs.docker-registry-user }}
           password: ${{ secrets.docker-registry-token }}
 
       - name: Build and push
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: Wandalen/wretry.action@df981d2bb22b26b5b23754bb516d0de8c1bfbbec # Node 24 support
         id: build
         with:
           action: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -193,11 +193,11 @@ jobs:
       - name: Export digest
         run: |
           mkdir -p /tmp/digests
-          digest="${{ fromJSON(steps.build.outputs.outputs).digest }}"
+          digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: digests-${{ steps.build-id.outputs.id }}-${{ matrix.platform.name }}
           path: /tmp/digests/*
@@ -213,7 +213,7 @@ jobs:
       metadata: ${{ steps.meta.outputs.json }}
     steps:
       - name: Download digests
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: digests-${{ needs.build.outputs.build-id }}-*
           path: /tmp/digests
@@ -221,13 +221,13 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ inputs.image-repository }}
           tags: ${{ inputs.tags }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Validate Docker registry credentials
         env:
@@ -245,7 +245,7 @@ jobs:
           fi
 
       - name: Login to Docker registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ inputs.docker-registry-user }}
@@ -292,7 +292,7 @@ jobs:
 
       - name: Upload OCI index digest
         if: ${{ inputs.export-index-digest }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: index-digest-${{ needs.build.outputs.build-id }}
           path: /tmp/index-digest/*.json

--- a/.github/workflows/framework-commit-artifacts.yml
+++ b/.github/workflows/framework-commit-artifacts.yml
@@ -212,7 +212,7 @@ jobs:
       ]
     steps:
       - name: Download OCI index digests
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: index-digest-*
           path: index-digests

--- a/.github/workflows/framework-release-finalize.yml
+++ b/.github/workflows/framework-release-finalize.yml
@@ -126,10 +126,10 @@ jobs:
             "release-artifacts/flwr-${VERSION}.tar.gz"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to Docker registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ vars.DOCKER_IMAGE_REGISTRY }}
           username: ${{ vars.DOCKER_IMAGE_REGISTRY_USER }}

--- a/.github/workflows/framework-test.yml
+++ b/.github/workflows/framework-test.yml
@@ -163,7 +163,7 @@ jobs:
           cp .pytest_cache/.coverage coverage-data/coverage
       - name: Upload coverage data
         if: ${{ (matrix.task == 'pytest' || matrix.task == 'pytest_serial') && needs.changes.outputs.framework == 'true' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: coverage-${{ matrix.task }}-${{ matrix.python }}
           path: framework/coverage-data/
@@ -194,7 +194,7 @@ jobs:
           cd framework
           uv sync --python=3.11 --locked --all-extras --all-groups
       - name: Download coverage data
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: coverage-*
           path: framework/coverage-artifacts


### PR DESCRIPTION
## Summary

- update the artifact and Docker actions from the linked `Framework Commit Artifacts` run to releases that declare the Node 24 runtime
- pin the retry action's merged Node 24 implementation and consume the wrapped build action's native `digest` output
- align the same action pins in the framework test and release workflows

Fixes the Node.js 20 deprecation warning reported in https://github.com/flwrlabs/flower/actions/runs/33199624180.

## Validation

- parsed all changed workflow files as YAML
- ran `git diff --check`
- verified every replacement action declares `runs.using: node24`
- validated the PR title with `devtool.check_pr_title`
