### PR TITLE
break(framework): Make all APIs share SSL settings by default

### DIFF
--- a/framework/docker/complete/with-state.yml
+++ b/framework/docker/complete/with-state.yml
@@ -21,9 +21,6 @@ services:
     # - --ssl-ca-certfile=certificates/ca.crt
     # - --ssl-certfile=certificates/server.pem
     # - --ssl-keyfile=certificates/server.key
-    # - --appio-ssl-ca-certfile=certificates/ca.crt
-    # - --appio-ssl-certfile=certificates/server.pem
-    # - --appio-ssl-keyfile=certificates/server.key
     # - --database=state/state.db
     volumes:
       - ./state/:/app/state/:rw

--- a/framework/docker/complete/with-tls.yml
+++ b/framework/docker/complete/with-tls.yml
@@ -10,9 +10,6 @@ services:
       - --ssl-ca-certfile=certificates/ca.crt
       - --ssl-certfile=certificates/server.pem
       - --ssl-keyfile=certificates/server.key
-      - --appio-ssl-ca-certfile=certificates/ca.crt
-      - --appio-ssl-certfile=certificates/server.pem
-      - --appio-ssl-keyfile=certificates/server.key
     secrets:
       - source: superlink-ca-certfile
         target: /app/certificates/ca.crt

--- a/framework/docker/distributed/server/compose.yml
+++ b/framework/docker/distributed/server/compose.yml
@@ -11,9 +11,6 @@ services:
       - --ssl-ca-certfile=certificates/ca.crt
       - --ssl-certfile=certificates/server.pem
       - --ssl-keyfile=certificates/server.key
-      - --appio-ssl-ca-certfile=certificates/ca.crt
-      - --appio-ssl-certfile=certificates/server.pem
-      - --appio-ssl-keyfile=certificates/server.key
       - --database=state/state.db
     volumes:
       - ./state/:/app/state/:rw

--- a/framework/docs/source/docker/enable-tls.rst
+++ b/framework/docs/source/docker/enable-tls.rst
@@ -54,9 +54,6 @@ Transport Layer Security (TLS) for each Flower component to ensure secure commun
                 --ssl-ca-certfile certificates/ca.crt \
                 --ssl-certfile certificates/server.pem \
                 --ssl-keyfile certificates/server.key \
-                --appio-ssl-ca-certfile certificates/ca.crt \
-                --appio-ssl-certfile certificates/server.pem \
-                --appio-ssl-keyfile certificates/server.key \
                 <additional-args>
 
         .. dropdown:: Understanding the command
@@ -85,10 +82,6 @@ Transport Layer Security (TLS) for each Flower component to ensure secure commun
               |
               | The ``certificates/server.key`` file is used to decrypt the data that is transmitted over
               | the network.
-            * | ``--appio-ssl-ca-certfile``, ``--appio-ssl-certfile``, and
-              | ``--appio-ssl-keyfile``: Configure TLS for the shared Runtime and Control
-              | HTTP APIs.
-
         **SuperNode**
 
         .. note::
@@ -145,9 +138,6 @@ Transport Layer Security (TLS) for each Flower component to ensure secure commun
                 --ssl-ca-certfile certificates/ca.crt \
                 --ssl-certfile certificates/server.pem \
                 --ssl-keyfile certificates/server.key \
-                --appio-ssl-ca-certfile certificates/ca.crt \
-                --appio-ssl-certfile certificates/server.pem \
-                --appio-ssl-keyfile certificates/server.key \
                 --isolation process \
                 <additional-args>
 
@@ -178,9 +168,6 @@ Transport Layer Security (TLS) for each Flower component to ensure secure commun
               |
               | The ``certificates/server.key`` file is used to decrypt the data that is transmitted over
               | the network.
-            * | ``--appio-ssl-ca-certfile``, ``--appio-ssl-certfile``, and
-              | ``--appio-ssl-keyfile``: Configure TLS for the shared Runtime and Control
-              | HTTP APIs.
             * | ``--isolation process``: Tells the SuperLink that the ServerApp is created by separate
               | independent process. The SuperLink does not attempt to create it.
 

--- a/framework/docs/source/docker/tutorial-quickstart-docker-compose.rst
+++ b/framework/docs/source/docker/tutorial-quickstart-docker-compose.rst
@@ -397,9 +397,6 @@ To run Flower with persisted SuperLink state and enabled TLS, a slight change in
              - --ssl-ca-certfile=certificates/ca.crt
              - --ssl-certfile=certificates/server.pem
              - --ssl-keyfile=certificates/server.key
-             - --appio-ssl-ca-certfile=certificates/ca.crt
-             - --appio-ssl-certfile=certificates/server.pem
-             - --appio-ssl-keyfile=certificates/server.key
              - --database=state/state.db
            volumes:
              - ./state/:/app/state/:rw

--- a/framework/docs/source/how-to-authenticate-supernodes.rst
+++ b/framework/docs/source/how-to-authenticate-supernodes.rst
@@ -93,21 +93,13 @@ To launch a SuperLink with SuperNode authentication enabled, you need to provide
 aditional files in addition to the certificates needed for the TLS connections. Recall
 that the authentication feature can only be enabled in the presence of TLS.
 
