### PR TITLE
fix(framework): Notify result delivery for all task types

### DIFF
--- a/framework/py/flwr/superlink/servicer/control/control_handlers.py
+++ b/framework/py/flwr/superlink/servicer/control/control_handlers.py
@@ -750,11 +750,8 @@ def stream_run_events(
     _validate_federation_membership_in_request(
         state, account.flwr_aid, run.federation_id
     )
-    # A chat/read receipt represents an AgentApp result. ServerApp and
-    # simulation runs can also expose task events, but those are not chat
-    # results and must not be classified as such.
-    if run.primary_task_type == TaskType.AGENT_APP:
-        extensions.notify_result_delivered(run, account.flwr_aid, "chat")
+    # Record every accepted result request, regardless of the primary task type.
+    extensions.notify_result_delivered(run, account.flwr_aid, "chat")
 
     after_task_event_id = None
     if request.HasField("after_task_event_id"):

--- a/framework/py/flwr/superlink/servicer/control/control_servicer_test.py
+++ b/framework/py/flwr/superlink/servicer/control/control_servicer_test.py
@@ -1847,7 +1847,7 @@ class TestControlServicerAuth(unittest.TestCase):
             federation_id=NOOP_FEDERATION_ID,
             primary_task_id=123,
             status=RunStatus(Status.FINISHED, SubStatus.COMPLETED, ""),
-            primary_task_type=TaskType.AGENT_APP,
+            primary_task_type=TaskType.SERVER_APP,
         )
         event = TaskEvent(
             id=6,


### PR DESCRIPTION
## Summary

- Notify extensions for accepted chat result requests for every primary task type.
- Update the control-service coverage to exercise a non-Agent task.

The logs path already notifies extensions for all task types; this removes the
remaining AgentApp-only condition from the chat/task-event path.

## Validation

- `pytest py/flwr/superlink/servicer/control/control_servicer_test.py -k streamrunevents`
- Black and Ruff checks on the changed files
