### PR TITLE
feat(framework): Add configurable SuperExec task polling interval

### DIFF
--- a/framework/docs/source/helm/how-to-deploy-superlink-using-helm.md
+++ b/framework/docs/source/helm/how-to-deploy-superlink-using-helm.md
@@ -39,12 +39,14 @@ superexec:
 
 SuperExec polls the Runtime API for pending tasks every 100 milliseconds by default.
 To use a different interval, set `FLWR_SUPEREXEC_TASK_POLL_INTERVAL` in the SuperExec
-environment. The value must be a positive, finite number of seconds.
+environment. The value must be between 0.01 and 60 seconds.
 
+```yaml
 superexec:
   env:
     - name: FLWR_SUPEREXEC_TASK_POLL_INTERVAL
       value: "0.25"
+```
 
 ## Run simulations in Kubernetes using the Simulation Plugin
 
@@ -116,7 +118,7 @@ You can configure the license key in the `global.license` section of your `value
 of two ways:
 
 1. Directly — by setting `global.license.key` to your license key.
-2. From an existing Kubernetes Secret — by setting `global.license.existingSecret` to the name of
+1. From an existing Kubernetes Secret — by setting `global.license.existingSecret` to the name of
    a secret that contains your key.
 
 ```{note}

--- a/framework/docs/source/helm/how-to-deploy-superlink-using-helm.md
+++ b/framework/docs/source/helm/how-to-deploy-superlink-using-helm.md
@@ -118,7 +118,7 @@ You can configure the license key in the `global.license` section of your `value
 of two ways:
 
 1. Directly — by setting `global.license.key` to your license key.
-1. From an existing Kubernetes Secret — by setting `global.license.existingSecret` to the name of
+2. From an existing Kubernetes Secret — by setting `global.license.existingSecret` to the name of
    a secret that contains your key.
 
 ```{note}

--- a/framework/docs/source/helm/how-to-deploy-superlink-using-helm.md
+++ b/framework/docs/source/helm/how-to-deploy-superlink-using-helm.md
@@ -41,12 +41,10 @@ SuperExec polls the Runtime API for pending tasks every 100 milliseconds by defa
 To use a different interval, set `FLWR_SUPEREXEC_TASK_POLL_INTERVAL` in the SuperExec
 environment. The value must be a positive, finite number of seconds.
 
-```yaml
 superexec:
   env:
     - name: FLWR_SUPEREXEC_TASK_POLL_INTERVAL
-      value: "0.1"
-```
+      value: "0.25"
 
 ## Run simulations in Kubernetes using the Simulation Plugin
 

