### PR TITLE
feat(framework): Update flwr chat to use ListRunSeriesEvents

### DIFF
--- a/framework/py/flwr/cli/chat/chat_history.py
+++ b/framework/py/flwr/cli/chat/chat_history.py
@@ -15,22 +15,22 @@
 """History command helpers for Flower Chat."""
 
 import json
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 import click
 from prompt_toolkit.formatted_text import StyleAndTextTuples
 from prompt_toolkit.utils import get_cwidth
 
-from flwr.app import ConfigRecord
-from flwr.common.serde import context_from_proto
 from flwr.proto.control_pb2 import (  # pylint: disable=E0611
-    GetRunSeriesRequest,
+    ListRunSeriesEventsRequest,
     ListRunSeriesRequest,
 )
-from flwr.proto.message_pb2 import Context as ProtoContext  # pylint: disable=E0611
 from flwr.proto.runseries_pb2 import RunSeries  # pylint: disable=E0611
+from flwr.proto.task_pb2 import TaskEvent  # pylint: disable=E0611
 from flwr.supercore.control import ControlHttpClient
 
+from ..constant import CHAT_TERMINAL_EVENTS, CHAT_TEXT_DELTA_EVENT
 from ..utils import flwr_cli_exc_handler
 
 
@@ -60,15 +60,15 @@ def load_conversation(
     stub: ControlHttpClient, entry: RunSeries, federation: str
 ) -> list[tuple[str, str]]:
     """Load displayable messages for one conversation."""
-    with flwr_cli_exc_handler():
-        response = stub.GetRunSeries(GetRunSeriesRequest(series_id=entry.series_id))
-    if response.series.federation != federation:
+    if entry.federation != federation:
         raise click.ClickException(
             f"Conversation {entry.series_id} does not belong to {federation}."
         )
-    if not response.HasField("context"):
-        return []
-    return _parse_conversation_context(response.context)
+    with flwr_cli_exc_handler():
+        response = stub.ListRunSeriesEvents(
+            ListRunSeriesEventsRequest(series_id=entry.series_id)
+        )
+    return _parse_conversation_events(response.events)
 
 
 def render_history(block: HistoryBlock, width: int) -> StyleAndTextTuples:
@@ -97,47 +97,89 @@ def render_history(block: HistoryBlock, width: int) -> StyleAndTextTuples:
     return fragments
 
 
-def _parse_conversation_context(  # pylint: disable=too-many-branches
-    context_proto: ProtoContext,
-) -> list[tuple[str, str]]:
-    """Extract displayable user and assistant messages from RunSeries context."""
-    context = context_from_proto(context_proto)
-    record = context.state.get("items")
-    if not isinstance(record, ConfigRecord):
-        return []
-    raw_items = record.get("json")
-    if not isinstance(raw_items, list):
-        return []
-
+def _parse_conversation_events(events: Iterable[TaskEvent]) -> list[tuple[str, str]]:
+    """Extract displayable messages from persisted run-series events."""
     messages: list[tuple[str, str]] = []
-    for raw_item in raw_items:
-        if not isinstance(raw_item, str):
-            continue
+    assistant_parts: list[str] = []
+
+    def flush_assistant_parts() -> None:
+        if assistant_parts:
+            messages.append(("assistant", "".join(assistant_parts)))
+            assistant_parts.clear()
+
+    for event in events:
         try:
-            item = json.loads(raw_item)
+            payload = json.loads(event.data)
         except json.JSONDecodeError:
             continue
-        if not isinstance(item, dict) or item.get("type") != "message":
+        if not isinstance(payload, dict):
             continue