-.. note::
-
-    To enable TLS also for the Runtime API on SuperLink, please refer to :ref:`Launching
-    the SuperLink with TLS <launching-the-superlink-with-tls>`.
-
 .. code-block:: bash
-    :emphasize-lines: 8
+    :emphasize-lines: 5
 
     $ flower-superlink \
         --ssl-ca-certfile certificates/ca.crt \
         --ssl-certfile certificates/server.pem \
         --ssl-keyfile certificates/server.key \
-        --appio-ssl-ca-certfile certificates/ca.crt \
-        --appio-ssl-certfile certificates/server.pem \
-        --appio-ssl-keyfile certificates/server.key \
         --enable-supernode-auth
 
 .. dropdown:: Understand the command

--- a/framework/docs/source/how-to-configure-logging.rst
+++ b/framework/docs/source/how-to-configure-logging.rst
@@ -18,10 +18,7 @@ example, to launch your ``SuperLink`` with ``DEBUG`` logs, use:
     FLWR_LOG_LEVEL=DEBUG flower-superlink \
         --ssl-ca-certfile certificates/ca.crt \
         --ssl-certfile certificates/server.pem \
-        --ssl-keyfile certificates/server.key \
-        --appio-ssl-ca-certfile certificates/ca.crt \
-        --appio-ssl-certfile certificates/server.pem \
-        --appio-ssl-keyfile certificates/server.key
+        --ssl-keyfile certificates/server.key
 
     WARNING 2025-08-20 17:13:30,391:   DEBUG logs enabled. Do not use this in production, as it may expose sensitive details.
     INFO 2025-08-20 17:13:31,360:      Starting Flower SuperLink

--- a/framework/docs/source/how-to-enable-tls-connections.rst
+++ b/framework/docs/source/how-to-enable-tls-connections.rst
@@ -73,33 +73,30 @@ new``).
 This section describes how to launch a SuperLink that works on TLS-enabled connections.
 The code snippet below assumes the `certificates/` directory is in the same directory
 where you execute the command from. Edit the paths accordingly if that is not the case.
-When providing certificates for the Fleet API and Control API, the SuperLink expects a
-tuple of three certificates paths: CA certificate, server certificate and server private
-key. The same command can also provide AppIo-named certificates for the SuperLink's
-Runtime API.
+The SuperLink expects three certificate paths: CA certificate, server certificate, and
+server private key.
+
+.. note::
+
+    Since Flower 1.37, the Fleet, Control, and Runtime APIs share this TLS
+    configuration.
 
 .. code-block:: bash
-    :emphasize-lines: 2,3,4,5,6,7
+    :emphasize-lines: 2,3,4
 
     $ flower-superlink \
         --ssl-ca-certfile certificates/ca.crt \
         --ssl-certfile certificates/server.pem \
-        --ssl-keyfile certificates/server.key \
-        --appio-ssl-ca-certfile certificates/ca.crt \
-        --appio-ssl-certfile certificates/server.pem \
-        --appio-ssl-keyfile certificates/server.key
+        --ssl-keyfile certificates/server.key
 
 .. dropdown:: Understand the command
 
     * ``--ssl-ca-certfile``: Specify the location of the CA certificate file in your file. This file is a certificate that is used to verify the identity of the SuperLink.
     * | ``--ssl-certfile``: Specify the location of the SuperLink's TLS certificate file. This file is used to identify the SuperLink and to encrypt the packages that are transmitted over the network.
+      The certificate must include Subject Alternative Names (SANs) for the Runtime API
+      address used by SuperExec. When using an IP address such as ``127.0.0.1``, the
+      certificate must include a matching IP SAN.
     * | ``--ssl-keyfile``: Specify the location of the SuperLink's TLS private key file. This file is used to decrypt the packages that are transmitted over the network.
-    * | ``--appio-ssl-ca-certfile``: Specify the location of the CA certificate file used by SuperExec to verify the SuperLink's Runtime API server certificate.
-    * | ``--appio-ssl-certfile``: Specify the location of the Runtime API server TLS certificate file.
-        The certificate must include Subject Alternative Names (SANs) for the Runtime API address used by
-        SuperExec. When using an IP address such as ``127.0.0.1``, the certificate must include a
-        matching IP SAN.
-    * | ``--appio-ssl-keyfile``: Specify the location of the Runtime API server TLS private key file.
 
 .. _connecting-the-supernodes-with-tls:
 

--- a/framework/docs/source/ref-flower-network-communication.rst
+++ b/framework/docs/source/ref-flower-network-communication.rst
@@ -186,18 +186,19 @@ communicate with the SuperLink or SuperNode:
 .. note::
 
     The Runtime API links above can run with plaintext communication or with
-    server-authenticated TLS. Without the ``--appio-ssl-*`` options, these links remain
+    server-authenticated TLS. Without the relevant TLS options, these links remain
     unencrypted and should stay inside a trusted network:
 
     - SuperLink + SuperExec + ``ServerApp`` process
     - SuperNode + SuperExec + ``ClientApp`` process
 