--- a/framework/docs/source/helm/how-to-deploy-superlink-using-helm.md
+++ b/framework/docs/source/helm/how-to-deploy-superlink-using-helm.md
@@ -35,6 +35,19 @@ superexec:
   enabled: true
 ```
 
+## Configure SuperExec task polling
+
+SuperExec polls the Runtime API for pending tasks every 100 milliseconds by default.
+To use a different interval, set `FLWR_SUPEREXEC_TASK_POLL_INTERVAL` in the SuperExec
+environment. The value must be a positive, finite number of seconds.
+
+```yaml
+superexec:
+  env:
+    - name: FLWR_SUPEREXEC_TASK_POLL_INTERVAL
+      value: "0.1"
+```
+
 ## Run simulations in Kubernetes using the Simulation Plugin
 
 For more details, visit the [Run simulations](../how-to-run-simulations.rst) guide.

--- a/framework/docs/source/helm/how-to-deploy-superlink-using-helm.md
+++ b/framework/docs/source/helm/how-to-deploy-superlink-using-helm.md
@@ -37,7 +37,7 @@ superexec:
 
 ## Configure SuperExec task polling
 
-SuperExec polls the Runtime API for pending tasks every 100 milliseconds by default.
+SuperExec polls the Runtime API for pending tasks every 1 second by default.
 To use a different interval, set `FLWR_SUPEREXEC_TASK_POLL_INTERVAL` in the SuperExec
 environment. The value must be between 0.01 and 60 seconds.
 

--- a/framework/py/flwr/supercore/superexec/run_superexec.py
+++ b/framework/py/flwr/supercore/superexec/run_superexec.py
@@ -53,7 +53,7 @@ from .plugin.base_ephemeral_exec_plugin import BaseEphemeralExecPlugin
 _TASK_POLL_INTERVAL_ENV = "FLWR_SUPEREXEC_TASK_POLL_INTERVAL"
 _MIN_TASK_POLL_INTERVAL_SECONDS = 0.01
 _MAX_TASK_POLL_INTERVAL_SECONDS = 60.0
-_DEFAULT_TASK_POLL_INTERVAL_SECONDS = 0.1
+_DEFAULT_TASK_POLL_INTERVAL_SECONDS = 1.0
 
 
 def _get_task_poll_interval() -> float:

--- a/framework/py/flwr/supercore/superexec/run_superexec.py
+++ b/framework/py/flwr/supercore/superexec/run_superexec.py
@@ -15,6 +15,8 @@
 """Flower SuperExec."""
 
 
+import math
+import os
 import time
 from logging import ERROR, WARNING
 from typing import Any
@@ -47,6 +49,32 @@ from .executor import LaunchResult, LaunchResultStatus, get_executor
 from .executor.config import ExecutorConfig
 from .plugin import ExecPlugin
 from .plugin.base_ephemeral_exec_plugin import BaseEphemeralExecPlugin
+
+_TASK_POLL_INTERVAL_ENV = "FLWR_SUPEREXEC_TASK_POLL_INTERVAL"
+_DEFAULT_TASK_POLL_INTERVAL_SECONDS = 0.1
+
+
+def _get_task_poll_interval() -> float:
+    """Read and validate the SuperExec task polling interval."""
+    raw_interval = os.getenv(_TASK_POLL_INTERVAL_ENV)
+    if raw_interval is None:
+        return _DEFAULT_TASK_POLL_INTERVAL_SECONDS
+
+    try:
+        interval = float(raw_interval)
+    except ValueError as err:
+        raise ValueError(
+            f"Environment variable {_TASK_POLL_INTERVAL_ENV} must be a positive "
+            f"finite number of seconds, got {raw_interval!r}."
+        ) from err
+
+    if not math.isfinite(interval) or interval <= 0:
+        raise ValueError(
+            f"Environment variable {_TASK_POLL_INTERVAL_ENV} must be a positive "
+            f"finite number of seconds, got {raw_interval!r}."
+        )
+
+    return interval
 
 
 def _handle_launch_result(result: LaunchResult | None, task: Task) -> None:
@@ -143,6 +171,8 @@ def run_superexec(  # pylint: disable=R0912,R0913,R0914,R0915,R0917
     executor_config : Optional[ExecutorConfig] (default: None)
         Parsed executor configuration.
     """
+    task_poll_interval = _get_task_poll_interval()
+
     try:
         executor = get_executor(executor_type, executor_config=executor_config)
     except ValueError as err:
@@ -245,6 +275,6 @@ def run_superexec(  # pylint: disable=R0912,R0913,R0914,R0915,R0917
                     _handle_launch_result(launch_result, task)
 
             # Sleep for a while before checking again
-            time.sleep(1)
+            time.sleep(task_poll_interval)
     finally:
         client.close()

--- a/framework/py/flwr/supercore/superexec/run_superexec.py
+++ b/framework/py/flwr/supercore/superexec/run_superexec.py
@@ -51,6 +51,8 @@ from .plugin import ExecPlugin
 from .plugin.base_ephemeral_exec_plugin import BaseEphemeralExecPlugin
 
 _TASK_POLL_INTERVAL_ENV = "FLWR_SUPEREXEC_TASK_POLL_INTERVAL"
+_MIN_TASK_POLL_INTERVAL_SECONDS = 0.01
+_MAX_TASK_POLL_INTERVAL_SECONDS = 60.0
 _DEFAULT_TASK_POLL_INTERVAL_SECONDS = 0.1
 
 
@@ -64,14 +66,20 @@ def _get_task_poll_interval() -> float:
         interval = float(raw_interval)
     except ValueError as err:
         raise ValueError(
-            f"Environment variable {_TASK_POLL_INTERVAL_ENV} must be a positive "
-            f"finite number of seconds, got {raw_interval!r}."
+            f"Environment variable {_TASK_POLL_INTERVAL_ENV} must be a finite "
+            f"number of seconds between {_MIN_TASK_POLL_INTERVAL_SECONDS} and "
+            f"{_MAX_TASK_POLL_INTERVAL_SECONDS}, got {raw_interval!r}."
         ) from err
 
-    if not math.isfinite(interval) or interval <= 0:
+    if (
+        not math.isfinite(interval)
+        or interval < _MIN_TASK_POLL_INTERVAL_SECONDS
+        or interval > _MAX_TASK_POLL_INTERVAL_SECONDS
+    ):
         raise ValueError(
-            f"Environment variable {_TASK_POLL_INTERVAL_ENV} must be a positive "
-            f"finite number of seconds, got {raw_interval!r}."
+            f"Environment variable {_TASK_POLL_INTERVAL_ENV} must be a finite "
+            f"number of seconds between {_MIN_TASK_POLL_INTERVAL_SECONDS} and "
+            f"{_MAX_TASK_POLL_INTERVAL_SECONDS}, got {raw_interval!r}."
         )
 
     return interval

--- a/framework/py/flwr/supercore/superexec/run_superexec_test.py
+++ b/framework/py/flwr/supercore/superexec/run_superexec_test.py
@@ -33,7 +33,7 @@ from . import run_superexec as run_superexec_module
 
 def _run_superexec_one_launch(
     monkeypatch: pytest.MonkeyPatch, launch_result: LaunchResult | None
-) -> tuple[Mock, Mock, Mock]:
+) -> tuple[Mock, Mock, Mock, Mock]:
     """Run one SuperExec launch loop and stop at the loop sleep."""
     task = Mock()
     task.task_id = 123
@@ -50,10 +50,8 @@ def _run_superexec_one_launch(
     monkeypatch.setattr(run_superexec_module, "register_signal_handlers", Mock())
     monkeypatch.setattr(run_superexec_module, "get_executor", Mock())
     monkeypatch.setattr(run_superexec_module, "log", log)
-    monkeypatch.setattr(
-        "flwr.supercore.superexec.run_superexec.time.sleep",
-        Mock(side_effect=KeyboardInterrupt()),
-    )
+    sleep_mock = Mock(side_effect=KeyboardInterrupt())
+    monkeypatch.setattr("flwr.supercore.superexec.run_superexec.time.sleep", sleep_mock)
 
     with pytest.raises(KeyboardInterrupt):
         run_superexec_module.run_superexec(
@@ -63,7 +61,7 @@ def _run_superexec_one_launch(
             insecure=True,
         )
 
-    return log, plugin, client
+    return log, plugin, client, sleep_mock
 
 
 @pytest.mark.parametrize(
@@ -144,11 +142,14 @@ def test_run_superexec_preserves_accepted_launch_behavior(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """SuperExec should launch and continue quietly when launch is accepted."""
-    log, plugin, stub = _run_superexec_one_launch(monkeypatch, LaunchResult.accepted())
+    log, plugin, stub, sleep_mock = _run_superexec_one_launch(
+        monkeypatch, LaunchResult.accepted()
+    )
 
     stub.ClaimTask.assert_called_once()
     plugin.launch_task.assert_called_once()
     log.assert_not_called()
+    sleep_mock.assert_called_once_with(0.1)
 
 
 @pytest.mark.parametrize(
@@ -178,7 +179,7 @@ def test_run_superexec_logs_non_accepted_launch_result(
     expected_message: str,
 ) -> None:
     """SuperExec should log non-accepted launch results and keep loop behavior."""
-    log, plugin, stub = _run_superexec_one_launch(monkeypatch, launch_result)
+    log, plugin, stub, _ = _run_superexec_one_launch(monkeypatch, launch_result)
 
     stub.ClaimTask.assert_called_once()
     plugin.launch_task.assert_called_once()
@@ -192,11 +193,39 @@ def test_run_superexec_continues_when_plugin_returns_no_launch_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """SuperExec should not crash if a plugin returns no launch result."""
-    log, plugin, stub = _run_superexec_one_launch(monkeypatch, None)
+    log, plugin, stub, _ = _run_superexec_one_launch(monkeypatch, None)
 
     stub.ClaimTask.assert_called_once()
     plugin.launch_task.assert_called_once()
     log.assert_not_called()
+
+
+def test_run_superexec_uses_configured_task_poll_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SuperExec should use the task polling interval from the environment."""
+    monkeypatch.setenv("FLWR_SUPEREXEC_TASK_POLL_INTERVAL", "0.25")
+    _, _, _, sleep_mock = _run_superexec_one_launch(
+        monkeypatch, LaunchResult.accepted()
+    )
+
+    sleep_mock.assert_called_once_with(0.25)
+
+
+@pytest.mark.parametrize("value", ["", "0", "-1", "nan", "inf", "not-a-number"])
+def test_run_superexec_rejects_invalid_task_poll_interval(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """SuperExec should reject invalid task polling intervals."""
+    monkeypatch.setenv("FLWR_SUPEREXEC_TASK_POLL_INTERVAL", value)
+
+    with pytest.raises(ValueError, match="FLWR_SUPEREXEC_TASK_POLL_INTERVAL"):
+        run_superexec_module.run_superexec(
+            plugin_class=Mock(),
+            client_class=Mock(),
+            runtime_api_address="127.0.0.1:9091",
+            insecure=True,
+        )
 
 
 def test_handle_launch_result_handles_all_statuses() -> None:

--- a/framework/py/flwr/supercore/superexec/run_superexec_test.py
+++ b/framework/py/flwr/supercore/superexec/run_superexec_test.py
@@ -156,7 +156,7 @@ def test_run_superexec_preserves_accepted_launch_behavior(
     stub.ClaimTask.assert_called_once()
     plugin.launch_task.assert_called_once()
     log.assert_not_called()
-    sleep_mock.assert_called_once_with(0.1)
+    sleep_mock.assert_called_once_with(1.0)
 
 
 @pytest.mark.parametrize(

--- a/framework/py/flwr/supercore/superexec/run_superexec_test.py
+++ b/framework/py/flwr/supercore/superexec/run_superexec_test.py
@@ -32,9 +32,16 @@ from . import run_superexec as run_superexec_module
 
 
 def _run_superexec_one_launch(
-    monkeypatch: pytest.MonkeyPatch, launch_result: LaunchResult | None
+    monkeypatch: pytest.MonkeyPatch,
+    launch_result: LaunchResult | None,
+    task_poll_interval: str | None = None,
 ) -> tuple[Mock, Mock, Mock, Mock]:
     """Run one SuperExec launch loop and stop at the loop sleep."""
+    if task_poll_interval is None:
+        monkeypatch.delenv("FLWR_SUPEREXEC_TASK_POLL_INTERVAL", raising=False)
+    else:
+        monkeypatch.setenv("FLWR_SUPEREXEC_TASK_POLL_INTERVAL", task_poll_interval)
+
     task = Mock()
     task.task_id = 123
     client = Mock()
@@ -204,9 +211,8 @@ def test_run_superexec_uses_configured_task_poll_interval(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """SuperExec should use the task polling interval from the environment."""
-    monkeypatch.setenv("FLWR_SUPEREXEC_TASK_POLL_INTERVAL", "0.25")
     _, _, _, sleep_mock = _run_superexec_one_launch(
-        monkeypatch, LaunchResult.accepted()
+        monkeypatch, LaunchResult.accepted(), task_poll_interval="0.25"
     )
 
     sleep_mock.assert_called_once_with(0.25)

--- a/framework/py/flwr/supercore/superexec/run_superexec_test.py
+++ b/framework/py/flwr/supercore/superexec/run_superexec_test.py
@@ -218,7 +218,9 @@ def test_run_superexec_uses_configured_task_poll_interval(
     sleep_mock.assert_called_once_with(0.25)
 
 
-@pytest.mark.parametrize("value", ["", "0", "-1", "nan", "inf", "not-a-number"])
+@pytest.mark.parametrize(
+    "value", ["", "0", "0.009", "-1", "60.001", "1e20", "nan", "inf", "not-a-number"]
+)
 def test_run_superexec_rejects_invalid_task_poll_interval(
     monkeypatch: pytest.MonkeyPatch, value: str
 ) -> None:
@@ -232,6 +234,18 @@ def test_run_superexec_rejects_invalid_task_poll_interval(
             runtime_api_address="127.0.0.1:9091",
             insecure=True,
         )
+
+
+@pytest.mark.parametrize("value", ["0.01", "60"])
+def test_run_superexec_accepts_task_poll_interval_bounds(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """SuperExec should accept the configured polling interval bounds."""
+    monkeypatch.setenv("FLWR_SUPEREXEC_TASK_POLL_INTERVAL", value)
+
+    # pylint: disable-next=protected-access
+    get_task_poll_interval = run_superexec_module._get_task_poll_interval
+    assert get_task_poll_interval() == float(value)
 
 
 def test_handle_launch_result_handles_all_statuses() -> None:


### PR DESCRIPTION
## Summary
- Set the default SuperExec pending-task polling interval to 1 second.
- Allow operators to override it with `FLWR_SUPEREXEC_TASK_POLL_INTERVAL`.
- Accept configured intervals from 0.01 through 60 seconds and document the Helm environment configuration.

## Configuration design
`FLWR_SUPEREXEC_TASK_POLL_INTERVAL` is read once at SuperExec startup and converted to a validated float. A dedicated typed `SuperExecSettings` object would be the cleaner boundary if more SuperExec options are added; for this single setting, keeping the parsing local avoids introducing an unnecessary abstraction. The value intentionally does not belong in `ExecutorConfig`, because that config describes TaskExecutor pods rather than the SuperExec process.

If more SuperExec configuration is introduced, the natural next step is to parse the environment at the CLI boundary into `SuperExecSettings` and pass that typed object into `run_superexec`.

## Validation
- `uv run --no-sync --python=3.11.14 ./dev/test.sh false`
- `uv run --no-sync --python=3.11.14 mdformat --check --number docs/source`

All package checks and GitHub CI checks pass.