-        role = item.get("role")
-        if role not in {"user", "assistant"}:
-            continue
-        content = item.get("content")
-        if isinstance(content, str):
-            text = content
-        elif isinstance(content, list):
-            parts: list[str] = []
-            for part in content:
-                if isinstance(part, str):
-                    parts.append(part)
-                elif isinstance(part, dict) and isinstance(part.get("text"), str):
-                    parts.append(part["text"])
-            text = "".join(parts)
-        else:
-            continue
-        if text:
-            messages.append((role, text))
+
+        event_type = event.event
+        if not event_type and isinstance(payload.get("type"), str):
+            event_type = payload["type"]
+        if event_type == CHAT_TEXT_DELTA_EVENT:
+            delta = payload.get("delta")
+            if isinstance(delta, str):
+                assistant_parts.append(delta)
+        elif event_type in CHAT_TERMINAL_EVENTS:
+            response_text = _parse_response_text(payload)
+            if response_text:
+                assistant_parts.clear()
+                messages.append(("assistant", response_text))
+            else:
+                flush_assistant_parts()
+        elif event_type == "message":
+            role = payload.get("role")
+            if role not in {"user", "assistant"}:
+                continue
+            flush_assistant_parts()
+            text = _parse_message_content(payload.get("content"))
+            if text:
+                messages.append((role, text))
+
+    flush_assistant_parts()
     return messages