-    To secure these links, configure the SuperLink and SuperNode Runtime API servers
-    with ``--appio-ssl-certfile``, ``--appio-ssl-keyfile``, and
-    ``--appio-ssl-ca-certfile``. Runtime API clients verify server certificates with
-    ``--root-certificates``. In ``subprocess`` isolation mode, the SuperLink and
-    SuperNode pass the CA path to the SuperExec processes they launch. This is not mTLS.
-    See :doc:`how-to-enable-tls-connections` for concrete commands.
+    For SuperLink, ``--ssl-certfile``, ``--ssl-keyfile``, and ``--ssl-ca-certfile``
+    secure all APIs. For SuperNode, configure its Runtime API with
+    ``--appio-ssl-certfile``, ``--appio-ssl-keyfile``, and ``--appio-ssl-ca-certfile``.
+    Runtime API clients verify server certificates with ``--root-certificates``. In
+    ``subprocess`` isolation mode, the SuperLink and SuperNode pass the CA path to the
+    SuperExec processes they launch. This is not mTLS. See
+    :doc:`how-to-enable-tls-connections` for concrete commands.
 
 .. warning::
 

--- a/framework/e2e/test_control_api.sh
+++ b/framework/e2e/test_control_api.sh
@@ -7,10 +7,7 @@ case "$1" in
       ./generate.sh
       server_arg='--ssl-ca-certfile ../certificates/ca.crt
                   --ssl-certfile    ../certificates/server.pem
-                  --ssl-keyfile     ../certificates/server.key
-                  --appio-ssl-ca-certfile ../certificates/ca.crt
-                  --appio-ssl-certfile    ../certificates/server.pem
-                  --appio-ssl-keyfile     ../certificates/server.key'
+                  --ssl-keyfile     ../certificates/server.key'
       client_arg='--root-certificates ../certificates/ca.crt'
       ;;
     insecure)

--- a/framework/e2e/test_superlink.sh
+++ b/framework/e2e/test_superlink.sh
@@ -6,10 +6,7 @@ case "$1" in
     ./generate.sh
     server_arg='--ssl-ca-certfile certificates/ca.crt
                 --ssl-certfile certificates/server.pem
-                --ssl-keyfile certificates/server.key
-                --appio-ssl-ca-certfile certificates/ca.crt
-                --appio-ssl-certfile certificates/server.pem
-                --appio-ssl-keyfile certificates/server.key'
+                --ssl-keyfile certificates/server.key'
     client_arg="--root-certificates certificates/ca.crt"
     server_dir="./"
     ;;

--- a/framework/py/flwr/superlink/cli/flower_superlink.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink.py
@@ -23,7 +23,6 @@ import sys
 import threading
 from collections.abc import Sequence
 from logging import INFO, WARN
-from pathlib import Path
 from time import sleep
 from typing import cast
 
@@ -84,7 +83,6 @@ from flwr.supercore.object_store import ObjectStoreFactory
 from flwr.supercore.telemetry import EventType, event
 from flwr.supercore.tls import (
     get_client_tls_args,
-    try_obtain_optional_runtime_server_certificates,
 )
 from flwr.supercore.update_check import warn_if_flwr_update_available
 from flwr.supercore.utils import get_popen_detach_kwargs

--- a/framework/py/flwr/superlink/cli/flower_superlink.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink.py
@@ -23,6 +23,7 @@ import sys
 import threading
 from collections.abc import Sequence
 from logging import INFO, WARN
+from pathlib import Path
 from time import sleep
 from typing import cast
 
@@ -81,9 +82,7 @@ from flwr.supercore.interceptors import (
 from flwr.supercore.logger import configure_superlink_log_file, console_handler
 from flwr.supercore.object_store import ObjectStoreFactory
 from flwr.supercore.telemetry import EventType, event
-from flwr.supercore.tls import (
-    get_client_tls_args,
-)
+from flwr.supercore.tls import get_client_tls_args
 from flwr.supercore.update_check import warn_if_flwr_update_available
 from flwr.supercore.utils import get_popen_detach_kwargs
 from flwr.supercore.version import package_version
@@ -438,9 +437,21 @@ def _parse_superlink_lifespan_config() -> SuperLinkLifespanConfig:
         ssl_certfile=args.ssl_certfile,
         database=args.database,
         isolation=args.isolation,
-        runtime_ssl_ca_certfile=args.ssl_ca_certfile,
-        runtime_ssl_certfile=args.ssl_certfile,
-        runtime_ssl_keyfile=args.ssl_keyfile,
+        runtime_ssl_ca_certfile=(
+            str(Path(args.ssl_ca_certfile).expanduser())
+            if certificates is not None
+            else None
+        ),
+        runtime_ssl_certfile=(
+            str(Path(args.ssl_certfile).expanduser())
+            if certificates is not None
+            else None
+        ),
+        runtime_ssl_keyfile=(
+            str(Path(args.ssl_keyfile).expanduser())
+            if certificates is not None
+            else None
+        ),
         runtime_dependency_install=args.runtime_dependency_install,
     )
 
@@ -774,36 +785,33 @@ def _add_args_http_api(parser: argparse.ArgumentParser) -> None:
 
 
 def _add_args_runtime_api(parser: argparse.ArgumentParser) -> None:
