### PR TITLE
fix(framework): Include exception details in LoadClientAppError reason

### DIFF
--- a/framework/py/flwr/clientapp/client_app.py
+++ b/framework/py/flwr/clientapp/client_app.py
@@ -397,6 +397,13 @@ class LoadClientAppError(Exception):
     """Error when trying to load `ClientApp`."""
 
 
+def format_load_client_app_error_reason(ex: LoadClientAppError) -> str:
+    """Format the error reason string for a LoadClientAppError."""
+    prefix = "An exception was raised when attempting to load `ClientApp`"
+    exc_msg = str(ex)
+    return f"{prefix}: {exc_msg}" if exc_msg else prefix
+
+
 def _get_decorator(
     app: ClientApp, category: str, action: str, mods: list[Mod] | None
 ) -> Callable[[ClientAppCallable], ClientAppCallable]:

--- a/framework/py/flwr/clientapp/client_app_test.py
+++ b/framework/py/flwr/clientapp/client_app_test.py
@@ -23,7 +23,11 @@ import pytest
 
 from flwr.app.message import Context, Message
 
-from .client_app import ClientApp
+from .client_app import (
+    ClientApp,
+    LoadClientAppError,
+    format_load_client_app_error_reason,
+)
 from .typing import ClientAppCallable
 
 
@@ -259,3 +263,17 @@ def test_register_repeated_func(category: str, action: str | None) -> None:
         @decorator(*args)  # type: ignore
         def func2(_msg: Message, _cxt: Context) -> Message:
             raise AssertionError("This function should not be called")
+
+
+def test_format_load_client_app_error_reason() -> None:
+    """Test formatting of LoadClientAppError reason."""
+    err_with_msg = LoadClientAppError("ModuleNotFoundError: foo")
+    assert format_load_client_app_error_reason(err_with_msg) == (
+        "An exception was raised when attempting to load `ClientApp`: "
+        "ModuleNotFoundError: foo"
+    )
+
+    err_empty = LoadClientAppError("")
+    assert format_load_client_app_error_reason(err_empty) == (
+        "An exception was raised when attempting to load `ClientApp`"
+    )

--- a/framework/py/flwr/compat/client/app.py
+++ b/framework/py/flwr/compat/client/app.py
@@ -475,10 +475,11 @@ def start_client_internal(
                         reason = str(type(ex)) + ":<'" + str(ex) + "'>"
                         exc_entity = "ClientApp"
                         if isinstance(ex, LoadClientAppError):
-                            reason = (
+                            prefix = (
                                 "An exception was raised when attempting to load "
                                 "`ClientApp`"
                             )
+                            reason = f"{prefix}: {ex}" if str(ex) else prefix
                             e_code = ErrorCode.LOAD_CLIENT_APP_EXCEPTION
                             exc_entity = "SuperNode"
 

--- a/framework/py/flwr/compat/client/app.py
+++ b/framework/py/flwr/compat/client/app.py
@@ -29,7 +29,11 @@ from flwr.app.user_config import UserConfig
 from flwr.cli.config_utils import get_fab_metadata
 from flwr.cli.install import install_from_fab
 from flwr.client.message_handler.message_handler import handle_control_message
-from flwr.clientapp.client_app import ClientApp, LoadClientAppError
+from flwr.clientapp.client_app import (
+    ClientApp,
+    LoadClientAppError,
+    format_load_client_app_error_reason,
+)
 from flwr.common.constant import MAX_RETRY_DELAY, ErrorCode
 from flwr.compat.client.client import Client
 from flwr.compat.client.grpc_client.connection import grpc_connection
@@ -475,11 +479,7 @@ def start_client_internal(
                         reason = str(type(ex)) + ":<'" + str(ex) + "'>"
                         exc_entity = "ClientApp"
                         if isinstance(ex, LoadClientAppError):
-                            prefix = (
-                                "An exception was raised when attempting to load "
-                                "`ClientApp`"
-                            )
-                            reason = f"{prefix}: {ex}" if str(ex) else prefix
+                            reason = format_load_client_app_error_reason(ex)
                             e_code = ErrorCode.LOAD_CLIENT_APP_EXCEPTION
                             exc_entity = "SuperNode"
 

--- a/framework/py/flwr/supernode/runtime/run_clientapp.py
+++ b/framework/py/flwr/supernode/runtime/run_clientapp.py
@@ -198,7 +198,8 @@ def run_clientapp(  # pylint: disable=R0913, R0914, R0915, R0917
         reason = str(type(ex)) + ":<'" + str(ex) + "'>"
         exc_entity = "ClientApp"
         if isinstance(ex, LoadClientAppError):
-            reason = "An exception was raised when attempting to load `ClientApp`"
+            prefix = "An exception was raised when attempting to load `ClientApp`"
+            reason = f"{prefix}: {ex}" if str(ex) else prefix
             e_code = ErrorCode.LOAD_CLIENT_APP_EXCEPTION
 
         log(ERROR, "%s raised an exception", exc_entity, exc_info=ex)

--- a/framework/py/flwr/supernode/runtime/run_clientapp.py
+++ b/framework/py/flwr/supernode/runtime/run_clientapp.py
@@ -23,7 +23,11 @@ from flwr.app import Context, Message
 from flwr.app.error import Error
 from flwr.app.message import remove_content_from_message
 from flwr.cli.install import install_from_fab
-from flwr.clientapp.client_app import ClientApp, LoadClientAppError
+from flwr.clientapp.client_app import (
+    ClientApp,
+    LoadClientAppError,
+    format_load_client_app_error_reason,
+)
 from flwr.clientapp.utils import get_load_client_app_fn
 from flwr.common.config import get_project_dir
 from flwr.common.constant import RUNTIME_DEPENDENCY_INSTALL, ErrorCode, SubStatus
@@ -198,8 +202,7 @@ def run_clientapp(  # pylint: disable=R0913, R0914, R0915, R0917
         reason = str(type(ex)) + ":<'" + str(ex) + "'>"
         exc_entity = "ClientApp"
         if isinstance(ex, LoadClientAppError):
-            prefix = "An exception was raised when attempting to load `ClientApp`"
-            reason = f"{prefix}: {ex}" if str(ex) else prefix
+            reason = format_load_client_app_error_reason(ex)
             e_code = ErrorCode.LOAD_CLIENT_APP_EXCEPTION
 
         log(ERROR, "%s raised an exception", exc_entity, exc_info=ex)


### PR DESCRIPTION
## Issue

### Description

When loading `ClientApp` fails with `LoadClientAppError`, the failure `reason` string in the SuperNode was hardcoded and swallowed the underlying exception details.

**Before:**
```text
An exception was raised when attempting to load `ClientApp`
```
Root cause (e.g. `ModuleNotFoundError`, `ImportError`, invalid attribute) was obscured from the error message.

**After:**
```text
An exception was raised when attempting to load `ClientApp`: No module named 'custom_module'
```
The underlying exception message is appended, or falls back to prefix if string representation is empty.

### Related issues/PRs

Fixes #6561

## Proposal

### Explanation

Updated `LoadClientAppError` handling in [`app.py`](framework/py/flwr/compat/client/app.py) and [`run_clientapp.py`](framework/py/flwr/supernode/runtime/run_clientapp.py):

```python
prefix = "An exception was raised when attempting to load `ClientApp`"
reason = f"{prefix}: {ex}" if str(ex) else prefix
```

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [x] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [x] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

None
