### PR TITLE
feat(framework): Improve OpenAPI docs

### DIFF
--- a/framework/py/flwr/supercore/protobuf/routing.py
+++ b/framework/py/flwr/supercore/protobuf/routing.py
@@ -17,15 +17,51 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Awaitable, Callable
-from typing import Any, cast, get_type_hints
+from collections.abc import Awaitable, Callable, Iterator
+from functools import update_wrapper
+from typing import Any, cast, get_origin, get_type_hints
 
 from fastapi import Request
 from fastapi.responses import Response
 from fastapi.routing import APIRoute
 from starlette.concurrency import run_in_threadpool
 
+from flwr.supercore.protobuf.constants import (
+    PROTOBUF_MEDIA_TYPE,
+    PROTOBUF_STREAM_MEDIA_TYPE,
+)
+
 _HTTP_REQUEST_PARAMETER = "_protobuf_http_request"
+_BINARY_SCHEMA = {"type": "string", "format": "binary"}
+
+
+def _configure_openapi(
+    endpoint_hints: dict[str, Any],
+    kwargs: dict[str, Any],
+) -> None:
+    """Add the common protobuf wire contract to OpenAPI metadata."""
+    openapi_extra = dict(kwargs.get("openapi_extra") or {})
+    openapi_extra["requestBody"] = {
+        "required": True,
+        "content": {
+            PROTOBUF_MEDIA_TYPE: {"schema": _BINARY_SCHEMA},
+        },
+    }
+    kwargs["openapi_extra"] = openapi_extra
+    kwargs["response_class"] = Response
+
+    response_annotation = endpoint_hints.get("return", inspect.Signature.empty)
+    response_media_type = (
+        PROTOBUF_STREAM_MEDIA_TYPE
+        if get_origin(response_annotation) is Iterator
+        else PROTOBUF_MEDIA_TYPE
+    )
+    responses = dict(kwargs.get("responses") or {})
+    responses[200] = {
+        "description": "Successful Response",
+        "content": {response_media_type: {"schema": _BINARY_SCHEMA}},
+    }
+    kwargs["responses"] = responses
 
 
 class ProtobufRoute(APIRoute):
@@ -43,6 +79,11 @@ class ProtobufRoute(APIRoute):
         endpoint: Callable[..., object],
         **kwargs: Any,
     ) -> None:
+        # Resolve postponed annotations before replacing the handler's signature.
+        endpoint_signature = inspect.signature(endpoint)
+        endpoint_hints = get_type_hints(endpoint, include_extras=True)
+        _configure_openapi(endpoint_hints, kwargs)
+
         async def protobuf_endpoint(*args: Any, **endpoint_kwargs: Any) -> Response:
             # Remove the injected HTTP request before calling the original handler.
             http_request = cast(Request, endpoint_kwargs.pop(_HTTP_REQUEST_PARAMETER))
@@ -60,12 +101,9 @@ class ProtobufRoute(APIRoute):
             http_request.state.protobuf_response = result
             return Response()
 
-        # Retain the handler name in route metadata, operation IDs, and logs.
-        protobuf_endpoint.__name__ = endpoint.__name__
+        # Preserve handler metadata for route descriptions, operation IDs, and logs.
+        update_wrapper(protobuf_endpoint, endpoint)
 
-        # Resolve postponed annotations in the original handler's module.
-        endpoint_signature = inspect.signature(endpoint)
-        endpoint_hints = get_type_hints(endpoint, include_extras=True)
         if _HTTP_REQUEST_PARAMETER in endpoint_signature.parameters:
             raise TypeError(
                 f"{endpoint.__name__} parameter {_HTTP_REQUEST_PARAMETER!r} is reserved"

--- a/framework/py/flwr/superlink/routers/control/router_test.py
+++ b/framework/py/flwr/superlink/routers/control/router_test.py
@@ -15,6 +15,7 @@
 """Tests for the Control API router."""
 
 
+import inspect
 from collections import Counter
 from collections.abc import Callable
 from datetime import datetime
@@ -122,6 +123,40 @@ def test_all_control_routes_have_protobuf_request_types() -> None:
         if route_key[1].startswith("/v1/control/")
     }
     assert route_keys == control_request_types
