### PR TITLE
break(framework): Remove long-deprecated `exec-` flags in `SuperLink`

### DIFF
--- a/framework/py/flwr/superlink/cli/flower_superlink.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink.py
@@ -295,51 +295,14 @@ def _parse_superlink_lifespan_config() -> SuperLinkLifespanConfig:
             backup_count=args.log_rotation_backup_count,
         )
 
-    # Detect if `--executor*` arguments were set
-    if args.executor or args.executor_dir or args.executor_config:
-        flwr_exit(
-            ExitCode.SUPERLINK_INVALID_ARGS,
-            "The arguments `--executor`, `--executor-dir`, and `--executor-config` are "
-            "deprecated and will be removed in a future release. To run SuperLink with "
-            "the simulation runtime, please use `--simulation`.",
-        )
-
-    # Detect if both Control API and Exec API addresses were set explicitly
-    explicit_args = set()
-    for arg in sys.argv[1:]:
-        if arg.startswith("--"):
-            explicit_args.add(
-                arg.split("=")[0]
-            )  # handles both `--arg val` and `--arg=val`
-
     # The old opt-in flag is accepted for compatibility, but no longer needed.
-    if "--allow-runtime-dependency-installation" in explicit_args:
+    if "--allow-runtime-dependency-installation" in sys.argv:
         log(
             WARN,
             "The `--allow-runtime-dependency-installation` argument is deprecated. "
             "Runtime dependency installation is enabled by default for SuperLink. "
             "Use `--disable-runtime-dependency-installation` to disable it.",
         )
-
-    control_api_set = "--control-api-address" in explicit_args
-    exec_api_set = "--exec-api-address" in explicit_args
-
-    if control_api_set and exec_api_set:
-        flwr_exit(
-            ExitCode.SUPERLINK_INVALID_ARGS,
-            "Both `--control-api-address` and `--exec-api-address` are set. "
-            "Please use only `--control-api-address` as `--exec-api-address` is "
-            "deprecated.",
-        )
-
-    # Warn deprecated `--exec-api-address` argument
-    if args.exec_api_address is not None:
-        log(
-            WARN,
-            "The `--exec-api-address` argument is deprecated and will be removed in a "
-            "future release. Use `--control-api-address` instead.",
-        )
-        args.control_api_address = args.exec_api_address
 
     # Parse IP addresses
     control_address, _, _ = _format_address(args.control_api_address)
@@ -885,27 +848,6 @@ def _add_args_control_api(parser: argparse.ArgumentParser) -> None:
         help="Control API server address (IPv4, IPv6, or a domain name) "
         f"By default, it is set to {CONTROL_API_DEFAULT_SERVER_ADDRESS}.",
         default=CONTROL_API_DEFAULT_SERVER_ADDRESS,
-    )
-    parser.add_argument(
-        "--exec-api-address",
-        help="This argument is deprecated and will be removed in a future release. "
-        "Use `--control-api-address` instead.",
-        default=None,
-    )
-    parser.add_argument(
-        "--executor",
-        help="This argument is deprecated and will be removed in a future release.",
-        default=None,
-    )
-    parser.add_argument(
-        "--executor-dir",
-        help="This argument is deprecated and will be removed in a future release.",
-        default=None,
-    )
-    parser.add_argument(
-        "--executor-config",
-        help="This argument is deprecated and will be removed in a future release.",
-        default=None,
     )
     parser.add_argument(  # To be removed in follow-up PRs
         "--simulation",

--- a/framework/py/flwr/superlink/cli/flower_superlink.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink.py
@@ -295,9 +295,7 @@ def _parse_superlink_lifespan_config() -> SuperLinkLifespanConfig:
             backup_count=args.log_rotation_backup_count,
         )
 
-    explicit_args = {
-        arg.split("=")[0] for arg in sys.argv[1:] if arg.startswith("--")
-    }
+    explicit_args = {arg.split("=")[0] for arg in sys.argv[1:] if arg.startswith("--")}
 
     # The old opt-in flag is accepted for compatibility, but no longer needed.
     if "--allow-runtime-dependency-installation" in explicit_args:

--- a/framework/py/flwr/superlink/cli/flower_superlink_test.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink_test.py
@@ -124,24 +124,14 @@ def test_parse_superlink_lifespan_config_keeps_fleet_address_unset_for_simulatio
     assert config.fleet_api_address is None
 
 
-def test_parse_superlink_lifespan_config_maps_exec_api_address(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Deprecated Exec API address should end up as Control API config."""
-    monkeypatch.setattr(
-        app_module.sys,
-        "argv",
-        [
-            "flower-superlink",
-            "--insecure",
-            "--exec-api-address",
-            "127.0.0.1:9099",
-        ],
-    )
-
-    config = _parse_superlink_lifespan_config()
-
-    assert config.control_address == "127.0.0.1:9099"
+@pytest.mark.parametrize(
+    "argument",
+    ["--exec-api-address", "--executor", "--executor-dir", "--executor-config"],
+)
+def test_parse_superlink_rejects_removed_arguments(argument: str) -> None:
+    """SuperLink should reject removed arguments."""
+    with pytest.raises(SystemExit):
+        _parse_args_run_superlink().parse_args([argument, "value"])
 
 
 def test_parse_superlink_log_rotation_args_custom_values() -> None:

--- a/framework/py/flwr/superlink/cli/flower_superlink_test.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink_test.py
@@ -124,16 +124,6 @@ def test_parse_superlink_lifespan_config_keeps_fleet_address_unset_for_simulatio
     assert config.fleet_api_address is None
 
 
-@pytest.mark.parametrize(
-    "argument",
-    ["--exec-api-address", "--executor", "--executor-dir", "--executor-config"],
-)
-def test_parse_superlink_rejects_removed_arguments(argument: str) -> None:
-    """SuperLink should reject removed arguments."""
-    with pytest.raises(SystemExit):
-        _parse_args_run_superlink().parse_args([argument, "value"])
-
-
 def test_parse_superlink_log_rotation_args_custom_values() -> None:
     """SuperLink log rotation args should parse explicit values."""
     # Execute


### PR DESCRIPTION
The `ExecAPI` was replaced by the `ControlAPI` over a year ago. The flags this PR removes have been deprecated for a year