### PR TITLE
refactor(framework): Support HTTP clients in CLI auth plugins

### DIFF
--- a/framework/py/flwr/cli/auth_plugin/auth_plugin.py
+++ b/framework/py/flwr/cli/auth_plugin/auth_plugin.py
@@ -42,7 +42,7 @@ class CliAuthPlugin(ABC):
     @abstractmethod
     def login(
         login_details: AccountAuthLoginDetails,
-        control_stub: ControlStub | ControlHttpClient,
+        control_client: ControlStub | ControlHttpClient,
     ) -> AccountAuthCredentials:
         """Authenticate the account and retrieve authentication credentials.
 
@@ -50,8 +50,8 @@ class CliAuthPlugin(ABC):
         ----------
         login_details : AccountAuthLoginDetails
             An object containing the account's login details.
-        control_stub : ControlStub | ControlHttpClient
-            A stub for executing RPC calls to the server.
+        control_client : ControlStub | ControlHttpClient
+            A client for making authentication requests.
 
         Returns
         -------

--- a/framework/py/flwr/cli/auth_plugin/auth_plugin.py
+++ b/framework/py/flwr/cli/auth_plugin/auth_plugin.py
@@ -14,12 +14,12 @@
 # ==============================================================================
 """Abstract classes for Flower account auth plugin."""
 
-
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
 from flwr.proto.control_pb2_grpc import ControlStub
 from flwr.supercore.auth.typing import AccountAuthCredentials, AccountAuthLoginDetails
+from flwr.supercore.control import ControlHttpClient
 
 
 class LoginError(Exception):
@@ -42,7 +42,7 @@ class CliAuthPlugin(ABC):
     @abstractmethod
     def login(
         login_details: AccountAuthLoginDetails,
-        control_stub: ControlStub,
+        control_stub: ControlStub | ControlHttpClient,
     ) -> AccountAuthCredentials:
         """Authenticate the account and retrieve authentication credentials.
 
@@ -50,7 +50,7 @@ class CliAuthPlugin(ABC):
         ----------
         login_details : AccountAuthLoginDetails
             An object containing the account's login details.
-        control_stub : ControlStub
+        control_stub : ControlStub | ControlHttpClient
             A stub for executing RPC calls to the server.
 
         Returns

--- a/framework/py/flwr/cli/auth_plugin/noop_auth_plugin.py
+++ b/framework/py/flwr/cli/auth_plugin/noop_auth_plugin.py
@@ -14,11 +14,11 @@
 # ==============================================================================
 """Concrete NoOp implementation for CLI-side account authentication plugin."""
 
-
 from collections.abc import Sequence
 
 from flwr.proto.control_pb2_grpc import ControlStub
 from flwr.supercore.auth.typing import AccountAuthCredentials, AccountAuthLoginDetails
+from flwr.supercore.control import ControlHttpClient
 
 from .auth_plugin import CliAuthPlugin, LoginError
 
@@ -33,7 +33,7 @@ class NoOpCliAuthPlugin(CliAuthPlugin):
     @staticmethod
     def login(
         login_details: AccountAuthLoginDetails,
-        control_stub: ControlStub,
+        control_stub: ControlStub | ControlHttpClient,
     ) -> AccountAuthCredentials:
         """Raise LoginError as no-op plugin does not support login.
 
@@ -41,7 +41,7 @@ class NoOpCliAuthPlugin(CliAuthPlugin):
         ----------
         login_details : AccountAuthLoginDetails
             Login details (unused).
-        control_stub : ControlStub
+        control_stub : ControlStub | ControlHttpClient
             Control stub (unused).
 
         Returns

--- a/framework/py/flwr/cli/auth_plugin/noop_auth_plugin.py
+++ b/framework/py/flwr/cli/auth_plugin/noop_auth_plugin.py
@@ -33,7 +33,7 @@ class NoOpCliAuthPlugin(CliAuthPlugin):
     @staticmethod
     def login(
         login_details: AccountAuthLoginDetails,
-        control_stub: ControlStub | ControlHttpClient,
+        control_client: ControlStub | ControlHttpClient,
     ) -> AccountAuthCredentials:
         """Raise LoginError as no-op plugin does not support login.
 
@@ -41,8 +41,8 @@ class NoOpCliAuthPlugin(CliAuthPlugin):
         ----------
         login_details : AccountAuthLoginDetails
             Login details (unused).
-        control_stub : ControlStub | ControlHttpClient
-            Control stub (unused).
+        control_client : ControlStub | ControlHttpClient
+            Control client (unused).
 
         Returns
         -------

--- a/framework/py/flwr/cli/auth_plugin/oidc_cli_plugin.py
+++ b/framework/py/flwr/cli/auth_plugin/oidc_cli_plugin.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 """Flower CLI account auth plugin for OIDC."""
 
-
 import time
 import webbrowser
 from collections.abc import Sequence
@@ -34,6 +33,7 @@ from flwr.proto.control_pb2 import (  # pylint: disable=E0611
 )
 from flwr.proto.control_pb2_grpc import ControlStub
 from flwr.supercore.auth.typing import AccountAuthCredentials, AccountAuthLoginDetails
+from flwr.supercore.control import ControlHttpClient
 from flwr.supercore.credential_store import get_credential_store
 from flwr.supercore.utils import get_metadata_str
 
@@ -56,7 +56,7 @@ class OidcCliPlugin(CliAuthPlugin):
     @staticmethod
     def login(
         login_details: AccountAuthLoginDetails,
-        control_stub: ControlStub,
+        control_stub: ControlStub | ControlHttpClient,
     ) -> AccountAuthCredentials:
         """Authenticate the account and retrieve authentication credentials.
 
@@ -64,7 +64,7 @@ class OidcCliPlugin(CliAuthPlugin):
         ----------
         login_details : AccountAuthLoginDetails
             Login details containing device code and verification URI.
-        control_stub : ControlStub
+        control_stub : ControlStub | ControlHttpClient
             Control stub for making authentication requests.
 
         Returns

--- a/framework/py/flwr/cli/auth_plugin/oidc_cli_plugin.py
+++ b/framework/py/flwr/cli/auth_plugin/oidc_cli_plugin.py
@@ -56,7 +56,7 @@ class OidcCliPlugin(CliAuthPlugin):
     @staticmethod
     def login(
         login_details: AccountAuthLoginDetails,
-        control_stub: ControlStub | ControlHttpClient,
+        control_client: ControlStub | ControlHttpClient,
     ) -> AccountAuthCredentials:
         """Authenticate the account and retrieve authentication credentials.
 
@@ -64,8 +64,8 @@ class OidcCliPlugin(CliAuthPlugin):
         ----------
         login_details : AccountAuthLoginDetails
             Login details containing device code and verification URI.
-        control_stub : ControlStub | ControlHttpClient
-            Control stub for making authentication requests.
+        control_client : ControlStub | ControlHttpClient
+            Control client for making authentication requests.
 
         Returns
         -------
@@ -92,7 +92,7 @@ class OidcCliPlugin(CliAuthPlugin):
         time.sleep(login_details.interval)
 
         while (time.time() - start_time) < login_details.expires_in:
-            res: GetAuthTokensResponse = control_stub.GetAuthTokens(
+            res: GetAuthTokensResponse = control_client.GetAuthTokens(
                 GetAuthTokensRequest(device_code=login_details.device_code)
             )
 


### PR DESCRIPTION
Allow CLI authentication plugins to accept either the existing gRPC `ControlStub` or `ControlHttpClient`, preparing them for the later HTTP-only CLI switch without changing current behavior.