### PR TITLE
refactor(framework): Reuse result delivery channel constants

### DIFF
--- a/framework/py/flwr/superlink/extensions.py
+++ b/framework/py/flwr/superlink/extensions.py
@@ -20,7 +20,7 @@ from copy import deepcopy
 from importlib import import_module
 from logging import WARNING
 from types import ModuleType
-from typing import Any, Literal, cast
+from typing import Any, Final, Literal, cast
 
 from fastapi import FastAPI
 from starlette.middleware import Middleware
@@ -32,6 +32,8 @@ from flwr.superlink.run_source import RunStartSource
 SuperLinkLifespanContext = Callable[
     [FastAPI], AbstractAsyncContextManager[Mapping[str, Any] | None]
 ]
+RESULT_DELIVERY_CHANNEL_LOGS: Final = "logs"
+RESULT_DELIVERY_CHANNEL_CHAT: Final = "chat"
 ResultDeliveryChannel = Literal["logs", "chat"]
 _SGXT_MODULE = "flwr.ee.superlink.extensions"
 

--- a/framework/py/flwr/superlink/extensions_test.py
+++ b/framework/py/flwr/superlink/extensions_test.py
@@ -73,14 +73,16 @@ def test_notify_result_delivered_passes_a_snapshot_to_the_extension(
     monkeypatch.setattr(extensions, "_try_import_sgxt", lambda: module)
     run = Run.create_empty(123)
 
-    extensions.notify_result_delivered(run, "account-123", "logs")
+    extensions.notify_result_delivered(
+        run, "account-123", extensions.RESULT_DELIVERY_CHANNEL_LOGS
+    )
 
     callback.assert_called_once()
     notified_run, flwr_aid, channel = callback.call_args.args
     assert notified_run == run
     assert notified_run is not run
     assert flwr_aid == "account-123"
-    assert channel == "logs"
+    assert channel == extensions.RESULT_DELIVERY_CHANNEL_LOGS
 
 
 def test_notify_result_delivered_isolates_extension_failure(
@@ -92,4 +94,6 @@ def test_notify_result_delivered_isolates_extension_failure(
     module.on_result_delivered = callback  # type: ignore[attr-defined]
     monkeypatch.setattr(extensions, "_try_import_sgxt", lambda: module)
 
-    extensions.notify_result_delivered(Run.create_empty(123), "account-123", "chat")
+    extensions.notify_result_delivered(
+        Run.create_empty(123), "account-123", extensions.RESULT_DELIVERY_CHANNEL_CHAT
+    )

--- a/framework/py/flwr/superlink/servicer/control/control_handlers.py
+++ b/framework/py/flwr/superlink/servicer/control/control_handlers.py
@@ -692,7 +692,9 @@ def stream_logs(
     _validate_federation_membership_in_request(
         state, account.flwr_aid, run.federation_id
     )
-    extensions.notify_result_delivered(run, account.flwr_aid, "logs")
+    extensions.notify_result_delivered(
+        run, account.flwr_aid, extensions.RESULT_DELIVERY_CHANNEL_LOGS
+    )
 
     after_timestamp = request.after_timestamp + 1e-6
     return _stream_logs(run_id, task_id, after_timestamp, state, is_active)
@@ -751,7 +753,9 @@ def stream_run_events(
         state, account.flwr_aid, run.federation_id
     )
     # Record every accepted result request, regardless of the primary task type.
-    extensions.notify_result_delivered(run, account.flwr_aid, "chat")
+    extensions.notify_result_delivered(
+        run, account.flwr_aid, extensions.RESULT_DELIVERY_CHANNEL_CHAT
+    )
 
     after_task_event_id = None
     if request.HasField("after_task_event_id"):

--- a/framework/py/flwr/superlink/servicer/control/control_servicer_test.py
+++ b/framework/py/flwr/superlink/servicer/control/control_servicer_test.py
@@ -103,6 +103,10 @@ from flwr.supercore.typing import (
 )
 from flwr.superlink.auth_plugin import NoOpControlAuthnPlugin
 from flwr.superlink.federation import NoOpFederationManager
+from flwr.superlink.extensions import (
+    RESULT_DELIVERY_CHANNEL_CHAT,
+    RESULT_DELIVERY_CHANNEL_LOGS,
+)
 from flwr.superlink.run_source import RUN_SOURCE_METADATA_KEY
 from flwr.superlink.servicer.control.control_account_auth_interceptor import (
     shared_account_info,
@@ -1803,7 +1807,7 @@ class TestControlServicerAuth(unittest.TestCase):
             mock_get_run_info.assert_called_with(run_ids=[run_id])
             mock_get_task_log.assert_called_once_with(456, 1e-06)
             notify_result_delivered.assert_called_once_with(
-                mock_run, "user-123", "logs"
+                mock_run, "user-123", RESULT_DELIVERY_CHANNEL_LOGS
             )
             self.assertEqual(len(msgs), 1)
             self.assertIsInstance(msgs[0], StreamLogsResponse)
@@ -1877,7 +1881,9 @@ class TestControlServicerAuth(unittest.TestCase):
             msgs = list(self.servicer.StreamRunEvents(request, ctx))
 
         # Assert
-        notify_result_delivered.assert_called_once_with(mock_run, "user-123", "chat")
+        notify_result_delivered.assert_called_once_with(
+            mock_run, "user-123", RESULT_DELIVERY_CHANNEL_CHAT
+        )
         mock_get_task_events.assert_called_once_with(
             run_id=run_id,
             task_ids=[123],

--- a/framework/py/flwr/superlink/servicer/control/control_servicer_test.py
+++ b/framework/py/flwr/superlink/servicer/control/control_servicer_test.py
@@ -102,11 +102,11 @@ from flwr.supercore.typing import (
     StartRunContext,
 )
 from flwr.superlink.auth_plugin import NoOpControlAuthnPlugin
-from flwr.superlink.federation import NoOpFederationManager
 from flwr.superlink.extensions import (
     RESULT_DELIVERY_CHANNEL_CHAT,
     RESULT_DELIVERY_CHANNEL_LOGS,
 )
+from flwr.superlink.federation import NoOpFederationManager
 from flwr.superlink.run_source import RUN_SOURCE_METADATA_KEY
 from flwr.superlink.servicer.control.control_account_auth_interceptor import (
     shared_account_info,


### PR DESCRIPTION
## Summary

- Define named constants for the logs and chat result-delivery channels.
- Reuse them in SuperLink notification call sites and tests.

Follow-up to #8038.

## Validation

- Focused SuperLink extension and control-servicer tests
- Black, Ruff, and mypy on changed framework files