### PR TITLE
feat(framework): Remove responses.create from agentapp API

### DIFF
--- a/framework/py/flwr/agentapp/__init__.py
+++ b/framework/py/flwr/agentapp/__init__.py
@@ -19,14 +19,12 @@ from .agent_app import AgentApp as AgentApp
 from .agent_app import LoadAgentAppError as LoadAgentAppError
 from .base import AgentConnectors as AgentConnectors
 from .base import AgentEvents as AgentEvents
-from .base import AgentResponses as AgentResponses
 from .base import AgentSession as AgentSession
 
 __all__ = [
     "AgentApp",
     "AgentConnectors",
     "AgentEvents",
-    "AgentResponses",
     "AgentSession",
     "LoadAgentAppError",
 ]

--- a/framework/py/flwr/agentapp/base.py
+++ b/framework/py/flwr/agentapp/base.py
@@ -24,25 +24,6 @@ from flwr.app import Context
 from flwr.supercore.typing import JSONObject
 
 
-class AgentResponses(ABC):
-    """Abstract base class for AgentApp model response creation."""
-
-    @abstractmethod
-    def create(self, request: JSONObject) -> JSONObject:
-        """Create a model response.
-
-        Parameters
-        ----------
-        request : JSONObject
-            Open Responses-compatible create request.
-
-        Returns
-        -------
-        response : JSONObject
-            Open Responses-compatible response.
-        """
-
-
 class AgentConnectors(ABC):
     """Abstract base class for AgentApp connector execution."""
 
@@ -69,11 +50,6 @@ class AgentEvents(ABC):
 
 class AgentSession(ABC):
     """Abstract base class for AgentApp runtime capabilities."""
-
-    @property
-    @abstractmethod
-    def responses(self) -> AgentResponses:
-        """Model response creation API."""
 
     @property
     @abstractmethod

--- a/framework/py/flwr/supercore/task_process/agent/run_agentapp.py
+++ b/framework/py/flwr/supercore/task_process/agent/run_agentapp.py
@@ -64,10 +64,10 @@ from flwr.supercore.tls import validate_and_resolve_root_certificates
 from flwr.superlink.grid import HttpGrid
 
 from .session import (
+    AgentRuntime,
     RuntimeAgentConnectors,
     RuntimeAgentEvents,
     RuntimeAgentSession,
-    RuntimeAgentTaskHandler,
 )
 
 _AGENT_INPUT_KEY = "agent.input"
@@ -240,7 +240,7 @@ def run_agentapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
                 f"Attribute '{agent_app_attr}' is not of type '{AgentApp.__name__}'.",
             ) from None
         agent_events = RuntimeAgentEvents(grid._runtime_client)
-        task_handler = RuntimeAgentTaskHandler(
+        agent_runtime = AgentRuntime(
             stub=grid._runtime_client,
             run_id=context.run_id,
             task_id=task_id,
@@ -254,7 +254,7 @@ def run_agentapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
             events=agent_events,
         )
         agent = RuntimeAgentSession(
-            connectors=RuntimeAgentConnectors(task_handler),
+            connectors=RuntimeAgentConnectors(agent_runtime),
             events=agent_events,
         )
         agent_app(agent=agent, context=context)

--- a/framework/py/flwr/supercore/task_process/agent/run_agentapp.py
+++ b/framework/py/flwr/supercore/task_process/agent/run_agentapp.py
@@ -66,8 +66,8 @@ from flwr.superlink.grid import HttpGrid
 from .session import (
     RuntimeAgentConnectors,
     RuntimeAgentEvents,
-    RuntimeAgentResponses,
     RuntimeAgentSession,
+    RuntimeAgentTaskHandler,
 )
 
 _AGENT_INPUT_KEY = "agent.input"
@@ -240,7 +240,7 @@ def run_agentapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
                 f"Attribute '{agent_app_attr}' is not of type '{AgentApp.__name__}'.",
             ) from None
         agent_events = RuntimeAgentEvents(grid._runtime_client)
