### PR TITLE
refactor(framework): Update the default Flower CLI API address

### DIFF
--- a/framework/py/flwr/cli/constant.py
+++ b/framework/py/flwr/cli/constant.py
@@ -17,8 +17,6 @@
 
 import os
 
-from flwr.supercore.constant import SUPERGRID_ADDRESS
-
 # General help message for config overrides
 CONFIG_HELP_MESSAGE = (
     "Override {0} values using one of the following formats:\n\n"
@@ -164,13 +162,15 @@ CONTROL_API_PROBE_INTERVAL = 0.2
 
 # CLI connection configuration file name
 FLOWER_CONFIG_FILE = "config.toml"
+LEGACY_SUPERGRID_ADDRESS = "supergrid.flower.ai"
+SUPERGRID_HTTP_ADDRESS = "api.flower.ai"
 
 # The default configuration for the Flower config file
 DEFAULT_FLOWER_CONFIG_TOML = f"""[superlink]
 default = "local"
 
 [superlink.supergrid]
-address = "{SUPERGRID_ADDRESS}"
+address = "{SUPERGRID_HTTP_ADDRESS}"
 
 [superlink.local]
 address = "{LOCAL_SUPERLINK_ADDRESS_MAGIC_VALUE}"

--- a/framework/py/flwr/cli/flower_config.py
+++ b/framework/py/flwr/cli/flower_config.py
@@ -63,10 +63,13 @@ def _get_supergrid_address_update_command(config_path: Path) -> str:
         )
 
     config_arg = shlex.quote(str(config_path))
-    return (
-        f"sed -i.bak 's/supergrid\\.flower\\.ai/{SUPERGRID_HTTP_ADDRESS}/g' "
-        f"{config_arg}"
+    legacy_pattern = re.escape(LEGACY_SUPERGRID_ADDRESS).replace("/", r"\/")
+    http_replacement = (
+        SUPERGRID_HTTP_ADDRESS.replace("\\", r"\\")
+        .replace("/", r"\/")
+        .replace("&", r"\&")
     )
+    return f"sed -i.bak 's/{legacy_pattern}/{http_replacement}/g' {config_arg}"
 
 
 def _parse_simulation_options(options: dict[str, Any]) -> SuperLinkSimulationOptions:

--- a/framework/py/flwr/cli/flower_config.py
+++ b/framework/py/flwr/cli/flower_config.py
@@ -30,12 +30,12 @@ from flwr.cli.constant import (
     DEFAULT_FLOWER_CONFIG_TOML,
     FLOWER_CONFIG_FILE,
     LEGACY_SUPERGRID_ADDRESS,
+    SUPERGRID_HTTP_ADDRESS,
     SimulationBackendConfigTomlKey,
     SimulationClientResourcesTomlKey,
     SimulationInitArgsTomlKey,
     SuperLinkConnectionTomlKey,
     SuperLinkSimulationOptionsTomlKey,
-    SUPERGRID_HTTP_ADDRESS,
 )
 from flwr.cli.typing import (
     SimulationBackendConfig,

--- a/framework/py/flwr/cli/flower_config.py
+++ b/framework/py/flwr/cli/flower_config.py
@@ -15,7 +15,9 @@
 """Flower command line interface configuration utils."""
 
 
+import platform
 import re
+import shlex
 from pathlib import Path
 from typing import Any, cast
 
@@ -27,11 +29,13 @@ import typer
 from flwr.cli.constant import (
     DEFAULT_FLOWER_CONFIG_TOML,
     FLOWER_CONFIG_FILE,
+    LEGACY_SUPERGRID_ADDRESS,
     SimulationBackendConfigTomlKey,
     SimulationClientResourcesTomlKey,
     SimulationInitArgsTomlKey,
     SuperLinkConnectionTomlKey,
     SuperLinkSimulationOptionsTomlKey,
+    SUPERGRID_HTTP_ADDRESS,
 )
 from flwr.cli.typing import (
     SimulationBackendConfig,
@@ -43,6 +47,26 @@ from flwr.cli.typing import (
 from flwr.common.config import flatten_dict
 from flwr.supercore.constant import DEFAULT_SIMULATION_CONFIG
 from flwr.supercore.utils import get_flwr_home
+
+_WARNED_LEGACY_SUPERGRID_CONFIGS: set[Path] = set()
+
+
+def _get_supergrid_address_update_command(config_path: Path) -> str:
+    """Return a platform-appropriate command for updating the SuperGrid address."""
+    if platform.system() == "Windows":
+        config_arg = str(config_path).replace("'", "''")
+        return (
+            f"$path = '{config_arg}'; "
+            "[System.IO.File]::WriteAllText($path, "
+            "[System.IO.File]::ReadAllText($path).Replace("
+            f"'{LEGACY_SUPERGRID_ADDRESS}', '{SUPERGRID_HTTP_ADDRESS}'))"
+        )
+
+    config_arg = shlex.quote(str(config_path))
+    return (
+        f"sed -i.bak 's/supergrid\\.flower\\.ai/{SUPERGRID_HTTP_ADDRESS}/g' "
+        f"{config_arg}"
+    )
 
 
 def _parse_simulation_options(options: dict[str, Any]) -> SuperLinkSimulationOptions:
@@ -166,6 +190,18 @@ def init_flwr_config() -> None:
         typer.secho(
             f"\nFlower configuration not found. Created default configuration"
             f" at {config_path}\n",
+        )
+    elif (
+        config_path not in _WARNED_LEGACY_SUPERGRID_CONFIGS
+        and LEGACY_SUPERGRID_ADDRESS in config_path.read_text(encoding="utf-8")
+    ):
+        _WARNED_LEGACY_SUPERGRID_CONFIGS.add(config_path)
+        update_command = _get_supergrid_address_update_command(config_path)
+        typer.secho(
+            "\n⚠️ The Flower configuration uses the deprecated SuperGrid address "
+            f"`{LEGACY_SUPERGRID_ADDRESS}`. Update it manually or by running "
+            f"the command:\n\n{update_command}\n",
+            fg=typer.colors.YELLOW,
         )
 
 

--- a/framework/py/flwr/cli/flower_config_test.py
+++ b/framework/py/flwr/cli/flower_config_test.py
@@ -24,6 +24,7 @@ from unittest.mock import Mock, patch
 
 import click
 import tomli
+import typer
 from parameterized import parameterized
 
 from flwr.cli.constant import (
@@ -84,9 +85,7 @@ class TestInitFlwrConfig(unittest.TestCase):
         # 3. Check [superlink.supergrid]
         self.assertIn("supergrid", superlink)
         supergrid = superlink["supergrid"]
-        self.assertEqual(
-            supergrid[SuperLinkConnectionTomlKey.ADDRESS], "supergrid.flower.ai"
-        )
+        self.assertEqual(supergrid[SuperLinkConnectionTomlKey.ADDRESS], "api.flower.ai")
 
         # 4. Check [superlink.local]
         self.assertIn("local", superlink)
@@ -112,6 +111,43 @@ class TestInitFlwrConfig(unittest.TestCase):
                 self.assertEqual(
                     config_path.read_text(encoding="utf-8"), "existing_content"
                 )
+
+    @parameterized.expand(
+        [
+            ("Darwin", "sed -i.bak"),
+            ("Linux", "sed -i.bak"),
+            ("Windows", "[System.IO.File]::WriteAllText"),
+        ]
+    )
+    def test_init_flwr_config_warns_about_deprecated_supergrid_address(
+        self, operating_system: str, expected_command: str
+    ) -> None:
+        """Warn existing users how to replace the deprecated SuperGrid address."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config_path = Path(tmp_dir) / "config.toml"
+            config_path.write_text(
+                '[superlink.supergrid]\naddress = "supergrid.flower.ai"\n',
+                encoding="utf-8",
+            )
+
+            with (
+                patch.dict(os.environ, {FLWR_HOME: tmp_dir}),
+                patch(
+                    "flwr.cli.flower_config.platform.system",
+                    return_value=operating_system,
+                ),
+                patch("flwr.cli.flower_config.typer.secho") as secho,
+            ):
+                init_flwr_config()
+                init_flwr_config()
+
+            secho.assert_called_once()
+            message = secho.call_args.args[0]
+            self.assertIn("supergrid.flower.ai", message)
+            self.assertIn("api.flower.ai", message)
+            self.assertIn(expected_command, message)
+            self.assertIn(str(config_path), message)
+            self.assertEqual(secho.call_args.kwargs["fg"], typer.colors.YELLOW)
 
 
 class TestSuperLinkConnection(unittest.TestCase):

--- a/framework/py/flwr/cli/flower_config_test.py
+++ b/framework/py/flwr/cli/flower_config_test.py
@@ -112,7 +112,7 @@ class TestInitFlwrConfig(unittest.TestCase):
                     config_path.read_text(encoding="utf-8"), "existing_content"
                 )
 
-    @parameterized.expand(
+    @parameterized.expand(  # type: ignore[untyped-decorator]
         [
             ("Darwin", "sed -i.bak"),
             ("Linux", "sed -i.bak"),


### PR DESCRIPTION
Create new `Flower CLI` configurations with `api.flower.ai`. For existing configurations using supergrid.flower.ai, display a one-time warning with an OS-specific command to update the address.