### PR TITLE
refactor(framework): Add HTTP account authentication support to the Flower CLI

### DIFF
--- a/framework/py/flwr/cli/auth_plugin/auth_plugin.py
+++ b/framework/py/flwr/cli/auth_plugin/auth_plugin.py
@@ -20,6 +20,7 @@ from collections.abc import Sequence
 
 from flwr.proto.control_pb2_grpc import ControlStub
 from flwr.supercore.auth.typing import AccountAuthCredentials, AccountAuthLoginDetails
+from flwr.supercore.control import ControlHttpClient
 
 
 class LoginError(Exception):
@@ -42,7 +43,7 @@ class CliAuthPlugin(ABC):
     @abstractmethod
     def login(
         login_details: AccountAuthLoginDetails,
-        control_stub: ControlStub,
+        control_stub: ControlStub | ControlHttpClient,
     ) -> AccountAuthCredentials:
         """Authenticate the account and retrieve authentication credentials.
 
@@ -50,7 +51,7 @@ class CliAuthPlugin(ABC):
         ----------
         login_details : AccountAuthLoginDetails
             An object containing the account's login details.
-        control_stub : ControlStub
+        control_stub : ControlStub | ControlHttpClient
             A stub for executing RPC calls to the server.
 
         Returns

--- a/framework/py/flwr/cli/auth_plugin/noop_auth_plugin.py
+++ b/framework/py/flwr/cli/auth_plugin/noop_auth_plugin.py
@@ -19,6 +19,7 @@ from collections.abc import Sequence
 
 from flwr.proto.control_pb2_grpc import ControlStub
 from flwr.supercore.auth.typing import AccountAuthCredentials, AccountAuthLoginDetails
+from flwr.supercore.control import ControlHttpClient
 
 from .auth_plugin import CliAuthPlugin, LoginError
 
@@ -33,7 +34,7 @@ class NoOpCliAuthPlugin(CliAuthPlugin):
     @staticmethod
     def login(
         login_details: AccountAuthLoginDetails,
-        control_stub: ControlStub,
+        control_stub: ControlStub | ControlHttpClient,
     ) -> AccountAuthCredentials:
         """Raise LoginError as no-op plugin does not support login.
 
@@ -41,7 +42,7 @@ class NoOpCliAuthPlugin(CliAuthPlugin):
         ----------
         login_details : AccountAuthLoginDetails
             Login details (unused).
-        control_stub : ControlStub
+        control_stub : ControlStub | ControlHttpClient
             Control stub (unused).
 
         Returns

--- a/framework/py/flwr/cli/auth_plugin/oidc_cli_plugin.py
+++ b/framework/py/flwr/cli/auth_plugin/oidc_cli_plugin.py
@@ -34,6 +34,7 @@ from flwr.proto.control_pb2 import (  # pylint: disable=E0611
 )
 from flwr.proto.control_pb2_grpc import ControlStub
 from flwr.supercore.auth.typing import AccountAuthCredentials, AccountAuthLoginDetails
+from flwr.supercore.control import ControlHttpClient
 from flwr.supercore.credential_store import get_credential_store
 from flwr.supercore.utils import get_metadata_str
 
@@ -56,7 +57,7 @@ class OidcCliPlugin(CliAuthPlugin):
     @staticmethod
     def login(
         login_details: AccountAuthLoginDetails,
-        control_stub: ControlStub,
+        control_stub: ControlStub | ControlHttpClient,
     ) -> AccountAuthCredentials:
         """Authenticate the account and retrieve authentication credentials.
 
@@ -64,7 +65,7 @@ class OidcCliPlugin(CliAuthPlugin):
         ----------
         login_details : AccountAuthLoginDetails
             Login details containing device code and verification URI.
-        control_stub : ControlStub
+        control_stub : ControlStub | ControlHttpClient
             Control stub for making authentication requests.
 
         Returns

--- a/framework/py/flwr/cli/cli_account_auth_interceptor.py
+++ b/framework/py/flwr/cli/cli_account_auth_interceptor.py
@@ -12,20 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Flower run interceptor."""
+"""CLI account authentication interceptors."""
 
 
 from collections.abc import Callable
 from typing import Any
 
 import grpc
+import httpx
 
+from flwr.common.constant import ACCESS_TOKEN_KEY
 from flwr.proto.control_pb2 import (  # pylint: disable=E0611
     StartRunRequest,
     StopRunRequest,
     StreamLogsRequest,
     StreamRunEventsRequest,
 )
+from flwr.supercore.protobuf.client import ProtobufCall, ProtobufRequestContext
+from flwr.supercore.utils import get_metadata_str
 
 from .auth_plugin import CliAuthPlugin
 
@@ -108,3 +112,21 @@ class CliAccountAuthInterceptor(
         the required authentication tokens to the RPC metadata.
         """
         return self._authenticated_call(continuation, client_call_details, request)
+
+
+class CliAccountAuthHttpInterceptor:
+    """Add CLI account authentication to protobuf-over-HTTP requests."""
+
+    def __init__(self, auth_plugin: CliAuthPlugin):
+        self.auth_plugin = auth_plugin
+
+    def intercept(
+        self,
+        context: ProtobufRequestContext,
+        call_next: ProtobufCall,
+    ) -> httpx.Response:
+        """Add the stored access token as a bearer token."""
+        metadata = self.auth_plugin.write_tokens_to_metadata([])
+        if access_token := get_metadata_str(metadata, ACCESS_TOKEN_KEY):
+            context.request.headers["authorization"] = f"Bearer {access_token}"
+        return call_next(context)

--- a/framework/py/flwr/cli/cli_account_auth_interceptor_test.py
+++ b/framework/py/flwr/cli/cli_account_auth_interceptor_test.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for CLI account authentication interceptors."""
+
+from unittest.mock import Mock
+
+import httpx
+
+from flwr.common.constant import ACCESS_TOKEN_KEY
+from flwr.proto.control_pb2 import ListFederationsRequest  # pylint: disable=E0611
+from flwr.supercore.protobuf.client import ProtobufRequestContext
+
+from .auth_plugin import CliAuthPlugin
+from .cli_account_auth_interceptor import CliAccountAuthHttpInterceptor
+
+
+def test_http_interceptor_adds_bearer_token() -> None:
+    """Send the stored access token in the Authorization header."""
+    auth_plugin = Mock(spec=CliAuthPlugin)
+    auth_plugin.write_tokens_to_metadata.return_value = [
+        (ACCESS_TOKEN_KEY, "access-token")
+    ]
+    context = ProtobufRequestContext(
+        rpc_method="/flwr.proto.Control/ListFederations",
+        message=ListFederationsRequest(),
+        request=httpx.Request("POST", "https://control.example"),
+    )
+    response = httpx.Response(200)
+
+    result = CliAccountAuthHttpInterceptor(auth_plugin).intercept(
+        context, Mock(return_value=response)
+    )
+
+    assert result is response
+    assert context.request.headers["authorization"] == "Bearer access-token"


### PR DESCRIPTION
Allow CLI auth plugins to use either gRPC or HTTP clients, and add an HTTP interceptor that sends the stored access token as a bearer token. This prepares authenticated CLI commands for the HTTP switch.