-    # Deprecated: Runtime API now uses the same TLS certificates as Fleet/Control APIs
     parser.add_argument(
         "--appio-ssl-certfile",
         dest="runtime_ssl_certfile",
         help=argparse.SUPPRESS,
-        type=lambda v: _deprecated_appio_ssl_flag(v, "appio-ssl-certfile"),
+        type=_unsupported_appio_ssl_flag,
     )
     parser.add_argument(
         "--appio-ssl-keyfile",
         dest="runtime_ssl_keyfile",
         help=argparse.SUPPRESS,
-        type=lambda v: _deprecated_appio_ssl_flag(v, "appio-ssl-keyfile"),
+        type=_unsupported_appio_ssl_flag,
     )
     parser.add_argument(
         "--appio-ssl-ca-certfile",
         dest="runtime_ssl_ca_certfile",
         help=argparse.SUPPRESS,
-        type=lambda v: _deprecated_appio_ssl_flag(v, "appio-ssl-ca-certfile"),
+        type=_unsupported_appio_ssl_flag,
     )
 
 
-def _deprecated_appio_ssl_flag(value: str, flag_name: str) -> str:
-    """Reject a deprecated --appio-ssl-* flag."""
-    flwr_exit(
-        ExitCode.SUPERLINK_INVALID_ARGS,
-        f"The `--{flag_name}` flag no longer exists. Control API, Fleet API, and "
+def _unsupported_appio_ssl_flag(_value: str) -> str:
+    """Reject a removed --appio-ssl-* flag."""
+    raise argparse.ArgumentTypeError(
+        "this flag no longer exists; Control API, Fleet API, and "
         "Runtime API use the same TLS certificates. Use `--ssl-certfile`, "
-        "`--ssl-keyfile`, and `--ssl-ca-certfile` instead.",
+        "`--ssl-keyfile`, and `--ssl-ca-certfile` instead."
     )
-    return value  # Never reached
 
 
 def _positive_int(value: str) -> int:

--- a/framework/py/flwr/superlink/cli/flower_superlink.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink.py
@@ -433,8 +433,6 @@ def _parse_superlink_lifespan_config() -> SuperLinkLifespanConfig:
         fleet_api_type=args.fleet_api_type,
         fleet_api_address=fleet_api_address,
         simulation=args.simulation,
-        ssl_keyfile=args.ssl_keyfile,
-        ssl_certfile=args.ssl_certfile,
         database=args.database,
         isolation=args.isolation,
         runtime_ssl_ca_certfile=(

--- a/framework/py/flwr/superlink/cli/flower_superlink.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink.py
@@ -267,7 +267,7 @@ class SuperLinkLifespan:  # pylint: disable=too-many-instance-attributes
         runtime_address = resolve_bind_address(f"{runtime_host}:{config.port}")
         command = _get_superexec_command(
             runtime_address=runtime_address,
-            runtime_certificates=config.runtime_certificates,
+            runtime_certificates=config.certificates,
             runtime_root_certificates_path=config.runtime_ssl_ca_certfile,
             parent_pid=os.getpid(),
             runtime_dependency_install=config.runtime_dependency_install,
@@ -322,7 +322,7 @@ def _parse_superlink_lifespan_config() -> SuperLinkLifespanConfig:
         health_server_address, _, _ = _format_address(args.health_server_address)
 
     # Obtain certificates
-    certificates, runtime_certificates = _obtain_superlink_certificates(args)
+    certificates = _obtain_superlink_certificates(args)
 
     # Load SuperExec auth secret
     superexec_auth_secret: bytes | None = None
@@ -427,7 +427,6 @@ def _parse_superlink_lifespan_config() -> SuperLinkLifespanConfig:
         port=args.port,
         insecure=args.insecure,
         certificates=certificates,
-        runtime_certificates=runtime_certificates,
         superexec_auth_secret=superexec_auth_secret,
         authn_plugin=authn_plugin,
         event_log_plugin=event_log_plugin,
@@ -441,17 +440,9 @@ def _parse_superlink_lifespan_config() -> SuperLinkLifespanConfig:
         ssl_certfile=args.ssl_certfile,
         database=args.database,
         isolation=args.isolation,
-        runtime_ssl_ca_certfile=args.runtime_ssl_ca_certfile,
-        runtime_ssl_certfile=(
-            str(Path(args.runtime_ssl_certfile).expanduser())
-            if runtime_certificates is not None
-            else None
-        ),
-        runtime_ssl_keyfile=(
-            str(Path(args.runtime_ssl_keyfile).expanduser())
-            if runtime_certificates is not None
-            else None
-        ),
+        runtime_ssl_ca_certfile=args.ssl_ca_certfile,
+        runtime_ssl_certfile=args.ssl_certfile,
+        runtime_ssl_keyfile=args.ssl_keyfile,
         runtime_dependency_install=args.runtime_dependency_install,
     )
 
@@ -521,8 +512,8 @@ def _run_superlink_http_api(lifespan_config: SuperLinkLifespanConfig) -> None:
 
 def _obtain_superlink_certificates(
     args: argparse.Namespace,
-) -> tuple[tuple[bytes, bytes, bytes] | None, tuple[bytes, bytes, bytes] | None]:
-    """Return Fleet/Control and Runtime API certificate tuples."""
+) -> tuple[bytes, bytes, bytes] | None:
+    """Return TLS certificate tuple used by all APIs (Fleet, Control, and Runtime)."""
     if args.insecure:
         log(
             WARN,
@@ -530,10 +521,8 @@ def _obtain_superlink_certificates(
             "unencrypted communication (TLS disabled). Proceed only if you understand "
             "the risks.",
         )
-        return None, None
-    certificates = try_obtain_server_certificates(args)
-    runtime_certificates = try_obtain_optional_runtime_server_certificates(args)
-    return certificates, runtime_certificates
+        return None
+    return try_obtain_server_certificates(args)
 
 
 def _get_superexec_command(
@@ -787,30 +776,36 @@ def _add_args_http_api(parser: argparse.ArgumentParser) -> None:
 
 
 def _add_args_runtime_api(parser: argparse.ArgumentParser) -> None:
+    # Deprecated: Runtime API now uses the same TLS certificates as Fleet/Control APIs
     parser.add_argument(
         "--appio-ssl-certfile",
         dest="runtime_ssl_certfile",
-        help="Runtime API server TLS certificate file (as a path str) "
-        "to create a secure connection. The certificate must include SANs for "
-        "the Runtime API address used by SuperExec.",
-        type=str,
-        default=None,
+        help=argparse.SUPPRESS,
+        type=lambda v: _deprecated_appio_ssl_flag(v, "appio-ssl-certfile"),
     )
     parser.add_argument(
         "--appio-ssl-keyfile",
         dest="runtime_ssl_keyfile",
-        help="Runtime API server TLS private key file (as a path str) "
-        "to create a secure connection.",
-        type=str,
+        help=argparse.SUPPRESS,
+        type=lambda v: _deprecated_appio_ssl_flag(v, "appio-ssl-keyfile"),
     )
     parser.add_argument(
         "--appio-ssl-ca-certfile",
         dest="runtime_ssl_ca_certfile",
-        help="Path to the PEM-encoded CA certificate file used by SuperExec to verify "
-        "the Runtime API server certificate. This is not a client certificate "
-        "for mTLS.",
-        type=str,
+        help=argparse.SUPPRESS,
+        type=lambda v: _deprecated_appio_ssl_flag(v, "appio-ssl-ca-certfile"),
     )
+
+
+def _deprecated_appio_ssl_flag(value: str, flag_name: str) -> str:
+    """Reject a deprecated --appio-ssl-* flag."""
+    flwr_exit(
+        ExitCode.SUPERLINK_INVALID_ARGS,
+        f"The `--{flag_name}` flag no longer exists. ControlAPI, FleetAPI and "
+        "Runtime API use the same TLS certificates. Use `--ssl-certfile`, "
+        "`--ssl-keyfile`, and `--ssl-ca-certfile` instead.",
+    )
+    return value  # Never reached
 
 
 def _positive_int(value: str) -> int:

--- a/framework/py/flwr/superlink/cli/flower_superlink.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink.py
@@ -799,7 +799,7 @@ def _deprecated_appio_ssl_flag(value: str, flag_name: str) -> str:
     """Reject a deprecated --appio-ssl-* flag."""
     flwr_exit(
         ExitCode.SUPERLINK_INVALID_ARGS,
-        f"The `--{flag_name}` flag no longer exists. ControlAPI, FleetAPI and "
+        f"The `--{flag_name}` flag no longer exists. Control API, Fleet API, and "
         "Runtime API use the same TLS certificates. Use `--ssl-certfile`, "
         "`--ssl-keyfile`, and `--ssl-ca-certfile` instead.",
     )

--- a/framework/py/flwr/superlink/cli/flower_superlink.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink.py
@@ -265,7 +265,7 @@ class SuperLinkLifespan:  # pylint: disable=too-many-instance-attributes
         command = _get_superexec_command(
             runtime_address=runtime_address,
             runtime_certificates=config.certificates,
-            runtime_root_certificates_path=config.runtime_ssl_ca_certfile,
+            runtime_root_certificates_path=config.ssl_ca_certfile,
             parent_pid=os.getpid(),
             runtime_dependency_install=config.runtime_dependency_install,
         )
@@ -433,23 +433,23 @@ def _parse_superlink_lifespan_config() -> SuperLinkLifespanConfig:
         fleet_api_type=args.fleet_api_type,
         fleet_api_address=fleet_api_address,
         simulation=args.simulation,
-        database=args.database,
-        isolation=args.isolation,
-        runtime_ssl_ca_certfile=(
+        ssl_ca_certfile=(
             str(Path(args.ssl_ca_certfile).expanduser())
             if certificates is not None
             else None
         ),
-        runtime_ssl_certfile=(
+        ssl_certfile=(
             str(Path(args.ssl_certfile).expanduser())
             if certificates is not None
             else None
         ),
-        runtime_ssl_keyfile=(
+        ssl_keyfile=(
             str(Path(args.ssl_keyfile).expanduser())
             if certificates is not None
             else None
         ),
+        database=args.database,
+        isolation=args.isolation,
         runtime_dependency_install=args.runtime_dependency_install,
     )
 
@@ -511,8 +511,8 @@ def _run_superlink_http_api(lifespan_config: SuperLinkLifespanConfig) -> None:
         reload=False,
         access_log=True,
         log_config=get_uvicorn_log_config(console_handler.level),
-        ssl_keyfile=lifespan_config.runtime_ssl_keyfile,
-        ssl_certfile=lifespan_config.runtime_ssl_certfile,
+        ssl_keyfile=lifespan_config.ssl_keyfile,
+        ssl_certfile=lifespan_config.ssl_certfile,
         workers=1,
     )
 

--- a/framework/py/flwr/superlink/cli/flower_superlink_test.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink_test.py
@@ -202,21 +202,6 @@ def test_parse_superlink_log_rotation_args_custom_values() -> None:
 
 
 @pytest.mark.parametrize(
-    "flag",
-    ["--appio-ssl-certfile", "--appio-ssl-keyfile", "--appio-ssl-ca-certfile"],
-)
-def test_parse_superlink_appio_tls_args_rejected(
-    flag: str, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """SuperLink should explain how to replace removed AppIO TLS args."""
-    with pytest.raises(SystemExit) as exc_info:
-        _parse_args_run_superlink().parse_args([flag, "certificate.pem"])
-
-    assert exc_info.value.code == 2
-    assert f"argument {flag}: this flag no longer exists" in capsys.readouterr().err
-
-
-@pytest.mark.parametrize(
     ("env_value", "cli_args", "expected"),
     [
         ("1", [], False),

--- a/framework/py/flwr/superlink/cli/flower_superlink_test.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink_test.py
@@ -17,6 +17,7 @@
 
 import argparse
 import importlib
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -123,6 +124,63 @@ def test_parse_superlink_lifespan_config_keeps_fleet_address_unset_for_simulatio
     assert config.fleet_api_address is None
 
 
+def test_parse_superlink_lifespan_config_disables_all_tls_when_insecure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The insecure flag should also disable Runtime API TLS."""
+    monkeypatch.setattr(
+        app_module.sys,
+        "argv",
+        [
+            "flower-superlink",
+            "--insecure",
+            "--ssl-ca-certfile",
+            "~/ca.pem",
+            "--ssl-certfile",
+            "~/cert.pem",
+            "--ssl-keyfile",
+            "~/key.pem",
+        ],
+    )
+
+    config = _parse_superlink_lifespan_config()
+
+    assert config.certificates is None
+    assert config.runtime_ssl_ca_certfile is None
+    assert config.runtime_ssl_certfile is None
+    assert config.runtime_ssl_keyfile is None
+
+
+def test_parse_superlink_lifespan_config_expands_runtime_tls_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtime API TLS paths should support the home-directory shorthand."""
+    monkeypatch.setattr(
+        app_module.sys,
+        "argv",
+        [
+            "flower-superlink",
+            "--ssl-ca-certfile",
+            "~/ca.pem",
+            "--ssl-certfile",
+            "~/cert.pem",
+            "--ssl-keyfile",
+            "~/key.pem",
+        ],
+    )
+    monkeypatch.setattr(
+        app_module,
+        "_obtain_superlink_certificates",
+        lambda _args: (b"ca", b"cert", b"key"),
+    )
+
+    config = _parse_superlink_lifespan_config()
+
+    assert config.runtime_ssl_ca_certfile == str(Path("~/ca.pem").expanduser())
+    assert config.runtime_ssl_certfile == str(Path("~/cert.pem").expanduser())
+    assert config.runtime_ssl_keyfile == str(Path("~/key.pem").expanduser())
+
+
 def test_parse_superlink_log_rotation_args_custom_values() -> None:
     """SuperLink log rotation args should parse explicit values."""
     # Execute
@@ -143,23 +201,19 @@ def test_parse_superlink_log_rotation_args_custom_values() -> None:
     assert args.log_rotation_backup_count == 14
 
 
-def test_parse_superlink_appio_tls_args_rejected() -> None:
-    """SuperLink should reject deprecated AppIO-named TLS args."""
-    # Test that --appio-ssl-certfile is rejected
-    with pytest.raises(SystemExit):
-        _parse_args_run_superlink().parse_args(
-            ["--appio-ssl-certfile", "appio-cert.pem"]
-        )
+@pytest.mark.parametrize(
+    "flag",
+    ["--appio-ssl-certfile", "--appio-ssl-keyfile", "--appio-ssl-ca-certfile"],
+)
+def test_parse_superlink_appio_tls_args_rejected(
+    flag: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """SuperLink should explain how to replace removed AppIO TLS args."""
+    with pytest.raises(SystemExit) as exc_info:
+        _parse_args_run_superlink().parse_args([flag, "certificate.pem"])
 
-    # Test that --appio-ssl-keyfile is rejected
-    with pytest.raises(SystemExit):
-        _parse_args_run_superlink().parse_args(["--appio-ssl-keyfile", "appio-key.pem"])
-
-    # Test that --appio-ssl-ca-certfile is rejected
-    with pytest.raises(SystemExit):
-        _parse_args_run_superlink().parse_args(
-            ["--appio-ssl-ca-certfile", "appio-ca.pem"]
-        )
+    assert exc_info.value.code == 2
+    assert f"argument {flag}: this flag no longer exists" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(

--- a/framework/py/flwr/superlink/cli/flower_superlink_test.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink_test.py
@@ -99,7 +99,6 @@ def test_parse_superlink_lifespan_config_returns_final_defaults(
     assert config.fleet_api_address == app_module.FLEET_API_GRPC_RERE_DEFAULT_ADDRESS
     assert config.health_server_address is None
     assert config.certificates is None
-    assert config.runtime_certificates is None
     assert config.superexec_auth_secret is None
     assert config.host == app_module.UVICORN_DEFAULT_HOST
     assert config.port == app_module.SUPERLINK_UVICORN_DEFAULT_PORT
@@ -144,22 +143,25 @@ def test_parse_superlink_log_rotation_args_custom_values() -> None:
     assert args.log_rotation_backup_count == 14
 
 
-def test_parse_superlink_appio_tls_args() -> None:
-    """SuperLink should parse AppIO-named TLS args for its Runtime API."""
-    args = _parse_args_run_superlink().parse_args(
-        [
-            "--appio-ssl-certfile",
-            "appio-cert.pem",
-            "--appio-ssl-keyfile",
-            "appio-key.pem",
-            "--appio-ssl-ca-certfile",
-            "appio-ca.pem",
-        ]
-    )
-
-    assert args.runtime_ssl_certfile == "appio-cert.pem"
-    assert args.runtime_ssl_keyfile == "appio-key.pem"
-    assert args.runtime_ssl_ca_certfile == "appio-ca.pem"
+def test_parse_superlink_appio_tls_args_rejected() -> None:
+    """SuperLink should reject deprecated AppIO-named TLS args."""
+    # Test that --appio-ssl-certfile is rejected
+    with pytest.raises(SystemExit):
+        _parse_args_run_superlink().parse_args(
+            ["--appio-ssl-certfile", "appio-cert.pem"]
+        )
+    
+    # Test that --appio-ssl-keyfile is rejected
+    with pytest.raises(SystemExit):
+        _parse_args_run_superlink().parse_args(
+            ["--appio-ssl-keyfile", "appio-key.pem"]
+        )
+    
+    # Test that --appio-ssl-ca-certfile is rejected
+    with pytest.raises(SystemExit):
+        _parse_args_run_superlink().parse_args(
+            ["--appio-ssl-ca-certfile", "appio-ca.pem"]
+        )
 
 
 @pytest.mark.parametrize(
@@ -265,72 +267,49 @@ def test_flower_superlink_runs_runtime_http_api(
     run_http.assert_called_once_with(lifespan_config=config)
 
 
-def test_obtain_superlink_certificates_keeps_runtime_separate(
+def test_obtain_superlink_certificates_uses_single_triplet(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """SuperLink should load separate certificate tuples for Fleet and Runtime."""
-    fleet_certificates = (b"fleet-ca", b"fleet-cert", b"fleet-key")
-    runtime_certificates = (b"appio-ca", b"appio-cert", b"appio-key")
+    """SuperLink should use a single certificate triplet for all APIs."""
+    certificates = (b"ca", b"cert", b"key")
     monkeypatch.setattr(
-        app_module, "try_obtain_server_certificates", lambda _args: fleet_certificates
-    )
-    monkeypatch.setattr(
-        app_module,
-        "try_obtain_optional_runtime_server_certificates",
-        lambda _args: runtime_certificates,
+        app_module, "try_obtain_server_certificates", lambda _args: certificates
     )
     args = argparse.Namespace(insecure=False)
 
-    certificates, runtime_certificates_result = _obtain_superlink_certificates(args)
+    result = _obtain_superlink_certificates(args)
 
-    assert certificates == fleet_certificates
-    assert runtime_certificates_result == runtime_certificates
+    assert result == certificates
 
 
-def test_obtain_superlink_certificates_allows_plaintext_runtime_when_secure(
+def test_obtain_superlink_certificates_returns_certificates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """SuperLink should allow plaintext Runtime with secure Fleet/Control APIs."""
+    """SuperLink returns certificates when TLS is enabled."""
     fleet_certificates = (b"fleet-ca", b"fleet-cert", b"fleet-key")
     monkeypatch.setattr(
         app_module, "try_obtain_server_certificates", lambda _args: fleet_certificates
     )
-    monkeypatch.setattr(
-        app_module,
-        "try_obtain_optional_runtime_server_certificates",
-        lambda _args: None,
-    )
     args = argparse.Namespace(insecure=False)
 
-    certificates, runtime_certificates = _obtain_superlink_certificates(args)
+    result = _obtain_superlink_certificates(args)
 
-    assert certificates == fleet_certificates
-    assert runtime_certificates is None
-
+    assert result == fleet_certificates
 
 def test_obtain_superlink_certificates_skips_cert_loading_when_insecure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """SuperLink should not load any TLS certificates when insecure."""
     obtain_server_certificates_mock = Mock()
-    obtain_runtime_certificates_mock = Mock()
     monkeypatch.setattr(
         app_module, "try_obtain_server_certificates", obtain_server_certificates_mock
     )
-    monkeypatch.setattr(
-        app_module,
-        "try_obtain_optional_runtime_server_certificates",
-        obtain_runtime_certificates_mock,
-    )
     args = argparse.Namespace(insecure=True)
 
-    certificates, runtime_certificates = _obtain_superlink_certificates(args)
+    result = _obtain_superlink_certificates(args)
 
-    assert certificates is None
-    assert runtime_certificates is None
     obtain_server_certificates_mock.assert_not_called()
-    obtain_runtime_certificates_mock.assert_not_called()
-
+    assert result is None
 
 def test_run_fleet_api_grpc_rere_orders_default_interceptors(
     monkeypatch: pytest.MonkeyPatch,

--- a/framework/py/flwr/superlink/cli/flower_superlink_test.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink_test.py
@@ -146,15 +146,15 @@ def test_parse_superlink_lifespan_config_disables_all_tls_when_insecure(
     config = _parse_superlink_lifespan_config()
 
     assert config.certificates is None
-    assert config.runtime_ssl_ca_certfile is None
-    assert config.runtime_ssl_certfile is None
-    assert config.runtime_ssl_keyfile is None
+    assert config.ssl_ca_certfile is None
+    assert config.ssl_certfile is None
+    assert config.ssl_keyfile is None
 
 
-def test_parse_superlink_lifespan_config_expands_runtime_tls_paths(
+def test_parse_superlink_lifespan_config_expands_tls_paths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Runtime API TLS paths should support the home-directory shorthand."""
+    """TLS paths should support the home-directory shorthand."""
     monkeypatch.setattr(
         app_module.sys,
         "argv",
@@ -176,9 +176,9 @@ def test_parse_superlink_lifespan_config_expands_runtime_tls_paths(
 
     config = _parse_superlink_lifespan_config()
 
-    assert config.runtime_ssl_ca_certfile == str(Path("~/ca.pem").expanduser())
-    assert config.runtime_ssl_certfile == str(Path("~/cert.pem").expanduser())
-    assert config.runtime_ssl_keyfile == str(Path("~/key.pem").expanduser())
+    assert config.ssl_ca_certfile == str(Path("~/ca.pem").expanduser())
+    assert config.ssl_certfile == str(Path("~/cert.pem").expanduser())
+    assert config.ssl_keyfile == str(Path("~/key.pem").expanduser())
 
 
 def test_parse_superlink_log_rotation_args_custom_values() -> None:

--- a/framework/py/flwr/superlink/cli/flower_superlink_test.py
+++ b/framework/py/flwr/superlink/cli/flower_superlink_test.py
@@ -150,13 +150,11 @@ def test_parse_superlink_appio_tls_args_rejected() -> None:
         _parse_args_run_superlink().parse_args(
             ["--appio-ssl-certfile", "appio-cert.pem"]
         )
-    
+
     # Test that --appio-ssl-keyfile is rejected
     with pytest.raises(SystemExit):
-        _parse_args_run_superlink().parse_args(
-            ["--appio-ssl-keyfile", "appio-key.pem"]
-        )
-    
+        _parse_args_run_superlink().parse_args(["--appio-ssl-keyfile", "appio-key.pem"])
+
     # Test that --appio-ssl-ca-certfile is rejected
     with pytest.raises(SystemExit):
         _parse_args_run_superlink().parse_args(
@@ -296,6 +294,7 @@ def test_obtain_superlink_certificates_returns_certificates(
 
     assert result == fleet_certificates
 
+
 def test_obtain_superlink_certificates_skips_cert_loading_when_insecure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -310,6 +309,7 @@ def test_obtain_superlink_certificates_skips_cert_loading_when_insecure(
 
     obtain_server_certificates_mock.assert_not_called()
     assert result is None
+
 
 def test_run_fleet_api_grpc_rere_orders_default_interceptors(
     monkeypatch: pytest.MonkeyPatch,

--- a/framework/py/flwr/superlink/config_loader.py
+++ b/framework/py/flwr/superlink/config_loader.py
@@ -77,8 +77,6 @@ class SuperLinkLifespanConfig:  # pylint: disable=too-many-instance-attributes
     fleet_api_type: str
     fleet_api_address: str | None
     simulation: bool
-    ssl_keyfile: str | None
-    ssl_certfile: str | None
     database: str
     isolation: str
     runtime_ssl_ca_certfile: str | None

--- a/framework/py/flwr/superlink/config_loader.py
+++ b/framework/py/flwr/superlink/config_loader.py
@@ -68,7 +68,6 @@ class SuperLinkLifespanConfig:  # pylint: disable=too-many-instance-attributes
     port: int
     insecure: bool
     certificates: tuple[bytes, bytes, bytes] | None
-    runtime_certificates: tuple[bytes, bytes, bytes] | None
     superexec_auth_secret: bytes | None
     authn_plugin: ControlAuthnPlugin
     event_log_plugin: EventLogWriterPlugin | None

--- a/framework/py/flwr/superlink/config_loader.py
+++ b/framework/py/flwr/superlink/config_loader.py
@@ -77,11 +77,11 @@ class SuperLinkLifespanConfig:  # pylint: disable=too-many-instance-attributes
     fleet_api_type: str
     fleet_api_address: str | None
     simulation: bool
+    ssl_ca_certfile: str | None
+    ssl_certfile: str | None
+    ssl_keyfile: str | None
     database: str
     isolation: str
-    runtime_ssl_ca_certfile: str | None
-    runtime_ssl_certfile: str | None
-    runtime_ssl_keyfile: str | None
     runtime_dependency_install: bool
 
 


### PR DESCRIPTION
This PR makes ``--appio-ssl-certfile``, ``--appio-ssl-keyfile``, and ``--appio-ssl-ca-certfile`` obsolete and launching a `SuperLink` with them will terminate it immediately. 