### PR TITLE
fix(framework): Warn for deprecated SuperExec address flag with equals syntax

### DIFF
--- a/framework/py/flwr/supercore/cli/flower_superexec.py
+++ b/framework/py/flwr/supercore/cli/flower_superexec.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """`flower-superexec` command."""
 
+
 import argparse
 import sys
 from logging import INFO, WARN

--- a/framework/py/flwr/supercore/cli/flower_superexec.py
+++ b/framework/py/flwr/supercore/cli/flower_superexec.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 """`flower-superexec` command."""
 
-
 import argparse
 import sys
 from logging import INFO, WARN
@@ -58,7 +57,10 @@ def flower_superexec() -> None:
     warn_if_flwr_update_available(process_name="flower-superexec")
     args = _parse_args().parse_args()
 
-    if "--appio-api-address" in sys.argv[1:]:
+    if any(
+        arg == "--appio-api-address" or arg.startswith("--appio-api-address=")
+        for arg in sys.argv[1:]
+    ):
         log(
             WARN,
             "The `--appio-api-address` argument has been renamed to "

--- a/framework/py/flwr/supercore/cli/flower_superexec_test.py
+++ b/framework/py/flwr/supercore/cli/flower_superexec_test.py
@@ -69,14 +69,21 @@ def test_parse_superexec_accepts_kubernetes_executor_config(
     assert args.executor_config == "executor.yaml"
 
 
+@pytest.mark.parametrize(
+    "address_args",
+    [
+        ["--appio-api-address", "127.0.0.1:9091"],
+        ["--appio-api-address=127.0.0.1:9091"],
+    ],
+)
 def test_flower_superexec_warns_for_renamed_appio_api_address(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, address_args: list[str]
 ) -> None:
     """SuperExec should warn when the renamed address flag is used."""
     monkeypatch.setattr(
         flower_superexec_module.sys,
         "argv",
-        ["flower-superexec", "--appio-api-address", "127.0.0.1:9091"],
+        ["flower-superexec", *address_args],
     )
     monkeypatch.setattr(flower_superexec_module, "_parse_args", Mock())
     monkeypatch.setattr(


### PR DESCRIPTION
Complete the `--appio-api-address` deprecation introduced in [#8010](https://github.com/flwrlabs/flower/pull/8010)