### PR TITLE
refactor(framework): Remove Runtime gRPC interceptor factories

### DIFF
--- a/framework/py/flwr/supercore/interceptors/__init__.py
+++ b/framework/py/flwr/supercore/interceptors/__init__.py
@@ -27,8 +27,6 @@ from .runtime_version_interceptor import (
     RuntimeVersionServerInterceptor,
     create_control_runtime_version_server_interceptor,
     create_fleet_runtime_version_server_interceptor,
-    create_superlink_runtime_version_server_interceptor,
-    create_supernode_runtime_version_server_interceptor,
 )
 
 __all__ = [
@@ -41,6 +39,4 @@ __all__ = [
     "TASK_TOKEN_HEADER",
     "create_control_runtime_version_server_interceptor",
     "create_fleet_runtime_version_server_interceptor",
-    "create_superlink_runtime_version_server_interceptor",
-    "create_supernode_runtime_version_server_interceptor",
 ]

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
@@ -239,34 +239,6 @@ class RuntimeVersionServerInterceptor(grpc.ServerInterceptor):  # type: ignore[m
         return method_handler
 
 
-def create_superlink_runtime_version_server_interceptor(
-    connection_name: str = "Caller <-> SuperLink Runtime API",
-    send_warning_metadata: bool = False,
-    reject_incompatible: bool = True,
-) -> RuntimeVersionServerInterceptor:
-    """Create the SuperLink Runtime API version interceptor."""
-    return RuntimeVersionServerInterceptor(
-        connection_name=connection_name,
-        local_metadata=RuntimeVersionMetadata.from_local_component("SuperLink"),
-        send_warning_metadata=send_warning_metadata,
-        reject_incompatible=reject_incompatible,
-    )
-
-
-def create_supernode_runtime_version_server_interceptor(
-    connection_name: str = "Caller <-> SuperNode Runtime API",
-    send_warning_metadata: bool = False,
-    reject_incompatible: bool = True,
-) -> RuntimeVersionServerInterceptor:
-    """Create the SuperNode Runtime API version interceptor."""
-    return RuntimeVersionServerInterceptor(
-        connection_name=connection_name,
-        local_metadata=RuntimeVersionMetadata.from_local_component("SuperNode"),
-        send_warning_metadata=send_warning_metadata,
-        reject_incompatible=reject_incompatible,
-    )
-
-
 def create_fleet_runtime_version_server_interceptor(
     connection_name: str = "SuperNode <-> SuperLink Fleet API",
     send_warning_metadata: bool = False,

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor_test.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor_test.py
@@ -38,8 +38,6 @@ from flwr.supercore.interceptors import (
     RuntimeVersionServerInterceptor,
     create_control_runtime_version_server_interceptor,
     create_fleet_runtime_version_server_interceptor,
-    create_superlink_runtime_version_server_interceptor,
-    create_supernode_runtime_version_server_interceptor,
 )
 from flwr.supercore.runtime_version_compatibility import RuntimeVersionMetadata
 
@@ -391,16 +389,6 @@ class TestRuntimeVersionServerInterceptor(TestCase):
             "expected a peer from the same major.minor release, but received "
             "simulation version 1.30.1.",
         )
-
-    def test_superlink_runtime_factory_rejects_incompatible_by_default(self) -> None:
-        """SuperLink Runtime factory should reject different major.minor."""
-        interceptor = create_superlink_runtime_version_server_interceptor()
-        self.assertTrue(interceptor._reject_incompatible)  # pylint: disable=W0212
-
-    def test_supernode_runtime_factory_rejects_incompatible_by_default(self) -> None:
-        """SuperNode Runtime factory should reject different major.minor."""
-        interceptor = create_supernode_runtime_version_server_interceptor()
-        self.assertTrue(interceptor._reject_incompatible)  # pylint: disable=W0212
 
     def test_fleet_factory_observes_by_default(self) -> None:
         """Fleet factory should not return warning metadata by default."""


### PR DESCRIPTION
## Issue

The Runtime API no longer uses gRPC, so its SuperLink and SuperNode gRPC runtime-version interceptor factories are obsolete.

## Description

- Remove the unused SuperLink and SuperNode Runtime gRPC interceptor factories
- Remove their package exports
- Remove their factory-only tests

The Fleet and Control gRPC runtime-version interceptors remain unchanged.

## Tests

- `uv run --no-sync --python=3.11.14 python -m pytest py/flwr/supercore/interceptors/runtime_version_interceptor_test.py py/flwr/superlink/servicer/control/control_grpc_test.py py/flwr/superlink/cli/flower_superlink_test.py -q`