-        responses = RuntimeAgentResponses(
+        task_handler = RuntimeAgentTaskHandler(
             stub=grid._runtime_client,
             run_id=context.run_id,
             task_id=task_id,
@@ -254,8 +254,7 @@ def run_agentapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
             events=agent_events,
         )
         agent = RuntimeAgentSession(
-            responses=responses,
-            connectors=RuntimeAgentConnectors(responses),
+            connectors=RuntimeAgentConnectors(task_handler),
             events=agent_events,
         )
         agent_app(agent=agent, context=context)

--- a/framework/py/flwr/supercore/task_process/agent/session.py
+++ b/framework/py/flwr/supercore/task_process/agent/session.py
@@ -191,8 +191,8 @@ class RuntimeAgentSession(AgentSession):
 class RuntimeAgentConnectors(AgentConnectors):
     """AgentConnectors implementation for model tools."""
 
-    def __init__(self, task_handler: RuntimeAgentTaskHandler) -> None:
-        self._task_handler = task_handler
+    def __init__(self, agent_runtime: AgentRuntime) -> None:
+        self._agent_runtime = agent_runtime
 
     def tools(self, names: Sequence[str]) -> list[JSONObject]:
         """Return model-facing tool schemas for the requested connectors."""
@@ -209,19 +209,19 @@ class RuntimeAgentConnectors(AgentConnectors):
         arguments_obj = cast(JSONObject, arguments)
 
         if name == START_AUTOMATION_TOOL_NAME:
-            return self._task_handler.call_automation_with_events(
+            return self._agent_runtime.call_automation_with_events(
                 call_id=call_id,
                 arguments=arguments_obj,
             )
-        return self._task_handler.call_connector_with_events(
+        return self._agent_runtime.call_connector_with_events(
             name=name,
             call_id=call_id,
             arguments=arguments_obj,
         )
 
 
-class RuntimeAgentTaskHandler:
-    """Handle child tasks used by AgentApp connectors."""
+class AgentRuntime:
+    """Coordinate AgentApp operations with Runtime services."""
 
     def __init__(  # pylint: disable=too-many-arguments
         self,

--- a/framework/py/flwr/supercore/task_process/agent/session.py
+++ b/framework/py/flwr/supercore/task_process/agent/session.py
@@ -26,7 +26,7 @@ from typing import cast
 
 from google.protobuf.json_format import ParseDict
 
-from flwr.agentapp import AgentConnectors, AgentEvents, AgentResponses, AgentSession
+from flwr.agentapp import AgentConnectors, AgentEvents, AgentSession
 from flwr.app import Message
 from flwr.common.serde import message_from_proto, message_to_proto
 from flwr.proto.control_pb2 import (  # pylint: disable=E0611
@@ -46,7 +46,6 @@ from flwr.supercore.json_message.connector_message import (
     ConnectorRequest,
     ConnectorResponse,
 )
-from flwr.supercore.json_message.model_message import ModelRequest, ModelResponse
 from flwr.supercore.runtime import RuntimeHttpClient
 from flwr.supercore.task_process.connector.automation import START_AUTOMATION_TOOL_NAME
 from flwr.supercore.task_process.connector.registry import (
@@ -56,8 +55,8 @@ from flwr.supercore.task_process.connector.registry import (
 from flwr.supercore.typing import JSONObject, JSONValue
 from flwr.supercore.utils import strict_json_dumps, strict_json_loads
 
-_DEFAULT_MODEL_REPLY_TIMEOUT = 300.0
-_DEFAULT_MODEL_REPLY_POLL_INTERVAL = 0.25
+_DEFAULT_TASK_REPLY_TIMEOUT = 300.0
+_DEFAULT_TASK_REPLY_POLL_INTERVAL = 0.25
 _EVENT_PUBLISH_BATCH_SIZE = 16
 _EVENT_PUBLISH_QUEUE_SIZE = 256
 _EVENT_PUBLISH_BATCH_WAIT = 0.05
@@ -172,18 +171,11 @@ class RuntimeAgentSession(AgentSession):
 
     def __init__(
         self,
-        responses: AgentResponses,
         connectors: AgentConnectors,
         events: AgentEvents,
     ) -> None:
-        self._responses = responses
         self._connectors = connectors
         self._events = events
-
-    @property
-    def responses(self) -> AgentResponses:
-        """Model response creation API."""
-        return self._responses
 
     @property
     def connectors(self) -> AgentConnectors:
@@ -199,8 +191,8 @@ class RuntimeAgentSession(AgentSession):
 class RuntimeAgentConnectors(AgentConnectors):
     """AgentConnectors implementation for model tools."""
 
-    def __init__(self, responses: RuntimeAgentResponses) -> None:
-        self._responses = responses
+    def __init__(self, task_handler: RuntimeAgentTaskHandler) -> None:
+        self._task_handler = task_handler
 
     def tools(self, names: Sequence[str]) -> list[JSONObject]:
         """Return model-facing tool schemas for the requested connectors."""
@@ -217,19 +209,19 @@ class RuntimeAgentConnectors(AgentConnectors):
         arguments_obj = cast(JSONObject, arguments)
 
         if name == START_AUTOMATION_TOOL_NAME:
-            return self._responses.call_automation_with_events(
+            return self._task_handler.call_automation_with_events(
                 call_id=call_id,
                 arguments=arguments_obj,
             )
-        return self._responses.call_connector_with_events(
+        return self._task_handler.call_connector_with_events(
             name=name,
             call_id=call_id,
             arguments=arguments_obj,
         )
 
 
-class RuntimeAgentResponses(AgentResponses):
-    """AgentResponses implementation backed by Runtime task messages."""
+class RuntimeAgentTaskHandler:
+    """Handle child tasks used by AgentApp connectors."""
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -245,43 +237,6 @@ class RuntimeAgentResponses(AgentResponses):
         self._task_id = task_id
         self._start_run_request = start_run_request
         self._events = events
-
-    def create(self, request: JSONObject) -> JSONObject:
-        """Create a model response through a child model task."""
-        return self._create_model_response(request)
-
-    def _create_model_response(self, request: JSONObject) -> JSONObject:
-        """Create one model response through a child model task."""
-        model = request.get("model")
-        if not isinstance(model, str) or not model:
-            raise ValueError(
-                "AgentResponses request requires a non-empty string 'model' field."
-            )
-
-        create_res = self._stub.CreateTask(
-            CreateTaskRequest(type=TaskType.MODEL, model_ref=model)
-        )
-        if not create_res.HasField("task_id"):
-            raise RuntimeError("Model task could not be created.")
-
-        model_task_id = create_res.task_id
-        message = ModelRequest(
-            dst_task_id=model_task_id,
-            input_=cast(str | Sequence[JSONObject], request.get("input")),
-            model=model,
-            stream=cast(bool, request.get("stream", False)),
-            tools=cast(Sequence[JSONObject] | None, request.get("tools")),
-            tool_choice=request.get("tool_choice"),
-            reasoning=cast(JSONObject | None, request.get("reasoning")),
-            previous_response_id=cast(str | None, request.get("previous_response_id")),
-            instructions=cast(str | None, request.get("instructions")),
-            max_output_tokens=cast(int | None, request.get("max_output_tokens")),
-            metadata=cast(JSONObject | None, request.get("metadata")),
-            text=cast(JSONObject | None, request.get("text")),
-        )
-        response_message = self._send_and_receive(message)
-        response = ModelResponse.from_message(response_message)
-        return response.payload
 
     def create_connector_response(
         self, *, name: str, call_id: str, arguments: JSONObject
@@ -457,7 +412,7 @@ class RuntimeAgentResponses(AgentResponses):
         message_id = message.metadata.message_id
 
         # Pull until a message arrives that replies to the pushed message, or timeout
-        deadline = time.monotonic() + _DEFAULT_MODEL_REPLY_TIMEOUT
+        deadline = time.monotonic() + _DEFAULT_TASK_REPLY_TIMEOUT
         while True:
             # The request destination becomes the source of its reply.
             for pulled_msg in self._pull_task_messages(src_task_id=child_task_id):
@@ -469,6 +424,6 @@ class RuntimeAgentResponses(AgentResponses):
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                raise TimeoutError("Timed out waiting for model response.")
+                raise TimeoutError("Timed out waiting for child task response.")
 
-            time.sleep(min(_DEFAULT_MODEL_REPLY_POLL_INTERVAL, remaining))
+            time.sleep(min(_DEFAULT_TASK_REPLY_POLL_INTERVAL, remaining))

--- a/framework/py/flwr/supercore/task_process/agent/session_test.py
+++ b/framework/py/flwr/supercore/task_process/agent/session_test.py
@@ -44,7 +44,7 @@ from flwr.supercore.task_process.connector.automation import START_AUTOMATION_TO
 from flwr.supercore.task_process.connector.registry import get_builtin_connector_tool
 from flwr.supercore.typing import JSONObject
 
-from .session import RuntimeAgentConnectors, RuntimeAgentEvents, RuntimeAgentTaskHandler
+from .session import AgentRuntime, RuntimeAgentConnectors, RuntimeAgentEvents
 
 
 def test_emit_event_pushes_task_event() -> None:
@@ -147,7 +147,7 @@ def test_agent_events_and_connector_items_use_same_publisher() -> None:
     """Publish explicit AgentApp events and connector items through one publisher."""
     stub = Mock()
     events = Mock()
-    task_handler = RuntimeAgentTaskHandler(
+    agent_runtime = AgentRuntime(
         stub=stub,
         run_id=123,
         task_id=789,
@@ -166,7 +166,7 @@ def test_agent_events_and_connector_items_use_same_publisher() -> None:
     }
 
     events.emit(model_event)
-    task_handler.push_run_events([connector_event])
+    agent_runtime.push_run_events([connector_event])
 
     assert events.emit.call_args_list == [
         call(model_event),
@@ -178,7 +178,7 @@ def test_pull_task_messages_filters_by_child_task() -> None:
     """Claim only messages sent by the expected child task."""
     stub = Mock()
     stub.PullTaskMessage.return_value = PullTaskMessageResponse()
-    task_handler = RuntimeAgentTaskHandler(
+    agent_runtime = AgentRuntime(
         stub=stub,
         run_id=123,
         task_id=789,
@@ -186,7 +186,7 @@ def test_pull_task_messages_filters_by_child_task() -> None:
         events=Mock(),
     )
 
-    assert task_handler._pull_task_messages(456) == []  # pylint: disable=W0212
+    assert agent_runtime._pull_task_messages(456) == []  # pylint: disable=W0212
     stub.PullTaskMessage.assert_called_once_with(
         PullTaskMessageRequest(limit=1, src_task_id=456)
     )
@@ -236,7 +236,7 @@ def test_call_automation_embeds_input_in_control_request() -> None:
         federation="@account/federation",
         series_id=2,
     )
-    task_handler = RuntimeAgentTaskHandler(
+    agent_runtime = AgentRuntime(
         stub=stub,
         run_id=123,
         task_id=789,
@@ -251,8 +251,8 @@ def test_call_automation_embeds_input_in_control_request() -> None:
     }
 
     # Execute
-    with patch.object(task_handler, "push_run_events") as push_run_events:
-        task_handler.call_automation_with_events(call_id="call-1", arguments=arguments)
+    with patch.object(agent_runtime, "push_run_events") as push_run_events:
+        agent_runtime.call_automation_with_events(call_id="call-1", arguments=arguments)
 
     # Assert
     request = stub.StartAutomation.call_args.args[0]
@@ -279,7 +279,7 @@ def test_call_automation_embeds_input_in_control_request() -> None:
 
 def test_connector_call_emits_standard_items() -> None:
     """Emit standard function call and output items."""
-    task_handler = RuntimeAgentTaskHandler(
+    agent_runtime = AgentRuntime(
         stub=Mock(),
         run_id=123,
         task_id=789,
@@ -290,11 +290,11 @@ def test_connector_call_emits_standard_items() -> None:
 
     with (
         patch.object(
-            task_handler, "create_connector_response", return_value={"results": []}
+            agent_runtime, "create_connector_response", return_value={"results": []}
         ),
-        patch.object(task_handler, "push_run_events") as push_run_events,
+        patch.object(agent_runtime, "push_run_events") as push_run_events,
     ):
-        output = task_handler.call_connector_with_events(
+        output = agent_runtime.call_connector_with_events(
             name="notion_search", call_id="call-1", arguments=arguments
         )
 
@@ -322,7 +322,7 @@ def test_create_connector_response_resolves_canonical_name() -> None:
     """Task creation should resolve the canonical tool name to its connector."""
     stub = Mock()
     stub.CreateTask.return_value = CreateTaskResponse(task_id=456)
-    task_handler = RuntimeAgentTaskHandler(
+    agent_runtime = AgentRuntime(
         stub=stub,
         run_id=123,
         task_id=789,
@@ -344,10 +344,10 @@ def test_create_connector_response_resolves_canonical_name() -> None:
             return_value="notion",
         ) as get_connector_ref,
         patch.object(
-            task_handler, "_send_and_receive", return_value=reply
+            agent_runtime, "_send_and_receive", return_value=reply
         ) as send_and_receive,
     ):
-        output = task_handler.create_connector_response(
+        output = agent_runtime.create_connector_response(
             name=" NoTiOn_Search ",
             call_id="call-1",
             arguments={},

--- a/framework/py/flwr/supercore/task_process/agent/session_test.py
+++ b/framework/py/flwr/supercore/task_process/agent/session_test.py
@@ -252,9 +252,7 @@ def test_call_automation_embeds_input_in_control_request() -> None:
 
     # Execute
     with patch.object(task_handler, "push_run_events") as push_run_events:
-        task_handler.call_automation_with_events(
-            call_id="call-1", arguments=arguments
-        )
+        task_handler.call_automation_with_events(call_id="call-1", arguments=arguments)
 
     # Assert
     request = stub.StartAutomation.call_args.args[0]

--- a/framework/py/flwr/supercore/task_process/agent/session_test.py
+++ b/framework/py/flwr/supercore/task_process/agent/session_test.py
@@ -44,7 +44,7 @@ from flwr.supercore.task_process.connector.automation import START_AUTOMATION_TO
 from flwr.supercore.task_process.connector.registry import get_builtin_connector_tool
 from flwr.supercore.typing import JSONObject
 
-from .session import RuntimeAgentConnectors, RuntimeAgentEvents, RuntimeAgentResponses
+from .session import RuntimeAgentConnectors, RuntimeAgentEvents, RuntimeAgentTaskHandler
 
 
 def test_emit_event_pushes_task_event() -> None:
@@ -147,7 +147,7 @@ def test_agent_events_and_connector_items_use_same_publisher() -> None:
     """Publish explicit AgentApp events and connector items through one publisher."""
     stub = Mock()
     events = Mock()
-    responses = RuntimeAgentResponses(
+    task_handler = RuntimeAgentTaskHandler(
         stub=stub,
         run_id=123,
         task_id=789,
@@ -166,7 +166,7 @@ def test_agent_events_and_connector_items_use_same_publisher() -> None:
     }
 
     events.emit(model_event)
-    responses.push_run_events([connector_event])
+    task_handler.push_run_events([connector_event])
 
     assert events.emit.call_args_list == [
         call(model_event),
@@ -178,7 +178,7 @@ def test_pull_task_messages_filters_by_child_task() -> None:
     """Claim only messages sent by the expected child task."""
     stub = Mock()
     stub.PullTaskMessage.return_value = PullTaskMessageResponse()
-    responses = RuntimeAgentResponses(
+    task_handler = RuntimeAgentTaskHandler(
         stub=stub,
         run_id=123,
         task_id=789,
@@ -186,7 +186,7 @@ def test_pull_task_messages_filters_by_child_task() -> None:
         events=Mock(),
     )
 
-    assert responses._pull_task_messages(456) == []  # pylint: disable=W0212
+    assert task_handler._pull_task_messages(456) == []  # pylint: disable=W0212
     stub.PullTaskMessage.assert_called_once_with(
         PullTaskMessageRequest(limit=1, src_task_id=456)
     )
@@ -236,7 +236,7 @@ def test_call_automation_embeds_input_in_control_request() -> None:
         federation="@account/federation",
         series_id=2,
     )
-    responses = RuntimeAgentResponses(
+    task_handler = RuntimeAgentTaskHandler(
         stub=stub,
         run_id=123,
         task_id=789,
@@ -251,8 +251,10 @@ def test_call_automation_embeds_input_in_control_request() -> None:
     }
 
     # Execute
-    with patch.object(responses, "push_run_events") as push_run_events:
-        responses.call_automation_with_events(call_id="call-1", arguments=arguments)
+    with patch.object(task_handler, "push_run_events") as push_run_events:
+        task_handler.call_automation_with_events(
+            call_id="call-1", arguments=arguments
+        )
 
     # Assert
     request = stub.StartAutomation.call_args.args[0]
@@ -279,7 +281,7 @@ def test_call_automation_embeds_input_in_control_request() -> None:
 
 def test_connector_call_emits_standard_items() -> None:
     """Emit standard function call and output items."""
-    responses = RuntimeAgentResponses(
+    task_handler = RuntimeAgentTaskHandler(
         stub=Mock(),
         run_id=123,
         task_id=789,
@@ -290,11 +292,11 @@ def test_connector_call_emits_standard_items() -> None:
 
     with (
         patch.object(
-            responses, "create_connector_response", return_value={"results": []}
+            task_handler, "create_connector_response", return_value={"results": []}
         ),
-        patch.object(responses, "push_run_events") as push_run_events,
+        patch.object(task_handler, "push_run_events") as push_run_events,
     ):
-        output = responses.call_connector_with_events(
+        output = task_handler.call_connector_with_events(
             name="notion_search", call_id="call-1", arguments=arguments
         )
 
@@ -322,7 +324,7 @@ def test_create_connector_response_resolves_canonical_name() -> None:
     """Task creation should resolve the canonical tool name to its connector."""
     stub = Mock()
     stub.CreateTask.return_value = CreateTaskResponse(task_id=456)
-    responses = RuntimeAgentResponses(
+    task_handler = RuntimeAgentTaskHandler(
         stub=stub,
         run_id=123,
         task_id=789,
@@ -344,10 +346,10 @@ def test_create_connector_response_resolves_canonical_name() -> None:
             return_value="notion",
         ) as get_connector_ref,
         patch.object(
-            responses, "_send_and_receive", return_value=reply
+            task_handler, "_send_and_receive", return_value=reply
         ) as send_and_receive,
     ):
-        output = responses.create_connector_response(
+        output = task_handler.create_connector_response(
             name=" NoTiOn_Search ",
             call_id="call-1",
             arguments={},


### PR DESCRIPTION
## Summary

Removed responses.create from the AgentApp API.

  - Removed AgentResponses and AgentSession.responses.
  - Removed AgentResponses from public exports.
  - Deleted the unused model-task response implementation.
  - Renamed the remaining internal helper to RuntimeAgentTaskHandler.
  - Updated runtime wiring and tests.
  - Left existing untracked documentation files untouched.