### PR TITLE
feat(framework): Add input and raw tool calls into task events

### DIFF
--- a/framework/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
@@ -38,12 +38,13 @@ from flwr.common.constant import (
 from flwr.proto.federation_config_pb2 import SimulationConfig  # pylint: disable=E0611
 from flwr.proto.message_pb2 import ObjectTree  # pylint: disable=E0611
 from flwr.proto.node_pb2 import NodeInfo  # pylint: disable=E0611
-from flwr.proto.task_pb2 import Task, TaskStatus  # pylint: disable=E0611
+from flwr.proto.task_pb2 import Task, TaskEvent, TaskStatus  # pylint: disable=E0611
 from flwr.server.superlink.linkstate.linkstate import LinkState
 from flwr.server.utils import validate_message
 from flwr.supercore import log
 from flwr.supercore.constant import NodeStatus, TaskType
 from flwr.supercore.corestate.in_memory_corestate import InMemoryCoreState
+from flwr.supercore.corestate.utils import validate_task_event_data
 from flwr.supercore.date import now
 from flwr.supercore.object_store.object_store import ObjectStore
 from flwr.supercore.run import Run, RunStatus
@@ -641,13 +642,19 @@ class InMemoryLinkState(LinkState, InMemoryCoreState):  # pylint: disable=R0902,
         series_id: int | None = None,
         series_description: str | None = None,
         connector_refs: Sequence[str] = (),
+        initial_task_event: TaskEvent | None = None,
     ) -> int:
         """Create a new run."""
         if isinstance(connector_refs, str) or any(
             not connector_ref for connector_ref in connector_refs
         ):
             return 0
-        with self.lock_task_store, self.lock:
+        if initial_task_event is not None:
+            try:
+                validate_task_event_data(initial_task_event.data)
+            except ValueError:
+                return 0
+        with self.lock_task_store, self.lock, self.lock_task_event_store:
             run_id = generate_rand_int_from_bytes(
                 RUN_ID_NUM_BYTES,
                 exclude=set(self.run_ids),
@@ -717,6 +724,13 @@ class InMemoryLinkState(LinkState, InMemoryCoreState):  # pylint: disable=R0902,
                 model_ref=None,
                 connector_ref=None,
             )