+
+
+def test_all_control_routes_declare_protobuf_openapi_contracts() -> None:
+    """Document every Control route as protobuf-over-HTTP."""
+    schema = _create_app().openapi()
+    control_routes = [route for route in router.routes if isinstance(route, APIRoute)]
+    stream_paths = {
+        "/v1/control/stream-logs",
+        "/v1/control/stream-run-events",
+    }
+
+    assert len(control_routes) == 37
+    for route in control_routes:
+        operation = schema["paths"][route.path]["post"]
+        request_body = operation["requestBody"]
+        success_content = operation["responses"]["200"]["content"]
+        expected_media_type = (
+            PROTOBUF_STREAM_MEDIA_TYPE
+            if route.path in stream_paths
+            else PROTOBUF_MEDIA_TYPE
+        )
+
+        assert operation["description"] == inspect.getdoc(
+            inspect.unwrap(route.endpoint)
+        )
+        assert request_body["required"] is True
+        assert request_body["content"] == {
+            PROTOBUF_MEDIA_TYPE: {"schema": {"type": "string", "format": "binary"}}
+        }
+        assert set(success_content) == {expected_media_type}
+        assert success_content[expected_media_type]["schema"] == {
+            "type": "string",
+            "format": "binary",
+        }
 
 
 def test_control_http_routes_cover_all_grpc_methods() -> None:

--- a/framework/py/flwr/superlink/routers/runtime/router_test.py
+++ b/framework/py/flwr/superlink/routers/runtime/router_test.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Tests for the Runtime API router."""
 
+import inspect
 from typing import cast
 from unittest.mock import Mock
 
@@ -121,6 +122,29 @@ def test_all_runtime_routes_have_protobuf_request_types() -> None:
 
     assert len(route_keys) == 19
     assert route_keys == runtime_request_types
+
+
+def test_all_runtime_routes_declare_protobuf_openapi_contracts() -> None:
+    """Document every Runtime route as protobuf-over-HTTP."""
+    schema = _create_app(Mock(spec=LinkState)).openapi()
+    runtime_routes = [route for route in router.routes if isinstance(route, APIRoute)]
+
+    assert len(runtime_routes) == 19
+    for route in runtime_routes:
+        operation = schema["paths"][route.path]["post"]
+        request_body = operation["requestBody"]
+        success_content = operation["responses"]["200"]["content"]
+
+        assert operation["description"] == inspect.getdoc(
+            inspect.unwrap(route.endpoint)
+        )
+        assert request_body["required"] is True
+        assert request_body["content"] == {
+            PROTOBUF_MEDIA_TYPE: {"schema": {"type": "string", "format": "binary"}}
+        }
+        assert success_content == {
+            PROTOBUF_MEDIA_TYPE: {"schema": {"type": "string", "format": "binary"}}
+        }
 
 
 def test_runtime_routes_declare_expected_security() -> None:


### PR DESCRIPTION
## Summary

Improve OpenAPI documentation for protobuf-over-HTTP routes.

Previously, protobuf endpoints appeared without handler descriptions and advertised empty JSON responses. This change preserves endpoint docstrings and documents the actual binary request and response formats.

## Changes

- Preserve handler metadata in `ProtobufRoute`, allowing FastAPI to include endpoint docstrings in OpenAPI.
- Document request bodies as binary `application/protobuf`.
- Document unary responses as `application/protobuf`.
- Document streaming responses as `application/flower-protobuf-stream`.
- Remove the misleading `application/json` success response from protobuf endpoints.
- Add aggregate OpenAPI coverage for all Control and Runtime routes.

The generated schema now contains:

- 56 documented protobuf operations
- 56 binary protobuf request bodies
- 54 unary protobuf responses
- 2 streaming protobuf responses
- No JSON success responses for protobuf routes

Runtime request handling and protobuf serialization remain unchanged.