### PR TITLE
refactor(framework): Handle Type Runtime API dependency

### DIFF
--- a/framework/py/flwr/supercore/dependencies/runtime.py
+++ b/framework/py/flwr/supercore/dependencies/runtime.py
@@ -14,11 +14,38 @@
 # ==============================================================================
 """FastAPI dependencies for the shared Runtime API."""
 
-from types import ModuleType
-from typing import Annotated, Protocol, cast
+from typing import Annotated, Any, Protocol, TypeVar, cast
 
 from fastapi import Depends, Request, Security
 
+from flwr.proto.control_pb2 import (  # pylint: disable=E0611
+    StartAutomationRequest,
+    StartAutomationResponse,
+)
+from flwr.proto.message_pb2 import (  # pylint: disable=E0611
+    ConfirmMessageReceivedRequest,
+    ConfirmMessageReceivedResponse,
+    PullObjectRequest,
+    PullObjectResponse,
+    PushObjectRequest,
+    PushObjectResponse,
+)
+from flwr.proto.runtime_pb2 import (  # pylint: disable=E0611
+    GetConnectorRequest,
+    GetConnectorResponse,
+    GetNodesRequest,
+    GetNodesResponse,
+    PullAppMessagesRequest,
+    PullAppMessagesResponse,
+    PullPendingTasksRequest,
+    PullPendingTasksResponse,
+    PullTaskInputRequest,
+    PullTaskInputResponse,
+    PushAppMessagesRequest,
+    PushAppMessagesResponse,
+    PushTaskOutputRequest,
+    PushTaskOutputResponse,
+)
 from flwr.proto.task_pb2 import Task  # pylint: disable=E0611
 from flwr.supercore.corestate import CoreState
 from flwr.supercore.error import ApiErrorCode, FlowerError
@@ -32,6 +59,68 @@ class RuntimeStateFactory(Protocol):
 
     def state(self) -> CoreState:
         """Return the Runtime state."""
+
+
+StateT = TypeVar("StateT", bound=CoreState, contravariant=True)
+
+
+class RuntimeHandlers(Protocol[StateT]):
+    """Component-specific handlers used by the shared Runtime API router."""
+
+    def pull_pending_tasks(
+        self, request: PullPendingTasksRequest, state: StateT
+    ) -> PullPendingTasksResponse:
+        """Pull pending tasks."""
+
+    def pull_task_input(
+        self, request: PullTaskInputRequest, state: StateT, task: Task
+    ) -> PullTaskInputResponse:
+        """Pull task input."""
+
+    def push_task_output(
+        self, request: PushTaskOutputRequest, state: StateT, task: Task
+    ) -> PushTaskOutputResponse:
+        """Push task output."""
+
+    def push_object(
+        self, request: PushObjectRequest, state: StateT, task: Task
+    ) -> PushObjectResponse:
+        """Push an object."""
+
+    def pull_object(
+        self, request: PullObjectRequest, state: StateT, task: Task
+    ) -> PullObjectResponse:
+        """Pull an object."""
+
+    def confirm_message_received(
+        self, request: ConfirmMessageReceivedRequest, state: StateT, task: Task
+    ) -> ConfirmMessageReceivedResponse:
+        """Confirm message receipt."""
+
+    def start_automation(
+        self, request: StartAutomationRequest, state: StateT, task: Task
+    ) -> StartAutomationResponse:
+        """Start an automation."""
+
+    def get_connector(
+        self, request: GetConnectorRequest, state: StateT, task: Task
+    ) -> GetConnectorResponse:
+        """Get connector credentials."""
+
+    def push_messages(
+        self, request: PushAppMessagesRequest, state: StateT, task: Task
+    ) -> PushAppMessagesResponse:
+        """Push app messages."""
+
+    def pull_messages(
+        self, request: PullAppMessagesRequest, state: StateT, task: Task
+    ) -> PullAppMessagesResponse:
+        """Pull app messages."""
+
+    def get_nodes(
+        self, request: GetNodesRequest, state: StateT, task: Task
+    ) -> GetNodesResponse:
+        """Get available nodes."""
 
 
 def get_runtime_state(request: Request) -> CoreState:
