### PR TITLE
ci(*:skip): Fix `fastai` e2e

### DIFF
--- a/framework/e2e/e2e-fastai/pyproject.toml
+++ b/framework/e2e/e2e-fastai/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "fastai>=2.7.12,<3.0.0",
     "fastprogress==1.0.5",
     "torch>=2.10.0,<3.0.0",
+    "plum-dispatch<2.10.0",
     "spacy==3.8.7",
     "numpy<2.0.0",
 ]

--- a/framework/e2e/e2e-fastai/pyproject.toml
+++ b/framework/e2e/e2e-fastai/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "flwr[simulation] @ {root:parent:parent:uri}",
     "fastai>=2.7.12,<3.0.0",
     "fastprogress==1.0.5",
-    "fastcore<1.12.2", # Remove this constraint once this issue is resolved. https://github.com/AnswerDotAI/fastcore/issues/751 
     "torch>=2.10.0,<3.0.0",
     "spacy==3.8.7",
     "numpy<2.0.0",


### PR DESCRIPTION
`plum-dispatch=2.10.0` was released 2h ago and things seem to fail as a result: https://pypi.org/project/plum-dispatch/#history