+
+
+def _parse_message_content(content: object) -> str | None:
+    """Extract text from an Open Responses message item."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict) and isinstance(part.get("text"), str):
+                parts.append(part["text"])
+        return "".join(parts)
+    return None
+
+
+def _parse_response_text(payload: dict[str, object]) -> str | None:
+    """Extract final assistant text from a terminal Open Responses event."""
+    response = payload.get("response")
+    if not isinstance(response, dict):
+        return None
+    output_text = response.get("output_text")
+    if isinstance(output_text, str):
+        return output_text
+    output = response.get("output")
+    if not isinstance(output, list):
+        return None
+    parts: list[str] = []
+    for item in output:
+        if (
+            not isinstance(item, dict)
+            or item.get("type") != "message"
+            or item.get("role") != "assistant"
+        ):
+            continue
+        text = _parse_message_content(item.get("content"))
+        if text:
+            parts.append(text)
+    return "".join(parts) or None
 
 
 def _truncate_to_width(text: str, width: int) -> str:

--- a/framework/py/flwr/cli/chat/chat_history_test.py
+++ b/framework/py/flwr/cli/chat/chat_history_test.py
@@ -15,22 +15,20 @@
 """Tests for conversation history in the CLI `chat` application."""
 
 import asyncio
-import json
 from unittest.mock import Mock, patch
 
-from flwr.app import ConfigRecord, Context, RecordDict
 from flwr.cli.chat.chat_app import ChatApplication
-from flwr.cli.chat.chat_history import HistoryBlock
+from flwr.cli.chat.chat_history import HistoryBlock, load_conversation
 from flwr.cli.constant import CHAT_DEFAULT_FEDERATION_NAME
-from flwr.common.serde import context_to_proto
 from flwr.proto.control_pb2 import (  # pylint: disable=E0611
-    GetRunSeriesRequest,
-    GetRunSeriesResponse,
+    ListRunSeriesEventsRequest,
+    ListRunSeriesEventsResponse,
     ListRunSeriesRequest,
     ListRunSeriesResponse,
 )
 from flwr.proto.federation_pb2 import Federation  # pylint: disable=E0611
 from flwr.proto.runseries_pb2 import RunSeries  # pylint: disable=E0611
+from flwr.proto.task_pb2 import TaskEvent  # pylint: disable=E0611
 
 FEDERATION = f"@flower/{CHAT_DEFAULT_FEDERATION_NAME}"
 
@@ -40,32 +38,43 @@ def _create_chat(stub: Mock) -> ChatApplication:
         return ChatApplication(stub, [Federation(name=FEDERATION)], Mock())
 
 
-def test_history_widget_restores_selected_context() -> None:
-    """History should navigate chronologically and restore the selected context."""
+def test_history_widget_restores_selected_events() -> None:
+    """History should navigate chronologically and restore the selected events."""
     stub = Mock()
     selected = RunSeries(series_id=6, federation=FEDERATION, description="Saved chat")
     latest = RunSeries(series_id=7, federation=FEDERATION, description="Latest chat")
     stub.ListRunSeries.return_value = ListRunSeriesResponse(entries=[latest, selected])
-    items = [
-        {"type": "message", "role": "user", "content": "Previous question"},
-        {
-            "type": "message",
-            "role": "assistant",
-            "content": [{"type": "output_text", "text": "**Previous answer**"}],
-        },
-    ]
-    context = Context(
-        run_id=10,
-        node_id=0,
-        node_config={},
-        state=RecordDict(
-            {"items": ConfigRecord({"json": [json.dumps(item) for item in items]})}
-        ),
-        run_config={},
-        series_id=6,
-    )
-    stub.GetRunSeries.return_value = GetRunSeriesResponse(
-        series=selected, context=context_to_proto(context)
+    stub.ListRunSeriesEvents.return_value = ListRunSeriesEventsResponse(
+        events=[
+            TaskEvent(
+                event="message",
+                data=(
+                    '{"type":"message","role":"user",'
+                    '"content":"Previous question"}'
+                ),
+            ),
+            TaskEvent(
+                event="response.output_text.delta",
+                data=(
+                    '{"type":"response.output_text.delta",'
+                    '"delta":"**Previous "}'
+                ),
+            ),
+            TaskEvent(
+                event="response.output_text.delta",
+                data=(
+                    '{"type":"response.output_text.delta",'
+                    '"delta":"answer**"}'
+                ),
+            ),
+            TaskEvent(
+                event="response.completed",
+                data=(
+                    '{"type":"response.completed","response":'
+                    '{"output_text":"**Previous answer**"}}'
+                ),
+            ),
+        ]
     )
     chat = _create_chat(stub)
     event = Mock()
@@ -87,7 +96,9 @@ def test_history_widget_restores_selected_context() -> None:
     stub.ListRunSeries.assert_called_once_with(
         ListRunSeriesRequest(federation_id=FEDERATION, is_agent=True)
     )
-    stub.GetRunSeries.assert_called_once_with(GetRunSeriesRequest(series_id=6))
+    stub.ListRunSeriesEvents.assert_called_once_with(
+        ListRunSeriesEventsRequest(series_id=6)
+    )
     assert chat.series_id == 6
     assert chat.transcript == [
         ("class:user.message", "❯ Previous question\n"),
@@ -106,6 +117,33 @@ def test_history_handles_empty_result() -> None:
     asyncio.run(event.app.create_background_task.call_args.args[0])
     assert chat.transcript == [
         ("class:notice", f"No conversation history found for {FEDERATION}.\n\n")
+    ]
+
+
+def test_load_conversation_restores_incomplete_response_from_deltas() -> None:
+    """Persisted deltas should restore an assistant response without a terminal."""
+    stub = Mock()
+    entry = RunSeries(series_id=6, federation=FEDERATION)
+    stub.ListRunSeriesEvents.return_value = ListRunSeriesEventsResponse(
+        events=[
+            TaskEvent(
+                event="message",
+                data='{"type":"message","role":"user","content":"Question"}',
+            ),
+            TaskEvent(
+                event="response.output_text.delta",
+                data='{"type":"response.output_text.delta","delta":"Partial "}',
+            ),
+            TaskEvent(
+                event="response.output_text.delta",
+                data='{"type":"response.output_text.delta","delta":"answer"}',
+            ),
+        ]
+    )
+
+    assert load_conversation(stub, entry, FEDERATION) == [
+        ("user", "Question"),
+        ("assistant", "Partial answer"),
     ]
 
 


### PR DESCRIPTION
Updated Flwr Chat history to use ListRunSeriesEvents instead of GetRunSeries.context.

  - Loads persisted conversation events via ListRunSeriesEvents.
  - Reconstructs user messages and assistant output from event payloads.
  - Prefers completed response text, falling back to streamed deltas for incomplete runs.
  - Preserves federation validation.
  - Updated tests and added incomplete-response coverage.