### PR TITLE
fix(framework): Lower Fleet.PullMessages node log to debug level

### DIFF
--- a/framework/docs/source/how-to-configure-audit-logging.rst
+++ b/framework/docs/source/how-to-configure-audit-logging.rst
@@ -115,5 +115,4 @@ And here is an example when a SuperNode pulls a message from the SuperLink:
 .. code-block:: shell
 
     INFO :      [AUDIT] {"timestamp": "2025-07-14T10:27:02Z", "actor": {"actor_id": "...", "description": "SuperNode", "ip_address": "..."}, "event": {"action": "FleetServicer.PullMessages", "run_id": null, "fab_hash": null}, "status": "started"}
-    INFO :      [Fleet.PullMessages] node_id=...
     INFO :      [AUDIT] {"timestamp": "2025-07-14T10:27:02Z", "actor": {"actor_id": "...", "description": "SuperNode", "ip_address": "..."}, "event": {"action": "FleetServicer.PullMessages", "run_id": null, "fab_hash": null}, "status": "completed"}

--- a/framework/py/flwr/server/superlink/fleet/grpc_rere/fleet_servicer.py
+++ b/framework/py/flwr/server/superlink/fleet/grpc_rere/fleet_servicer.py
@@ -197,7 +197,7 @@ class FleetServicer(fleet_pb2_grpc.FleetServicer):
         self, request: PullMessagesRequest, context: grpc.ServicerContext
     ) -> PullMessagesResponse:
         """Pull Messages."""
-        log(INFO, "[Fleet.PullMessages] node_id=%s", request.node.node_id)
+        log(DEBUG, "[Fleet.PullMessages] node_id=%s", request.node.node_id)
         log(DEBUG, "[Fleet.PullMessages] Request: %s", MessageToDict(request))
         return message_handler.pull_messages(
             request=request,


### PR DESCRIPTION
Lower the [Fleet.PullMessages] node_id=%s log from INFO to DEBUG. Verified with Python syntax compilation and git diff --check.