+            if initial_task_event is not None:
+                initial_task_event.id = self._next_task_event_id
+                initial_task_event.timestamp = current
+                initial_task_event.run_id = run_id
+                initial_task_event.task_id = task_id
+                self.task_event_store.setdefault(run_id, []).append(initial_task_event)
+                self._next_task_event_id += 1
             self.bind_connectors_to_run(
                 run_id=run_id,
                 connector_refs=connector_refs,

--- a/framework/py/flwr/server/superlink/linkstate/linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate.py
@@ -24,6 +24,7 @@ from flwr.app.user_config import UserConfig
 from flwr.common.constant import SUPERLINK_NODE_ID
 from flwr.proto.federation_config_pb2 import SimulationConfig  # pylint: disable=E0611
 from flwr.proto.node_pb2 import NodeInfo  # pylint: disable=E0611
+from flwr.proto.task_pb2 import TaskEvent  # pylint: disable=E0611
 from flwr.supercore.corestate import CoreState
 from flwr.supercore.run import Run, RunStatus
 from flwr.superlink.federation import FederationManager
@@ -276,6 +277,7 @@ class LinkState(CoreState):  # pylint: disable=R0904
         series_id: int | None = None,
         series_description: str | None = None,
         connector_refs: Sequence[str] = (),
+        initial_task_event: TaskEvent | None = None,
     ) -> int:
         """Create a new run.
 
@@ -307,6 +309,8 @@ class LinkState(CoreState):  # pylint: disable=R0904
             description was provided; an empty string is an explicit description.
         connector_refs : Sequence[str] (default: ())
             Connector references the run is allowed to invoke.
+        initial_task_event : TaskEvent | None (default: None)
+            Event to store atomically before the pending primary task is visible.
 
         Returns
         -------

--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -55,6 +55,7 @@ from flwr.proto.federation_config_pb2 import SimulationConfig  # pylint: disable
 from flwr.proto.message_pb2 import Message as ProtoMessage
 from flwr.proto.message_pb2 import Metadata as ProtoMetadata
 from flwr.proto.recorddict_pb2 import RecordDict as ProtoRecordDict
+from flwr.proto.task_pb2 import TaskEvent  # pylint: disable=E0611
 
 # pylint: enable=E0611
 from flwr.server.superlink.linkstate import InMemoryLinkState, LinkState, SqlLinkState
@@ -157,6 +158,7 @@ class StateTest(CoreStateTest):
         """Test if create_run and get_run_info work correctly."""
         # Prepare
         state: LinkState = self.state_factory()
+        initial_event = TaskEvent(event="message", data='{"type":"message"}')
         run_id = state.create_run(
             None,
             None,
@@ -166,6 +168,7 @@ class StateTest(CoreStateTest):
             None,
             "i1r9f",
             TaskType.SERVER_APP,
+            initial_task_event=initial_event,
         )
 
         # Execute
@@ -178,6 +181,10 @@ class StateTest(CoreStateTest):
         assert run.override_config["test_key"] == "test_value"
         assert run.flwr_aid == "i1r9f"
         assert run.series_id > 0
+        stored_event = state.get_task_events(run_ids=[run_id])[0]
+        assert stored_event.event == initial_event.event
+        assert stored_event.data == initial_event.data
+        assert stored_event.task_id == run.primary_task_id
 
     def test_create_run_uses_existing_series_id(self) -> None:
         """Test create_run links the run to an existing run series."""

--- a/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
@@ -52,16 +52,17 @@ from flwr.common.constant import (
 from flwr.proto.federation_config_pb2 import SimulationConfig  # pylint: disable=E0611
 from flwr.proto.message_pb2 import ObjectTree  # pylint: disable=E0611
 from flwr.proto.node_pb2 import NodeInfo  # pylint: disable=E0611
-from flwr.proto.task_pb2 import Task  # pylint: disable=E0611
+from flwr.proto.task_pb2 import Task, TaskEvent  # pylint: disable=E0611
 from flwr.server.utils.validator import validate_message
 from flwr.supercore import log
 from flwr.supercore.constant import NodeStatus, TaskType
 from flwr.supercore.corestate.sql_corestate import SqlCoreState
-from flwr.supercore.corestate.utils import timestamp_to_iso
+from flwr.supercore.corestate.utils import timestamp_to_iso, validate_task_event_data
 from flwr.supercore.date import now
 from flwr.supercore.object_store.object_store import ObjectStore
 from flwr.supercore.run import Run, RunStatus
 from flwr.supercore.state.schema.corestate_models import Task as TaskModel
+from flwr.supercore.state.schema.corestate_models import TaskEvent as TaskEventModel
 from flwr.supercore.state.schema.corestate_tables import create_corestate_metadata
 from flwr.supercore.state.schema.linkstate_models import MessageIns as MessageInsModel
 from flwr.supercore.state.schema.linkstate_models import MessageRes as MessageResModel
@@ -907,12 +908,18 @@ class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
         series_id: int | None = None,
         series_description: str | None = None,
         connector_refs: Sequence[str] = (),
+        initial_task_event: TaskEvent | None = None,
     ) -> int:
         """Create a new run."""
         if isinstance(connector_refs, str) or any(
             not connector_ref for connector_ref in connector_refs
         ):
             return 0
+        if initial_task_event is not None:
+            try:
+                validate_task_event_data(initial_task_event.data)
+            except ValueError:
+                return 0
         # Convert federation_config to JSON string for storage
         fed_config_json = None
         if federation_config:
@@ -980,6 +987,18 @@ class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
                         details="",
                     )
                 )
+                if initial_task_event is not None:
+                    initial_task_event.run_id = run_id
+                    initial_task_event.task_id = task_id
+                    session.execute(
+                        insert(TaskEventModel).values(
+                            timestamp=current,
+                            run_id=uint64_to_int64(run_id),
+                            task_id=uint64_to_int64(task_id),
+                            event=initial_task_event.event,
+                            data=initial_task_event.data,
+                        )
+                    )
                 self.bind_connectors_to_run(
                     run_id=run_id,
                     connector_refs=connector_refs,

--- a/framework/py/flwr/supercore/task_process/agent/session.py
+++ b/framework/py/flwr/supercore/task_process/agent/session.py
@@ -22,7 +22,7 @@ import time
 from collections.abc import Sequence
 from queue import Empty, Queue
 from threading import Lock, Thread
-from typing import Literal, cast
+from typing import cast
 
 from google.protobuf.json_format import ParseDict
 
@@ -51,9 +51,7 @@ from flwr.supercore.task_process.connector.automation import START_AUTOMATION_TO
 from flwr.supercore.task_process.connector.registry import (
     get_connector_ref,
     get_connector_tools,
-    has_builtin_connector,
 )
-from flwr.supercore.task_process.connector.web_fetch import WEB_FETCH_CONNECTOR_NAME
 from flwr.supercore.typing import JSONObject, JSONValue
 from flwr.supercore.utils import strict_json_dumps
 
@@ -314,39 +312,14 @@ class RuntimeAgentResponses(AgentResponses):
         self, *, name: str, call_id: str, arguments: JSONObject
     ) -> JSONObject:
         """Call a connector and emit/persist its activity events."""
-
-        def connector_event(
-            status: Literal["started", "completed", "failed"],
-            *,
-            output: JSONValue = None,
-            message: str | None = None,
-        ) -> list[JSONObject]:
-            if not has_builtin_connector(name):
-                return []
-
-            event: JSONObject = {
-                "type": f"response.tool_call.{status}",
-                "tool_call_id": call_id,
-                "connector_ref": name,
-                "arguments": arguments,
-            }
-
-            query = arguments.get("query")
-            if isinstance(query, str) and query:
-                event["query"] = query
-
-            url = arguments.get("url")
-            if name == WEB_FETCH_CONNECTOR_NAME and isinstance(url, str) and url:
-                event["links"] = [url]
-
-            if status == "completed":
-                event["output"] = output
-            elif status == "failed" and message is not None:
-                event["error"] = {"code": "connector_error", "message": message}
-
-            return [event]
-
-        self.append_and_push_run_events(connector_event("started"))
+        name = name.strip().lower()
+        function_call: JSONObject = {
+            "type": "function_call",
+            "call_id": call_id,
+            "name": name,
+            "arguments": strict_json_dumps(arguments, compact=True),
+        }
+        self.append_and_push_run_events([function_call])
 
         try:
             output = self.create_connector_response(
@@ -354,8 +327,22 @@ class RuntimeAgentResponses(AgentResponses):
                 call_id=call_id,
                 arguments=arguments,
             )
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            self.append_and_push_run_events(connector_event("failed", message=str(exc)))
+        except Exception:  # pylint: disable=broad-exception-caught
+            error_output: JSONObject = {
+                "error": {
+                    "code": "connector_error",
+                    "message": "Connector execution failed.",
+                }
+            }
+            self.append_and_push_run_events(
+                [
+                    {
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": strict_json_dumps(error_output, compact=True),
+                    }
+                ]
+            )
             raise
 
         output_item: JSONObject = {
@@ -363,37 +350,20 @@ class RuntimeAgentResponses(AgentResponses):
             "call_id": call_id,
             "output": strict_json_dumps(output, compact=True),
         }
-        self.append_and_push_run_events(connector_event("completed", output=output))
-        self.append_context_items([output_item])
+        self.append_and_push_run_events([output_item])
         return output_item
 
     def call_automation_with_events(
         self, *, call_id: str, arguments: JSONObject
     ) -> JSONObject:
         """Create an automation and emit/persist its activity events."""
-
-        def automation_event(
-            status: Literal["started", "completed", "failed"],
-            *,
-            output: JSONValue = None,
-            message: str | None = None,
-        ) -> JSONObject:
-            event: JSONObject = {
-                "type": f"response.tool_call.{status}",
-                "tool_call_id": call_id,
-                "tool_name": START_AUTOMATION_TOOL_NAME,
-                "arguments": arguments,
-            }
-            if status == "completed":
-                event["output"] = output
-            elif status == "failed" and message is not None:
-                event["error"] = {
-                    "code": "automation_error",
-                    "message": message,
-                }
-            return event
-
-        self.append_and_push_run_events([automation_event("started")])
+        function_call: JSONObject = {
+            "type": "function_call",
+            "call_id": call_id,
+            "name": START_AUTOMATION_TOOL_NAME,
+            "arguments": strict_json_dumps(arguments, compact=True),
+        }
+        self.append_and_push_run_events([function_call])
         try:
             input_value = arguments.get("input")
             if not isinstance(input_value, str) or not input_value.strip():
@@ -418,9 +388,21 @@ class RuntimeAgentResponses(AgentResponses):
                 "series_id": response.series_id,
                 "next_run_at": response.next_run_at,
             }
-        except Exception as exc:  # pylint: disable=broad-exception-caught
+        except Exception:  # pylint: disable=broad-exception-caught
+            error_output: JSONObject = {
+                "error": {
+                    "code": "automation_error",
+                    "message": "Automation execution failed.",
+                }
+            }
             self.append_and_push_run_events(
-                [automation_event("failed", message=str(exc))]
+                [
+                    {
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": strict_json_dumps(error_output, compact=True),
+                    }
+                ]
             )
             raise
 
@@ -429,8 +411,7 @@ class RuntimeAgentResponses(AgentResponses):
             "call_id": call_id,
             "output": strict_json_dumps(output, compact=True),
         }
-        self.append_and_push_run_events([automation_event("completed", output=output)])
-        self.append_context_items([output_item])
+        self.append_and_push_run_events([output_item])
         return output_item
 
     def push_run_events(self, events: Sequence[JSONObject]) -> None:
@@ -444,10 +425,6 @@ class RuntimeAgentResponses(AgentResponses):
             return
         append_items(self._context, events)
         self.push_run_events(events)
-
-    def append_context_items(self, items: list[JSONObject]) -> None:
-        """Append OpenResponses items to the AgentApp context."""
-        append_items(self._context, items)
 
     def _push_task_message(self, message: Message) -> None:
         """Push one task message and return its message ID."""

--- a/framework/py/flwr/supercore/task_process/agent/session_test.py
+++ b/framework/py/flwr/supercore/task_process/agent/session_test.py
@@ -108,8 +108,8 @@ def test_emit_event_requires_type() -> None:
     stub.PushTaskEvents.assert_not_called()
 
 
-def test_agent_events_and_connector_events_use_same_publisher() -> None:
-    """Publish explicit and built-in AgentApp events through one publisher."""
+def test_agent_events_and_connector_items_use_same_publisher() -> None:
+    """Publish explicit AgentApp events and connector items through one publisher."""
     stub = Mock()
     events = Mock()
     responses = RuntimeAgentResponses(
@@ -124,7 +124,12 @@ def test_agent_events_and_connector_events_use_same_publisher() -> None:
         "type": "response.output_text.delta",
         "delta": "Hello",
     }
-    connector_event: JSONObject = {"type": "response.tool_call.started"}
+    connector_event: JSONObject = {
+        "type": "function_call",
+        "call_id": "call-1",
+        "name": "web_search",
+        "arguments": '{"query":"Flower"}',
+    }
 
     events.emit(model_event)
     responses.push_run_events([connector_event])
@@ -214,10 +219,9 @@ def test_call_automation_embeds_input_in_control_request() -> None:
     }
 
     # Execute
-    with (
-        patch.object(responses, "append_and_push_run_events"),
-        patch.object(responses, "append_context_items"),
-    ):
+    with patch.object(
+        responses, "append_and_push_run_events"
+    ) as append_and_push_run_events:
         responses.call_automation_with_events(call_id="call-1", arguments=arguments)
 
     # Assert
@@ -235,6 +239,156 @@ def test_call_automation_embeds_input_in_control_request() -> None:
             series_id=2,
         ),
     )
+    assert append_and_push_run_events.call_args_list == [
+        call(
+            [
+                {
+                    "type": "function_call",
+                    "call_id": "call-1",
+                    "name": START_AUTOMATION_TOOL_NAME,
+                    "arguments": (
+                        '{"input":"Do work","start_at":"2026-07-28T12:00:00Z",'
+                        '"fixed_interval":60,"max_runs":3}'
+                    ),
+                }
+            ]
+        ),
+        call(
+            [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call-1",
+                    "output": (
+                        '{"automation_id":0,"series_id":0,"next_run_at":""}'
+                    ),
+                }
+            ]
+        ),
+    ]
+
+
+def test_automation_failure_emits_secret_safe_output() -> None:
+    """Persist a terminal, secret-safe output when automation creation fails."""
+    stub = Mock()
+    stub.StartAutomation.side_effect = RuntimeError("scheduler leaked secret-token")
+    responses = RuntimeAgentResponses(
+        stub=stub,
+        run_id=123,
+        task_id=789,
+        context=Mock(),
+        start_run_request=StartRunRequest(),
+        events=Mock(),
+    )
+
+    with (
+        patch.object(
+            responses, "append_and_push_run_events"
+        ) as append_and_push_run_events,
+        pytest.raises(RuntimeError, match="secret-token"),
+    ):
+        responses.call_automation_with_events(
+            call_id="call-1",
+            arguments={
+                "input": "Do work",
+                "start_at": "2026-07-28T12:00:00Z",
+            },
+        )
+
+    terminal_item = append_and_push_run_events.call_args_list[-1].args[0][0]
+    assert terminal_item == {
+        "type": "function_call_output",
+        "call_id": "call-1",
+        "output": (
+            '{"error":{"code":"automation_error",'
+            '"message":"Automation execution failed."}}'
+        ),
+    }
+    assert "secret-token" not in terminal_item["output"]
+
+
+@pytest.mark.parametrize("name", ["web_search", "notion_search"])
+def test_connector_call_emits_standard_items(name: str) -> None:
+    """Emit standard function items for built-in and OAuth connectors."""
+    responses = RuntimeAgentResponses(
+        stub=Mock(),
+        run_id=123,
+        task_id=789,
+        context=Mock(),
+        start_run_request=StartRunRequest(),
+        events=Mock(),
+    )
+    arguments: JSONObject = {"query": "Flower"}
+
+    with (
+        patch.object(
+            responses, "create_connector_response", return_value={"results": []}
+        ),
+        patch.object(
+            responses, "append_and_push_run_events"
+        ) as append_and_push_run_events,
+    ):
+        output = responses.call_connector_with_events(
+            name=name, call_id="call-1", arguments=arguments
+        )
+
+    assert output == {
+        "type": "function_call_output",
+        "call_id": "call-1",
+        "output": '{"results":[]}',
+    }
+    assert append_and_push_run_events.call_args_list == [
+        call(
+            [
+                {
+                    "type": "function_call",
+                    "call_id": "call-1",
+                    "name": name,
+                    "arguments": '{"query":"Flower"}',
+                }
+            ]
+        ),
+        call([output]),
+    ]
+
+
+def test_connector_failure_emits_secret_safe_output() -> None:
+    """Persist a terminal, secret-safe output before propagating a failure."""
+    responses = RuntimeAgentResponses(
+        stub=Mock(),
+        run_id=123,
+        task_id=789,
+        context=Mock(),
+        start_run_request=StartRunRequest(),
+        events=Mock(),
+    )
+
+    with (
+        patch.object(
+            responses,
+            "create_connector_response",
+            side_effect=RuntimeError("provider leaked secret-token"),
+        ),
+        patch.object(
+            responses, "append_and_push_run_events"
+        ) as append_and_push_run_events,
+        pytest.raises(RuntimeError, match="secret-token"),
+    ):
+        responses.call_connector_with_events(
+            name="notion_search",
+            call_id="call-1",
+            arguments={"query": "Flower"},
+        )
+
+    terminal_item = append_and_push_run_events.call_args_list[-1].args[0][0]
+    assert terminal_item == {
+        "type": "function_call_output",
+        "call_id": "call-1",
+        "output": (
+            '{"error":{"code":"connector_error",'
+            '"message":"Connector execution failed."}}'
+        ),
+    }
+    assert "secret-token" not in terminal_item["output"]
 
 
 def test_create_connector_response_resolves_canonical_name() -> None:

--- a/framework/py/flwr/supercore/task_process/agent/session_test.py
+++ b/framework/py/flwr/supercore/task_process/agent/session_test.py
@@ -239,76 +239,16 @@ def test_call_automation_embeds_input_in_control_request() -> None:
             series_id=2,
         ),
     )
-    assert append_and_push_run_events.call_args_list == [
-        call(
-            [
-                {
-                    "type": "function_call",
-                    "call_id": "call-1",
-                    "name": START_AUTOMATION_TOOL_NAME,
-                    "arguments": (
-                        '{"input":"Do work","start_at":"2026-07-28T12:00:00Z",'
-                        '"fixed_interval":60,"max_runs":3}'
-                    ),
-                }
-            ]
-        ),
-        call(
-            [
-                {
-                    "type": "function_call_output",
-                    "call_id": "call-1",
-                    "output": (
-                        '{"automation_id":0,"series_id":0,"next_run_at":""}'
-                    ),
-                }
-            ]
-        ),
+    items = [item.args[0][0] for item in append_and_push_run_events.call_args_list]
+    assert [item["type"] for item in items] == [
+        "function_call",
+        "function_call_output",
     ]
+    assert items[0]["name"] == START_AUTOMATION_TOOL_NAME
 
 
-def test_automation_failure_emits_secret_safe_output() -> None:
-    """Persist a terminal, secret-safe output when automation creation fails."""
-    stub = Mock()
-    stub.StartAutomation.side_effect = RuntimeError("scheduler leaked secret-token")
-    responses = RuntimeAgentResponses(
-        stub=stub,
-        run_id=123,
-        task_id=789,
-        context=Mock(),
-        start_run_request=StartRunRequest(),
-        events=Mock(),
-    )
-
-    with (
-        patch.object(
-            responses, "append_and_push_run_events"
-        ) as append_and_push_run_events,
-        pytest.raises(RuntimeError, match="secret-token"),
-    ):
-        responses.call_automation_with_events(
-            call_id="call-1",
-            arguments={
-                "input": "Do work",
-                "start_at": "2026-07-28T12:00:00Z",
-            },
-        )
-
-    terminal_item = append_and_push_run_events.call_args_list[-1].args[0][0]
-    assert terminal_item == {
-        "type": "function_call_output",
-        "call_id": "call-1",
-        "output": (
-            '{"error":{"code":"automation_error",'
-            '"message":"Automation execution failed."}}'
-        ),
-    }
-    assert "secret-token" not in terminal_item["output"]
-
-
-@pytest.mark.parametrize("name", ["web_search", "notion_search"])
-def test_connector_call_emits_standard_items(name: str) -> None:
-    """Emit standard function items for built-in and OAuth connectors."""
+def test_connector_call_emits_standard_items() -> None:
+    """Emit standard function call and output items."""
     responses = RuntimeAgentResponses(
         stub=Mock(),
         run_id=123,
@@ -328,7 +268,7 @@ def test_connector_call_emits_standard_items(name: str) -> None:
         ) as append_and_push_run_events,
     ):
         output = responses.call_connector_with_events(
-            name=name, call_id="call-1", arguments=arguments
+            name="notion_search", call_id="call-1", arguments=arguments
         )
 
     assert output == {
@@ -342,7 +282,7 @@ def test_connector_call_emits_standard_items(name: str) -> None:
                 {
                     "type": "function_call",
                     "call_id": "call-1",
-                    "name": name,
+                    "name": "notion_search",
                     "arguments": '{"query":"Flower"}',
                 }
             ]
@@ -379,16 +319,9 @@ def test_connector_failure_emits_secret_safe_output() -> None:
             arguments={"query": "Flower"},
         )
 
-    terminal_item = append_and_push_run_events.call_args_list[-1].args[0][0]
-    assert terminal_item == {
-        "type": "function_call_output",
-        "call_id": "call-1",
-        "output": (
-            '{"error":{"code":"connector_error",'
-            '"message":"Connector execution failed."}}'
-        ),
-    }
-    assert "secret-token" not in terminal_item["output"]
+    output = append_and_push_run_events.call_args_list[-1].args[0][0]["output"]
+    assert "Connector execution failed." in output
+    assert "secret-token" not in output
 
 
 def test_create_connector_response_resolves_canonical_name() -> None:

--- a/framework/py/flwr/supercore/task_process/agent/session_test.py
+++ b/framework/py/flwr/supercore/task_process/agent/session_test.py
@@ -291,39 +291,6 @@ def test_connector_call_emits_standard_items() -> None:
     ]
 
 
-def test_connector_failure_emits_secret_safe_output() -> None:
-    """Persist a terminal, secret-safe output before propagating a failure."""
-    responses = RuntimeAgentResponses(
-        stub=Mock(),
-        run_id=123,
-        task_id=789,
-        context=Mock(),
-        start_run_request=StartRunRequest(),
-        events=Mock(),
-    )
-
-    with (
-        patch.object(
-            responses,
-            "create_connector_response",
-            side_effect=RuntimeError("provider leaked secret-token"),
-        ),
-        patch.object(
-            responses, "append_and_push_run_events"
-        ) as append_and_push_run_events,
-        pytest.raises(RuntimeError, match="secret-token"),
-    ):
-        responses.call_connector_with_events(
-            name="notion_search",
-            call_id="call-1",
-            arguments={"query": "Flower"},
-        )
-
-    output = append_and_push_run_events.call_args_list[-1].args[0][0]["output"]
-    assert "Connector execution failed." in output
-    assert "secret-token" not in output
-
-
 def test_create_connector_response_resolves_canonical_name() -> None:
     """Task creation should resolve the canonical tool name to its connector."""
     stub = Mock()

--- a/framework/py/flwr/superlink/servicer/control/control_handlers.py
+++ b/framework/py/flwr/superlink/servicer/control/control_handlers.py
@@ -631,6 +631,20 @@ def start_run(  # pylint: disable=too-many-branches,too-many-locals,too-many-sta
                 _derive_run_series_description(fused_run_config) or None
             )
 
+        initial_task_event = None
+        if primary_task_type == TaskType.AGENT_APP:
+            agent_input = fused_run_config.get("agent.input")
+            if isinstance(agent_input, str) and agent_input:
+                input_item: JSONObject = {
+                    "type": "message",
+                    "role": "user",
+                    "content": agent_input,
+                }
+                initial_task_event = TaskEvent(
+                    event="message",
+                    data=strict_json_dumps(input_item, compact=True),
+                )
+
         run_id = state.create_run(
             fab_id,
             fab_version,
@@ -643,6 +657,7 @@ def start_run(  # pylint: disable=too-many-branches,too-many-locals,too-many-sta
             series_id=series_id,
             series_description=series_description,
             connector_refs=connector_refs,
+            initial_task_event=initial_task_event,
         )
 
         if run_id == 0:
@@ -656,27 +671,6 @@ def start_run(  # pylint: disable=too-many-branches,too-many-locals,too-many-sta
 
         run = state.get_run_info(run_ids=[run_id])[0]
         series_id = run.series_id
-
-        if primary_task_type == TaskType.AGENT_APP:
-            agent_input = fused_run_config.get("agent.input")
-            if isinstance(agent_input, str) and agent_input:
-                primary_task_id = cast(int, run.primary_task_id)
-                input_item: JSONObject = {
-                    "type": "message",
-                    "role": "user",
-                    "content": agent_input,
-                }
-                if not state.store_task_events(
-                    [
-                        TaskEvent(
-                            run_id=run_id,
-                            task_id=primary_task_id,
-                            event="message",
-                            data=strict_json_dumps(input_item, compact=True),
-                        )
-                    ]
-                ):
-                    raise RuntimeError("Failed to store the AgentApp input event.")
 
     except ValueError as e:
         log(ERROR, "Could not start run: %s", str(e))

--- a/framework/py/flwr/superlink/servicer/control/control_handlers.py
+++ b/framework/py/flwr/superlink/servicer/control/control_handlers.py
@@ -136,6 +136,7 @@ from flwr.proto.federation_config_pb2 import SimulationConfig  # pylint: disable
 from flwr.proto.federation_pb2 import Federation  # pylint: disable=E0611
 from flwr.proto.node_pb2 import NodeInfo  # pylint: disable=E0611
 from flwr.proto.runseries_pb2 import RunSeries  # pylint: disable=E0611
+from flwr.proto.task_pb2 import TaskEvent  # pylint: disable=E0611
 from flwr.server.superlink.linkstate import LinkState
 from flwr.supercore import log
 from flwr.supercore.auth.typing import AccountInfo
@@ -161,6 +162,7 @@ from flwr.supercore.typing import (
     AcceptInvitationContext,
     CreateFederationContext,
     CreateInvitationContext,
+    JSONObject,
     RegisterSupernodeContext,
     StartRunContext,
 )
@@ -654,6 +656,27 @@ def start_run(  # pylint: disable=too-many-branches,too-many-locals,too-many-sta
 
         run = state.get_run_info(run_ids=[run_id])[0]
         series_id = run.series_id
+
+        if primary_task_type == TaskType.AGENT_APP:
+            agent_input = fused_run_config.get("agent.input")
+            if isinstance(agent_input, str) and agent_input:
+                primary_task_id = cast(int, run.primary_task_id)
+                input_item: JSONObject = {
+                    "type": "message",
+                    "role": "user",
+                    "content": agent_input,
+                }
+                if not state.store_task_events(
+                    [
+                        TaskEvent(
+                            run_id=run_id,
+                            task_id=primary_task_id,
+                            event="message",
+                            data=strict_json_dumps(input_item, compact=True),
+                        )
+                    ]
+                ):
+                    raise RuntimeError("Failed to store the AgentApp input event.")
 
     except ValueError as e:
         log(ERROR, "Could not start run: %s", str(e))

--- a/framework/py/flwr/superlink/servicer/control/control_handlers_test.py
+++ b/framework/py/flwr/superlink/servicer/control/control_handlers_test.py
@@ -16,6 +16,7 @@
 
 
 import hashlib
+import json
 import unittest
 from typing import Any, cast
 from unittest.mock import Mock, call, patch
@@ -308,6 +309,50 @@ class TestControlHandlers(unittest.TestCase):  # pylint: disable=R0904
         self.assertEqual(
             [(app.app_id, app.fab_hash, app.app_type) for app in apps],
             [("@flwr/demo", fab_hash, TaskType.SERVER_APP)],
+        )
+
+    def test_start_run_persists_agent_input_event(self) -> None:
+        """Persist agent input as a primary-task message item."""
+        fab_content = b"AgentApp FAB"
+        request = StartRunRequest(federation=NOOP_FEDERATION_ID)
+        request.fab.content = fab_content
+        request.fab.hash_str = hashlib.sha256(fab_content).hexdigest()
+        request.override_config["agent.input"].string = "Hello from the user"
+
+        with (
+            patch(
+                "flwr.superlink.servicer.control.control_handlers.get_fab_config",
+                return_value={
+                    "tool": {
+                        "flwr": {
+                            "app": {
+                                "config": {"agent": {"input": "Default input"}},
+                                "components": {"agentapp": "agent:app"},
+                            }
+                        }
+                    }
+                },
+            ),
+            patch(
+                "flwr.superlink.servicer.control.control_handlers"
+                ".get_metadata_from_config",
+                return_value=("flwr/agent", "v0.0.1"),
+            ),
+        ):
+            response = start_run(request, self.account, self.state, None)
+
+        run = self.state.get_run_info(run_ids=[response.run_id])[0]
+        events = self.state.get_task_events(run_ids=[response.run_id])
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].task_id, run.primary_task_id)
+        self.assertEqual(events[0].event, "message")
+        self.assertEqual(
+            json.loads(events[0].data),
+            {
+                "type": "message",
+                "role": "user",
+                "content": "Hello from the user",
+            },
         )
 
     def test_start_run_notifies_extension_after_persisting_run(self) -> None:

--- a/framework/py/flwr/superlink/servicer/control/control_handlers_test.py
+++ b/framework/py/flwr/superlink/servicer/control/control_handlers_test.py
@@ -16,7 +16,6 @@
 
 
 import hashlib
-import json
 import unittest
 from typing import Any, cast
 from unittest.mock import Mock, call, patch
@@ -313,24 +312,15 @@ class TestControlHandlers(unittest.TestCase):  # pylint: disable=R0904
 
     def test_start_run_persists_agent_input_event(self) -> None:
         """Persist agent input as a primary-task message item."""
-        fab_content = b"AgentApp FAB"
         request = StartRunRequest(federation=NOOP_FEDERATION_ID)
-        request.fab.content = fab_content
-        request.fab.hash_str = hashlib.sha256(fab_content).hexdigest()
-        request.override_config["agent.input"].string = "Hello from the user"
+        request.fab.content = b"AgentApp FAB"
+        request.override_config["agent.input"].string = "Hello"
 
         with (
             patch(
                 "flwr.superlink.servicer.control.control_handlers.get_fab_config",
                 return_value={
-                    "tool": {
-                        "flwr": {
-                            "app": {
-                                "config": {"agent": {"input": "Default input"}},
-                                "components": {"agentapp": "agent:app"},
-                            }
-                        }
-                    }
+                    "tool": {"flwr": {"app": {"config": {"agent": {"input": ""}}}}}
                 },
             ),
             patch(
@@ -338,21 +328,22 @@ class TestControlHandlers(unittest.TestCase):  # pylint: disable=R0904
                 ".get_metadata_from_config",
                 return_value=("flwr/agent", "v0.0.1"),
             ),
+            patch(
+                "flwr.superlink.servicer.control.control_handlers._get_app_type",
+                return_value=TaskType.AGENT_APP,
+            ),
         ):
             response = start_run(request, self.account, self.state, None)
 
         run = self.state.get_run_info(run_ids=[response.run_id])[0]
-        events = self.state.get_task_events(run_ids=[response.run_id])
-        self.assertEqual(len(events), 1)
-        self.assertEqual(events[0].task_id, run.primary_task_id)
-        self.assertEqual(events[0].event, "message")
+        event = self.state.get_task_events(run_ids=[response.run_id])[0]
         self.assertEqual(
-            json.loads(events[0].data),
-            {
-                "type": "message",
-                "role": "user",
-                "content": "Hello from the user",
-            },
+            (event.task_id, event.event, event.data),
+            (
+                run.primary_task_id,
+                "message",
+                '{"type":"message","role":"user","content":"Hello"}',
+            ),
         )
 
     def test_start_run_notifies_extension_after_persisting_run(self) -> None:


### PR DESCRIPTION
StartRun records agent.input as a primary-task message, while connector and automation calls use standard function_call/function_call_output items with JSON-encoded arguments and outputs. 