### PR TITLE
fix(hub): Update flwrlabs agent app to save response into context

### DIFF
--- a/hub/apps/agent/agent/agent_app.py
+++ b/hub/apps/agent/agent/agent_app.py
@@ -4,7 +4,7 @@ import json
 import os
 
 from flwr.agentapp import AgentApp, AgentSession
-from flwr.app import Context
+from flwr.app import ConfigRecord, Context
 from openai import OpenAI
 
 MODEL = "openai/gpt-5.6-sol"
@@ -40,6 +40,12 @@ def main(agent: AgentSession, context: Context) -> None:
 
     final_text = "".join(output_text)
     message = {"type": "message", "role": "assistant", "content": final_text}
-    items = context.state.config_records["items"]["json"]
-    items.append(json.dumps(message))
+    with context.locked():
+        items_record = context.state.config_records.setdefault(
+            "items", ConfigRecord({"json": []})
+        )
+        items = items_record.get("json")
+        if not isinstance(items, list):
+            raise TypeError("Context items must be a list")
+        items.append(json.dumps(message))
     print(final_text)

--- a/hub/apps/agent/agent/agent_app.py
+++ b/hub/apps/agent/agent/agent_app.py
@@ -1,5 +1,6 @@
 """A minimal Flower AgentApp."""
 
+import json
 import os
 
 from flwr.agentapp import AgentApp, AgentSession
@@ -37,4 +38,8 @@ def main(agent: AgentSession, context: Context) -> None:
         if event.type == "response.output_text.delta":
             output_text.append(event.delta)
 
-    print("".join(output_text))
+    final_text = "".join(output_text)
+    message = {"type": "message", "role": "assistant", "content": final_text}
+    items = context.state.config_records["items"]["json"]
+    items.append(json.dumps(message))
+    print(final_text)

--- a/hub/apps/agent/pyproject.toml
+++ b/hub/apps/agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent"
-version = "0.2.0"
+version = "0.3.0"
 description = "A minimal Flower AgentApp"
 license = { file = "LICENSE" }
 requires-python = ">=3.11,<4.0"


### PR DESCRIPTION
## Summary
Update the `flwrlabs/agent` Flower Hub app to version `0.3.0` and persist completed assistant responses in the run-series context.

## Why
The app currently streams responses to connected clients and prints them to the run logs, but it does not store them in the conversation context. As a result, assistant messages disappear from Flower Chat after refreshing or reopening the conversation.

## What
- Collect the completed assistant response from the streamed output.
- Append it as an assistant message to `context.state.config_records["items"]["json"]`.
- Continue printing the completed response to the run logs.
- Bump the app version from `0.2.0` to `0.3.0` for publication to Flower Hub.