@@ -49,10 +138,10 @@ def get_runtime_state(request: Request) -> CoreState:
     return factory.state()
 
 
-def get_runtime_handlers(request: Request) -> ModuleType:
+def get_runtime_handlers(request: Request) -> RuntimeHandlers[Any]:
     """Return the handlers configured for the Runtime API."""
     handlers = cast(
-        ModuleType | None,
+        RuntimeHandlers[Any] | None,
         getattr(request.app.state, "runtime_handlers", None),
     )
     if handlers is None:
@@ -61,7 +150,9 @@ def get_runtime_handlers(request: Request) -> ModuleType:
 
 
 RuntimeStateDependency = Annotated[CoreState, Depends(get_runtime_state)]
-RuntimeHandlersDependency = Annotated[ModuleType, Depends(get_runtime_handlers)]
+RuntimeHandlersDependency = Annotated[
+    RuntimeHandlers[Any], Depends(get_runtime_handlers)
+]
 
 
 def get_task(

--- a/framework/py/flwr/supercore/dependencies/runtime.py
+++ b/framework/py/flwr/supercore/dependencies/runtime.py
@@ -61,64 +61,67 @@ class RuntimeStateFactory(Protocol):
         """Return the Runtime state."""
 
 
-StateT = TypeVar("StateT", bound=CoreState, contravariant=True)
+StateT_contra = TypeVar("StateT_contra", bound=CoreState, contravariant=True)
 
 
-class RuntimeHandlers(Protocol[StateT]):
+class RuntimeHandlers(Protocol[StateT_contra]):
     """Component-specific handlers used by the shared Runtime API router."""
 
     def pull_pending_tasks(
-        self, request: PullPendingTasksRequest, state: StateT
+        self, request: PullPendingTasksRequest, state: StateT_contra
     ) -> PullPendingTasksResponse:
         """Pull pending tasks."""
 
     def pull_task_input(
-        self, request: PullTaskInputRequest, state: StateT, task: Task
+        self, request: PullTaskInputRequest, state: StateT_contra, task: Task
     ) -> PullTaskInputResponse:
         """Pull task input."""
 
     def push_task_output(
-        self, request: PushTaskOutputRequest, state: StateT, task: Task
+        self, request: PushTaskOutputRequest, state: StateT_contra, task: Task
     ) -> PushTaskOutputResponse:
         """Push task output."""
 
     def push_object(
-        self, request: PushObjectRequest, state: StateT, task: Task
+        self, request: PushObjectRequest, state: StateT_contra, task: Task
     ) -> PushObjectResponse:
         """Push an object."""
 
     def pull_object(
-        self, request: PullObjectRequest, state: StateT, task: Task
+        self, request: PullObjectRequest, state: StateT_contra, task: Task
     ) -> PullObjectResponse:
         """Pull an object."""
 
     def confirm_message_received(
-        self, request: ConfirmMessageReceivedRequest, state: StateT, task: Task
+        self,
+        request: ConfirmMessageReceivedRequest,
+        state: StateT_contra,
+        task: Task,
     ) -> ConfirmMessageReceivedResponse:
         """Confirm message receipt."""
 
     def start_automation(
-        self, request: StartAutomationRequest, state: StateT, task: Task
+        self, request: StartAutomationRequest, state: StateT_contra, task: Task
     ) -> StartAutomationResponse:
         """Start an automation."""
 
     def get_connector(
-        self, request: GetConnectorRequest, state: StateT, task: Task
+        self, request: GetConnectorRequest, state: StateT_contra, task: Task
     ) -> GetConnectorResponse:
         """Get connector credentials."""
 
     def push_messages(
-        self, request: PushAppMessagesRequest, state: StateT, task: Task
+        self, request: PushAppMessagesRequest, state: StateT_contra, task: Task
     ) -> PushAppMessagesResponse:
         """Push app messages."""
 
     def pull_messages(
-        self, request: PullAppMessagesRequest, state: StateT, task: Task
+        self, request: PullAppMessagesRequest, state: StateT_contra, task: Task
     ) -> PullAppMessagesResponse:
         """Pull app messages."""
 
     def get_nodes(
-        self, request: GetNodesRequest, state: StateT, task: Task
+        self, request: GetNodesRequest, state: StateT_contra, task: Task
     ) -> GetNodesResponse:
         """Get available nodes."""
 

--- a/framework/py/flwr/supercore/routers/runtime/router.py
+++ b/framework/py/flwr/supercore/routers/runtime/router.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Shared Runtime API router."""
 
-from typing import Annotated, cast
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
 
@@ -98,7 +98,7 @@ def pull_pending_tasks(
     _auth: PullPendingTasksAuthDependency,
 ) -> PullPendingTasksResponse:
     """Pull pending tasks."""
-    return cast(PullPendingTasksResponse, handlers.pull_pending_tasks(request, state))
+    return handlers.pull_pending_tasks(request, state)
 
 
 @router.post("/claim-task")
@@ -129,7 +129,7 @@ def pull_task_input(
     task: TaskDependency,
 ) -> PullTaskInputResponse:
     """Pull app process inputs."""
-    return cast(PullTaskInputResponse, handlers.pull_task_input(request, state, task))
+    return handlers.pull_task_input(request, state, task)
 
 
 @router.post("/push-task-output")
@@ -140,7 +140,7 @@ def push_task_output(
     task: TaskDependency,
 ) -> PushTaskOutputResponse:
     """Push app process outputs."""
-    return cast(PushTaskOutputResponse, handlers.push_task_output(request, state, task))
+    return handlers.push_task_output(request, state, task)
 
 
 @router.post("/push-object")
@@ -151,7 +151,7 @@ def push_object(
     task: TaskDependency,
 ) -> PushObjectResponse:
     """Push an object to the ObjectStore."""
-    return cast(PushObjectResponse, handlers.push_object(request, state, task))
+    return handlers.push_object(request, state, task)
 
 
 @router.post("/pull-object")
@@ -162,7 +162,7 @@ def pull_object(
     task: TaskDependency,
 ) -> PullObjectResponse:
     """Pull an object from the ObjectStore."""
-    return cast(PullObjectResponse, handlers.pull_object(request, state, task))
+    return handlers.pull_object(request, state, task)
 
 
 @router.post("/confirm-message-received")
@@ -173,10 +173,7 @@ def confirm_message_received(
     task: TaskDependency,
 ) -> ConfirmMessageReceivedResponse:
     """Confirm message receipt."""
-    return cast(
-        ConfirmMessageReceivedResponse,
-        handlers.confirm_message_received(request, state, task),
-    )
+    return handlers.confirm_message_received(request, state, task)
 
 
 @router.post("/create-task")
@@ -197,9 +194,7 @@ def runtime_start_automation(
     task: TaskDependency,
 ) -> StartAutomationResponse:
     """Start an automation from a Runtime task."""
-    return cast(
-        StartAutomationResponse, handlers.start_automation(request, state, task)
-    )
+    return handlers.start_automation(request, state, task)
 
 
 @router.post("/push-task-message")
@@ -250,7 +245,7 @@ def get_connector(
     task: TaskDependency,
 ) -> GetConnectorResponse:
     """Get connector credentials."""
-    return cast(GetConnectorResponse, handlers.get_connector(request, state, task))
+    return handlers.get_connector(request, state, task)
 
 
 @router.post("/push-logs")
@@ -271,7 +266,7 @@ def push_messages(
     task: TaskDependency,
 ) -> PushAppMessagesResponse:
     """Push app messages."""
-    return cast(PushAppMessagesResponse, handlers.push_messages(request, state, task))
+    return handlers.push_messages(request, state, task)
 
 
 @router.post("/pull-messages")
@@ -282,7 +277,7 @@ def pull_messages(
     task: TaskDependency,
 ) -> PullAppMessagesResponse:
     """Pull app messages."""
-    return cast(PullAppMessagesResponse, handlers.pull_messages(request, state, task))
+    return handlers.pull_messages(request, state, task)
 
 
 @router.post("/get-nodes")
@@ -293,4 +288,4 @@ def get_nodes(
     task: TaskDependency,
 ) -> GetNodesResponse:
     """Get available nodes."""
-    return cast(GetNodesResponse, handlers.get_nodes(request, state, task))
+    return handlers.get_nodes(request, state, task)

--- a/framework/py/flwr/superlink/main.py
+++ b/framework/py/flwr/superlink/main.py
@@ -31,6 +31,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from flwr.common.constant import TRANSPORT_TYPE_GRPC_RERE
 from flwr.supercore import log
 from flwr.supercore.constant import FLWR_IN_MEMORY_DB_NAME
+from flwr.supercore.dependencies.runtime import RuntimeHandlers
 from flwr.supercore.dependencies.runtime_version import RuntimeVersionDependency
 from flwr.supercore.error import ApiErrorCode, http_error_translator
 from flwr.supercore.http_logging import configure_uvicorn_logging
@@ -69,8 +70,10 @@ except ModuleNotFoundError as exc:
 
 
 if TYPE_CHECKING:
+    from flwr.server.superlink.linkstate import LinkState
     from flwr.superlink.cli.flower_superlink import SuperLinkLifespan
 
+_RUNTIME_HANDLERS: RuntimeHandlers[LinkState] = runtime_handlers
 _RUNTIME_VERSION_DEPENDENCY = Depends(
     RuntimeVersionDependency(
         component_name="SuperLink",
@@ -196,7 +199,7 @@ def create_app(  # pylint: disable=too-many-statements
         ApiErrorCode.LINKSTATE_NOT_INITIALIZED,
         "SuperLink LinkStateFactory is not initialized.",
     )
-    fastapi_app.state.runtime_handlers = runtime_handlers
+    fastapi_app.state.runtime_handlers = _RUNTIME_HANDLERS
     fastapi_app.state.superexec_auth_secret = superexec_auth_secret
     fastapi_app.state.artifact_provider = artifact_provider
     fastapi_app.state.fleet_api_type = fleet_api_type

--- a/framework/py/flwr/supernode/main.py
+++ b/framework/py/flwr/supernode/main.py
@@ -25,14 +25,16 @@ from fastapi import Depends, FastAPI
 
 from flwr import __version__
 from flwr.supercore import log
+from flwr.supercore.dependencies.runtime import RuntimeHandlers
 from flwr.supercore.dependencies.runtime_version import RuntimeVersionDependency
 from flwr.supercore.error import ApiErrorCode, http_error_translator
 from flwr.supercore.protobuf.translation import ProtobufTranslationMiddleware
 from flwr.supercore.routers import health
 from flwr.supercore.routers.runtime import router as runtime_router
-from flwr.supernode.nodestate import NodeStateFactory
+from flwr.supernode.nodestate import NodeState, NodeStateFactory
 from flwr.supernode.servicer.runtime import runtime_handlers
 
+_RUNTIME_HANDLERS: RuntimeHandlers[NodeState] = runtime_handlers
 _RUNTIME_VERSION_DEPENDENCY = Depends(
     RuntimeVersionDependency(
         component_name="SuperNode",
@@ -65,7 +67,7 @@ def create_app(
         ApiErrorCode.NODESTATE_NOT_INITIALIZED,
         "SuperNode NodeStateFactory is not initialized.",
     )
-    fastapi_app.state.runtime_handlers = runtime_handlers
+    fastapi_app.state.runtime_handlers = _RUNTIME_HANDLERS
     fastapi_app.state.superexec_auth_secret = superexec_auth_secret
 
     # Core APIs


### PR DESCRIPTION
Add a shared `RuntimeHandlers` protocol so `mypy` validates the SuperLink and SuperNode handler implementations. Remove the casts previously required in the shared Runtime API router.