### PR TITLE
feat(framework): Flush first text delta event eagerly

### DIFF
--- a/framework/py/flwr/supercore/task_process/model/task.py
+++ b/framework/py/flwr/supercore/task_process/model/task.py
@@ -36,7 +36,9 @@ from flwr.supercore.utils import strict_json_dumps
 from .provider import ModelProviderError, invoke_model_provider
 
 _DEFAULT_TASK_EVENT_BATCH_SIZE = 16
-_TEXT_DELTA_EVENT = "response.output_text.delta"
+_TEXT_DELTA_EVENTS = frozenset(
+    {"response.output_text.delta", "response.reasoning_summary_text.delta"}
+)
 
 
 def handle_task(client: RuntimeHttpClient, task_id: int, run_id: int) -> None:
@@ -78,7 +80,7 @@ def handle_task(client: RuntimeHttpClient, task_id: int, run_id: int) -> None:
             return
         encoded = strict_json_dumps(event, compact=True)
         events.append(TaskEvent(event=cast(str, event["type"]), data=encoded))
-        if event["type"] == _TEXT_DELTA_EVENT and not first_text_event_flushed:
+        if event["type"] in _TEXT_DELTA_EVENTS and not first_text_event_flushed:
             _flush_events()
             first_text_event_flushed = True
         elif len(events) >= _DEFAULT_TASK_EVENT_BATCH_SIZE:

--- a/framework/py/flwr/supercore/task_process/model/task.py
+++ b/framework/py/flwr/supercore/task_process/model/task.py
@@ -36,6 +36,7 @@ from flwr.supercore.utils import strict_json_dumps
 from .provider import ModelProviderError, invoke_model_provider
 
 _DEFAULT_TASK_EVENT_BATCH_SIZE = 16
+_TEXT_DELTA_EVENT = "response.output_text.delta"
 
 
 def handle_task(client: RuntimeHttpClient, task_id: int, run_id: int) -> None:
@@ -61,7 +62,7 @@ def handle_task(client: RuntimeHttpClient, task_id: int, run_id: int) -> None:
 
     # Stream events are exposed through Control.StreamRunEvents.
     events: list[TaskEvent] = []
-    first_stream_event_flushed = False
+    first_text_event_flushed = False
 
     def _flush_events() -> None:
         """Push buffered stream events."""
@@ -72,14 +73,14 @@ def handle_task(client: RuntimeHttpClient, task_id: int, run_id: int) -> None:
 
     def _buffer_event(event: JSONObject) -> None:
         """Buffer one Open Responses stream event."""
-        nonlocal first_stream_event_flushed
+        nonlocal first_text_event_flushed
         if not is_stream:
             return
         encoded = strict_json_dumps(event, compact=True)
         events.append(TaskEvent(event=cast(str, event["type"]), data=encoded))
-        if not first_stream_event_flushed:
+        if event["type"] == _TEXT_DELTA_EVENT and not first_text_event_flushed:
             _flush_events()
-            first_stream_event_flushed = True
+            first_text_event_flushed = True
         elif len(events) >= _DEFAULT_TASK_EVENT_BATCH_SIZE:
             _flush_events()
 

--- a/framework/py/flwr/supercore/task_process/model/task.py
+++ b/framework/py/flwr/supercore/task_process/model/task.py
@@ -61,6 +61,7 @@ def handle_task(client: RuntimeHttpClient, task_id: int, run_id: int) -> None:
 
     # Stream events are exposed through Control.StreamRunEvents.
     events: list[TaskEvent] = []
+    first_stream_event_flushed = False
 
     def _flush_events() -> None:
         """Push buffered stream events."""
@@ -71,11 +72,15 @@ def handle_task(client: RuntimeHttpClient, task_id: int, run_id: int) -> None:
 
     def _buffer_event(event: JSONObject) -> None:
         """Buffer one Open Responses stream event."""
+        nonlocal first_stream_event_flushed
         if not is_stream:
             return
         encoded = strict_json_dumps(event, compact=True)
         events.append(TaskEvent(event=cast(str, event["type"]), data=encoded))
-        if len(events) >= _DEFAULT_TASK_EVENT_BATCH_SIZE:
+        if not first_stream_event_flushed:
+            _flush_events()
+            first_stream_event_flushed = True
+        elif len(events) >= _DEFAULT_TASK_EVENT_BATCH_SIZE:
             _flush_events()
 
     response = None

--- a/framework/py/flwr/supercore/task_process/model/task_test.py
+++ b/framework/py/flwr/supercore/task_process/model/task_test.py
@@ -46,8 +46,12 @@ def _completed_response() -> JSONObject:
     return {"object": "response", "status": "completed", "output": []}
 
 
+@pytest.mark.parametrize(
+    "first_text_event",
+    ["response.output_text.delta", "response.reasoning_summary_text.delta"],
+)
 def test_handle_task_flushes_first_text_event_eagerly(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, first_text_event: str
 ) -> None:
     """The first text event is persisted without waiting for a full batch."""
     stub = Mock()
@@ -67,7 +71,7 @@ def test_handle_task_flushes_first_text_event_eagerly(
         on_stream_event(
             cast(
                 JSONObject,
-                {"type": "response.output_text.delta", "delta": "Hello"},
+                {"type": first_text_event, "delta": "Hello"},
             )
         )
         assert stub.PushTaskEvents.call_count == 1
@@ -83,5 +87,5 @@ def test_handle_task_flushes_first_text_event_eagerly(
     assert [len(batch) for batch in batches] == [2, 16]
     assert [event.event for event in batches[0]] == [
         "response.created",
-        "response.output_text.delta",
+        first_text_event,
     ]

--- a/framework/py/flwr/supercore/task_process/model/task_test.py
+++ b/framework/py/flwr/supercore/task_process/model/task_test.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for Model task event buffering."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import cast
+from unittest.mock import Mock
+
+import pytest
+
+from flwr.supercore.json_message.model_message import ModelRequest
+from flwr.supercore.typing import JSONObject
+
+from . import task
+
+
+def _model_request() -> ModelRequest:
+    """Create a Model request with routed task metadata."""
+    request = ModelRequest(
+        dst_task_id=22,
+        input_="Return exactly: profiling-ready.",
+        model="model",
+        stream=True,
+    )
+    request.metadata.__dict__["_message_id"] = "request-message-id"
+    request.metadata.src_task_id = 11
+    return request
+
+
+def _completed_response() -> JSONObject:
+    """Return a minimal successful Model response."""
+    return {"object": "response", "status": "completed", "output": []}
+
+
+def test_handle_task_flushes_first_event_eagerly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The first streamed event is persisted without waiting for a full batch."""
+    stub = Mock()
+    monkeypatch.setattr(
+        task, "_pull_model_request", Mock(return_value=_model_request())
+    )
+
+    def invoke_provider(
+        _request: JSONObject,
+        *,
+        on_stream_event: Callable[[JSONObject], None],
+        usage_recorder: object,
+    ) -> JSONObject:
+        on_stream_event(cast(JSONObject, {"type": "response.created"}))
+        assert stub.PushTaskEvents.call_count == 1
+        for index in range(16):
+            on_stream_event(cast(JSONObject, {"type": f"response.event-{index}"}))
+        return _completed_response()
+
+    monkeypatch.setattr(task, "invoke_model_provider", invoke_provider)
+
+    task.handle_task(client=stub, task_id=22, run_id=7)
+
+    batches = [call.args[0].events for call in stub.PushTaskEvents.call_args_list]
+    assert [len(batch) for batch in batches] == [1, 16]

--- a/framework/py/flwr/supercore/task_process/model/task_test.py
+++ b/framework/py/flwr/supercore/task_process/model/task_test.py
@@ -46,10 +46,10 @@ def _completed_response() -> JSONObject:
     return {"object": "response", "status": "completed", "output": []}
 
 
-def test_handle_task_flushes_first_event_eagerly(
+def test_handle_task_flushes_first_text_event_eagerly(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The first streamed event is persisted without waiting for a full batch."""
+    """The first text event is persisted without waiting for a full batch."""
     stub = Mock()
     monkeypatch.setattr(
         task, "_pull_model_request", Mock(return_value=_model_request())
@@ -63,6 +63,13 @@ def test_handle_task_flushes_first_event_eagerly(
     ) -> JSONObject:
         del usage_recorder
         on_stream_event(cast(JSONObject, {"type": "response.created"}))
+        assert stub.PushTaskEvents.call_count == 0
+        on_stream_event(
+            cast(
+                JSONObject,
+                {"type": "response.output_text.delta", "delta": "Hello"},
+            )
+        )
         assert stub.PushTaskEvents.call_count == 1
         for index in range(16):
             on_stream_event(cast(JSONObject, {"type": f"response.event-{index}"}))
@@ -73,4 +80,8 @@ def test_handle_task_flushes_first_event_eagerly(
     task.handle_task(client=stub, task_id=22, run_id=7)
 
     batches = [call.args[0].events for call in stub.PushTaskEvents.call_args_list]
-    assert [len(batch) for batch in batches] == [1, 16]
+    assert [len(batch) for batch in batches] == [2, 16]
+    assert [event.event for event in batches[0]] == [
+        "response.created",
+        "response.output_text.delta",
+    ]

--- a/framework/py/flwr/supercore/task_process/model/task_test.py
+++ b/framework/py/flwr/supercore/task_process/model/task_test.py
@@ -59,8 +59,9 @@ def test_handle_task_flushes_first_event_eagerly(
         _request: JSONObject,
         *,
         on_stream_event: Callable[[JSONObject], None],
-        _usage_recorder: object,
+        usage_recorder: object,
     ) -> JSONObject:
+        del usage_recorder
         on_stream_event(cast(JSONObject, {"type": "response.created"}))
         assert stub.PushTaskEvents.call_count == 1
         for index in range(16):

--- a/framework/py/flwr/supercore/task_process/model/task_test.py
+++ b/framework/py/flwr/supercore/task_process/model/task_test.py
@@ -59,7 +59,7 @@ def test_handle_task_flushes_first_event_eagerly(
         _request: JSONObject,
         *,
         on_stream_event: Callable[[JSONObject], None],
-        usage_recorder: object,
+        _usage_recorder: object,
     ) -> JSONObject:
         on_stream_event(cast(JSONObject, {"type": "response.created"}))
         assert stub.PushTaskEvents.call_count == 1


### PR DESCRIPTION
For the very first streaming text delta event, we flush it directly instead of waiting for the batch to be complete. This gives the user faster visual feedback