### PR TITLE
docs(agent): Clarify self-hosted model and MCP integration

### DIFF
--- a/agent/docs/source/explanations/agentapp-runtime.md
+++ b/agent/docs/source/explanations/agentapp-runtime.md
@@ -35,9 +35,8 @@ and logs.
 ## AgentSession
 
 Flower creates an `AgentSession` for each AgentApp run and passes it to your
-main function. It exposes three capabilities:
+main function. It exposes two capabilities:
 
-- `agent.responses` provides a lower-level JSON model API
 - `agent.connectors` returns connector tools and executes function calls
 - `agent.events` publishes structured events selected by the AgentApp
 
@@ -86,10 +85,10 @@ The endpoint is authenticated for the current AgentApp task. It is not a public
 model API for an external client. See [Use the OpenAI SDK in an
 AgentApp](../how-to-guides/use-openai-sdk.md) for a complete example.
 
-`agent.responses.create(request)` remains available as a lower-level interface
-for JSON-based workflows. It returns a JSON response object and automatically
-appends its model output items to the Flower `Context`. New AgentApps should
-prefer the OpenAI SDK when they need typed responses or streaming events.
+The injected runtime credential authenticates the AgentApp to Flower; it does
+not authenticate a self-hosted SuperLink to an upstream provider. See
+{ref}`configure-local-model-provider` for the self-hosted configuration and
+supported endpoint protocol.
 
 The default model provider at `api.flower.ai` does not currently support
 continuing with `previous_response_id`. Rebuild `input` from stored messages for
@@ -151,9 +150,9 @@ as `get` when reading it through `context.state.config_records`.
 
 If `agent.input` is a non-empty string, the runtime records it as an Open
 Responses user-message item before calling the AgentApp. Connector calls append
-their outputs and built-in activity. The lower-level `agent.responses` API also
-appends model output, while SDK responses and events emitted with `agent.events`
-are persisted only when the app stores them explicitly.
+their outputs and built-in activity. Responses created through the OpenAI SDK
+and events emitted with `agent.events` are persisted only when the app stores
+them explicitly.
 
 Runs in the same series can receive the persisted context. The app chooses what
 to send to the model. A safe conversation loader selects only message items:

--- a/agent/docs/source/explanations/use-connectors.md
+++ b/agent/docs/source/explanations/use-connectors.md
@@ -3,6 +3,12 @@
 Connectors give an AgentApp tools supplied by the runtime without embedding
 provider implementations or credentials in the app.
 
+Flower connectors are registered and hosted by the Flower runtime. They are not
+a general tool-registration interface: `AgentSession` does not currently expose
+an MCP client or a method for registering an arbitrary MCP toolset. To connect
+an AgentApp to an MCP server, use [Use tools from an MCP
+server](../how-to-guides/use-mcp-tools.md).
+
 ## Distinguish built-in and account connectors
 
 Built-in connectors need no external account:
@@ -91,6 +97,8 @@ directly, see {ref}`publish-agentapp-generated-text`.
 
 Account connector credentials are delivered to the runtime action, not returned
 to the AgentApp.
+
+(bound-connector-tool-loop)=
 
 ## Bound the tool loop
 

--- a/agent/docs/source/how-to-guides/run-with-local-superlink.md
+++ b/agent/docs/source/how-to-guides/run-with-local-superlink.md
@@ -15,10 +15,25 @@ This guide disables TLS and is intended for local development only. Do not
 expose the insecure SuperLink ports to an untrusted network.
 ```
 
+(configure-local-model-provider)=
+
 ## Configure a model provider
 
 The local runtime needs an Open Responses-compatible model endpoint. Set the
 provider configuration in the terminal where you'll start SuperLink.
+
+The deployment determines where upstream model access is configured:
+
+| Deployment                                          | Required model configuration                                  |
+| --------------------------------------------------- | ------------------------------------------------------------- |
+| SuperGrid                                           | None in the AgentApp; Flower configures upstream model access |
+| Self-hosted with Flower's default endpoint          | `FLWR_MODEL_API_KEY`                                          |
+| Self-hosted with an authenticated custom endpoint   | `FLWR_MODEL_API_ENDPOINT` and `FLWR_MODEL_API_KEY`            |
+| Self-hosted with an unauthenticated custom endpoint | `FLWR_MODEL_API_ENDPOINT` only                                |
+
+`FLWR_RUNTIME_BASE_URL` and `FLWR_RUNTIME_API_KEY` are injected into the
+AgentApp in all of these cases. They authenticate the AgentApp to Flower and do
+not configure the upstream provider used by SuperLink.
 
 To use Flower's default model endpoint, provide a Flower API key:
 
@@ -37,6 +52,27 @@ $ export FLWR_MODEL_API_KEY="<your-provider-api-key>"
 You can omit `FLWR_MODEL_API_KEY` when the custom endpoint does not require
 authentication. The model and AgentApp subprocesses inherit these variables
 from SuperLink.
+
+Without either variable, model requests through a self-hosted SuperLink fail
+with:
+
+```text
+HTTP 502 {"message":"Model API key is not set (FLWR_MODEL_API_KEY)."}
+```
+
+### Use a fully on-premises model
+
+A local inference server is a drop-in model provider only when it implements the
+Open Responses protocol at a URL ending in `/responses`. An endpoint that only
+implements the OpenAI-compatible `/chat/completions` API is not directly
+compatible with Flower's model plane.
+
+For a fully local supported example, follow [Run an AgentApp with a local
+SuperLink and Ollama](run-with-ollama.md). For another inference server, point
+`FLWR_MODEL_API_ENDPOINT` at its Open Responses endpoint. If the server only
+supports Chat Completions, you must either provide your own protocol adapter or
+connect to it directly from the AgentApp. Flower does not currently provide a
+Chat Completions-to-Open Responses adapter.
 
 Account connectors configured in SuperGrid are not available to this local
 unauthenticated runtime. Built-in connectors depend on the local runtime and
@@ -100,6 +136,14 @@ $ uv run flwr stop <run-id> local-agent
 ```
 
 Press {kbd}`Ctrl+C` in the SuperLink terminal when you're finished.
+
+This guide starts a foreground, user-managed SuperLink. `flwr stop` stops a run;
+it does not stop the SuperLink process. A SuperLink started automatically for a
+`:local:` connection is a different, background-managed process. There is
+currently no dedicated `flwr` command or PID file for stopping that process; see
+[Run Flower locally with a managed
+SuperLink](https://flower.ai/docs/framework/how-to-run-flower-locally.html#stop-the-background-local-superlink)
+for the documented process-inspection procedure.
 
 ## Troubleshoot the local runtime
 

--- a/agent/docs/source/how-to-guides/run-with-local-superlink.md
+++ b/agent/docs/source/how-to-guides/run-with-local-superlink.md
@@ -50,15 +50,18 @@ $ export FLWR_MODEL_API_KEY="<your-provider-api-key>"
 ```
 
 You can omit `FLWR_MODEL_API_KEY` when the custom endpoint does not require
-authentication. The model and AgentApp subprocesses inherit these variables
-from SuperLink.
+authentication.
 
-Without either variable, model requests through a self-hosted SuperLink fail
-with:
-
-```text
-HTTP 502 {"message":"Model API key is not set (FLWR_MODEL_API_KEY)."}
+```{warning}
+The local subprocess executor passes the SuperLink environment, including
+`FLWR_MODEL_API_KEY`, to both model and AgentApp processes. Run only trusted
+AgentApps on a SuperLink configured with provider credentials.
 ```
+
+Without either variable, model requests through a self-hosted SuperLink fail. A
+streaming request receives a terminal SSE `error` event reporting that
+`FLWR_MODEL_API_KEY` is not set. A non-streaming request receives an HTTP 502
+response with the same message in its JSON `error` object.
 
 ### Use a fully on-premises model
 
@@ -142,7 +145,7 @@ it does not stop the SuperLink process. A SuperLink started automatically for a
 `:local:` connection is a different, background-managed process. There is
 currently no dedicated `flwr` command or PID file for stopping that process; see
 [Run Flower locally with a managed
-SuperLink](https://flower.ai/docs/framework/how-to-run-flower-locally.html#stop-the-background-local-superlink)
+SuperLink](https://flower.ai/docs/framework/how-to-run-flower-locally.html#stop-background-local-superlink)
 for the documented process-inspection procedure.
 
 ## Troubleshoot the local runtime

--- a/agent/docs/source/how-to-guides/use-mcp-tools.md
+++ b/agent/docs/source/how-to-guides/use-mcp-tools.md
@@ -14,112 +14,78 @@ Flower connectors and MCP tools therefore follow different execution paths:
 
 ## Add an MCP client
 
-Add the MCP Python SDK version used by Flower to the AgentApp dependencies:
+Add the MCP Python SDK to the AgentApp dependencies. This example targets its
+1.x API:
 
 ```console
 $ uv add 'mcp>=1.26.0,<2.0'
 ```
 
-Bridge Flower's synchronous entry point to the asynchronous MCP client and keep
-the client lifecycle inside context managers:
+## Implement the AgentApp
+
+The following AgentApp performs one bounded MCP tool round and then streams the
+final model response:
 
 ```python
+from __future__ import annotations
+
 import asyncio
+import json
 import os
+from typing import Any, cast
 
 from flwr.agentapp import AgentApp, AgentSession
 from flwr.app import Context
-from mcp import ClientSession
+from mcp import CallToolResult, ClientSession, Tool
 from mcp.client.streamable_http import streamable_http_client
+from mcp.types import PaginatedRequestParams
+from openai import AsyncOpenAI
+
+MODEL = "openai/gpt-5.6-sol"
+ALLOWED_MCP_TOOLS = {"search_documents", "read_document"}
 
 app = AgentApp()
 
 
-async def run_mcp(agent: AgentSession, context: Context) -> None:
-    async with streamable_http_client(os.environ["MCP_ENDPOINT"]) as (
-        read,
-        write,
-        _,
-    ):
-        async with ClientSession(read, write) as mcp_client:
-            await mcp_client.initialize()
-            await use_mcp_tools(mcp_client, agent, context)
-
-
-@app.main()
-def main(agent: AgentSession, context: Context) -> None:
-    asyncio.run(run_mcp(agent, context))
-```
-
-Set `MCP_ENDPOINT` to the URL of a running Streamable HTTP MCP server. The
-following sections build `use_mcp_tools`.
-
-## Discover and allowlist tools
-
-Inside the asynchronous helper, list the server's tools and select an explicit
-set of tool names:
-
-```python
-ALLOWED_MCP_TOOLS = {
-    "search_documents",
-    "read_document",
-}
-
-
-async def use_mcp_tools(
-    mcp_client: ClientSession,
-    agent: AgentSession,
-    context: Context,
-) -> None:
-    list_result = await mcp_client.list_tools()
-    selected_tools = [
-        tool for tool in list_result.tools if tool.name in ALLOWED_MCP_TOOLS
-    ]
-    model_tools = [as_response_tool(tool) for tool in selected_tools]
-    # Pass model_tools to the model and dispatch any returned tool calls.
-```
-
-The exact client setup and result container depend on the MCP library and
-transport. The important boundary is that a server advertising a new tool does
-not make that tool model-accessible automatically.
-
-## Convert definitions to Open Responses tools
-
-Define the schema converter at module scope. `use_mcp_tools` calls it while
-`selected_tools` is still in scope:
-
-```python
-def as_response_tool(tool: object) -> dict[str, object]:
+def as_response_tool(tool: Tool) -> dict[str, Any]:
+    """Convert an MCP tool definition to an Open Responses function tool."""
     return {
         "type": "function",
         "name": tool.name,
         "description": tool.description or "",
         "parameters": tool.inputSchema,
     }
-```
 
-Some MCP clients expose the schema as `input_schema` instead of `inputSchema`.
-Use the field provided by your client without otherwise changing the JSON
-Schema. Pass `model_tools` through the `tools` field of
-`client.responses.create(...)`.
 
-## Dispatch function calls back to MCP
+def serialize_mcp_result(result: CallToolResult) -> str:
+    """Serialize an MCP result for a function_call_output item."""
+    return result.model_dump_json(by_alias=True, exclude_none=True)
 
-When the OpenAI SDK returns a `function_call`, first convert it with
-`function_call.to_dict()`. Then reject any name outside the allowlist, parse its
-arguments, call the matching MCP tool, and create a `function_call_output` item
-with the same `call_id`:
 
-```python
-import json
+async def list_all_tools(mcp_client: ClientSession) -> list[Tool]:
+    """List every tool exposed by a paginated MCP server."""
+    tools = []
+    cursor = None
+    while True:
+        params = (
+            PaginatedRequestParams(cursor=cursor)
+            if cursor is not None
+            else None
+        )
+        page = await mcp_client.list_tools(params=params)
+        tools.extend(page.tools)
+        cursor = page.nextCursor
+        if cursor is None:
+            return tools
 
 
 async def call_mcp_tool(
     mcp_client: ClientSession,
-    tool_call: dict[str, object],
-) -> dict[str, object]:
+    tool_call: dict[str, Any],
+) -> dict[str, Any]:
+    """Validate and execute one model-requested MCP tool call."""
     name = tool_call.get("name")
-    if name not in ALLOWED_MCP_TOOLS:
+    if not isinstance(name, str) or name not in ALLOWED_MCP_TOOLS:
         raise RuntimeError(f"MCP tool {name!r} was not exposed")
 
     raw_arguments = tool_call.get("arguments", "{}")
@@ -128,22 +94,110 @@ async def call_mcp_tool(
         if isinstance(raw_arguments, str)
         else raw_arguments
     )
+    if not isinstance(arguments, dict):
+        raise ValueError("MCP tool arguments must be a JSON object")
+
+    call_id = tool_call.get("call_id")
+    if not isinstance(call_id, str):
+        raise ValueError("MCP tool call requires a string call_id")
+
     result = await mcp_client.call_tool(name, arguments)
     return {
         "type": "function_call_output",
-        "call_id": tool_call["call_id"],
+        "call_id": call_id,
         "output": serialize_mcp_result(result),
     }
+
+
+async def run_mcp(agent: AgentSession, context: Context) -> None:
+    """Discover MCP tools, execute one tool round, and publish the answer."""
+    prompt = context.run_config.get("agent.input")
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise ValueError("agent.input must be a non-empty string")
+
+    async with AsyncOpenAI(
+        base_url=os.environ["FLWR_RUNTIME_BASE_URL"],
+        api_key=os.environ["FLWR_RUNTIME_API_KEY"],
+        max_retries=0,
+    ) as client:
+        input_items: list[dict[str, Any]] = [
+            {"type": "message", "role": "user", "content": prompt.strip()}
+        ]
+
+        async with streamable_http_client(os.environ["MCP_ENDPOINT"]) as (
+            read,
+            write,
+            _,
+        ):
+            async with ClientSession(read, write) as mcp_client:
+                await mcp_client.initialize()
+                selected_tools = [
+                    tool
+                    for tool in await list_all_tools(mcp_client)
+                    if tool.name in ALLOWED_MCP_TOOLS
+                ]
+                if not selected_tools:
+                    raise RuntimeError("The MCP server exposed no allowed tools")
+                model_tools = [as_response_tool(tool) for tool in selected_tools]
+
+                response = await client.responses.create(
+                    model=MODEL,
+                    input=input_items,
+                    tools=model_tools,
+                    tool_choice="required",
+                )
+                response_output = [
+                    cast(dict[str, Any], item.to_dict())
+                    for item in response.output
+                ]
+                tool_calls = [
+                    item
+                    for item in response_output
+                    if item.get("type") == "function_call"
+                ]
+                if not tool_calls:
+                    raise RuntimeError("The model did not request an MCP tool")
+
+                function_outputs = [
+                    await call_mcp_tool(mcp_client, tool_call)
+                    for tool_call in tool_calls
+                ]
+                input_items.extend(response_output)
+                input_items.extend(function_outputs)
+
+        stream = await client.responses.create(
+            model=MODEL,
+            input=input_items,
+            stream=True,
+        )
+        output_text = []
+        async for event in stream:
+            agent.events.emit(event.to_dict())
+            if event.type in {
+                "error",
+                "response.failed",
+                "response.incomplete",
+            }:
+                raise RuntimeError(f"Model response did not complete: {event}")
+            if event.type in {
+                "response.output_text.delta",
+                "response.refusal.delta",
+            }:
+                output_text.append(event.delta)
+
+        print("".join(output_text))
+
+
+@app.main()
+def main(agent: AgentSession, context: Context) -> None:
+    """Run the asynchronous MCP workflow from Flower's synchronous entry point."""
+    asyncio.run(run_mcp(agent, context))
 ```
 
-`serialize_mcp_result` represents application-specific normalization. Serialize
-the MCP result's text, structured content, or error to a string accepted by your
-model provider. Do not pass client-library objects directly to the model
-request.
-
-Append both the model's original function-call item and the corresponding
-function output to the next request. Bound the loop exactly as you would for
-Flower connectors; see {ref}`bound-connector-tool-loop`.
+Set `MCP_ENDPOINT` to a running Streamable HTTP MCP server and replace the model
+and allowlist with values for your deployment. Only allowlisted MCP definitions
+are exposed to the model, and the final request omits tools so the workflow
+cannot start another tool round.
 
 ## Current limitations
 

--- a/agent/docs/source/how-to-guides/use-mcp-tools.md
+++ b/agent/docs/source/how-to-guides/use-mcp-tools.md
@@ -12,15 +12,12 @@ Flower connectors and MCP tools therefore follow different execution paths:
 - An MCP client created by your AgentApp connects to the MCP server, discovers
   its tools, and executes its calls.
 
-Both kinds of tools can be passed to the same Open Responses model request after
-the AgentApp converts the MCP definitions to function-tool schemas.
-
 ## Add an MCP client
 
-Add the MCP Python SDK to the AgentApp dependencies:
+Add the MCP Python SDK version used by Flower to the AgentApp dependencies:
 
 ```console
-$ uv add mcp
+$ uv add 'mcp>=1.26.0,<2.0'
 ```
 
 Bridge Flower's synchronous entry point to the asynchronous MCP client and keep
@@ -32,14 +29,21 @@ import os
 
 from flwr.agentapp import AgentApp, AgentSession
 from flwr.app import Context
-from mcp import Client
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
 
 app = AgentApp()
 
 
 async def run_mcp(agent: AgentSession, context: Context) -> None:
-    async with Client(os.environ["MCP_ENDPOINT"]) as mcp_client:
-        await use_mcp_tools(mcp_client, agent, context)
+    async with streamable_http_client(os.environ["MCP_ENDPOINT"]) as (
+        read,
+        write,
+        _,
+    ):
+        async with ClientSession(read, write) as mcp_client:
+            await mcp_client.initialize()
+            await use_mcp_tools(mcp_client, agent, context)
 
 
 @app.main()
@@ -63,7 +67,7 @@ ALLOWED_MCP_TOOLS = {
 
 
 async def use_mcp_tools(
-    mcp_client: Client,
+    mcp_client: ClientSession,
     agent: AgentSession,
     context: Context,
 ) -> None:
@@ -71,7 +75,8 @@ async def use_mcp_tools(
     selected_tools = [
         tool for tool in list_result.tools if tool.name in ALLOWED_MCP_TOOLS
     ]
-    # Convert selected_tools, pass them to the model, and dispatch tool calls.
+    model_tools = [as_response_tool(tool) for tool in selected_tools]
+    # Pass model_tools to the model and dispatch any returned tool calls.
 ```
 
 The exact client setup and result container depend on the MCP library and
@@ -80,8 +85,8 @@ not make that tool model-accessible automatically.
 
 ## Convert definitions to Open Responses tools
 
-For each selected MCP tool, map its name, description, and JSON input schema to
-an Open Responses function tool:
+Define the schema converter at module scope. `use_mcp_tools` calls it while
+`selected_tools` is still in scope:
 
 ```python
 def as_response_tool(tool: object) -> dict[str, object]:
@@ -91,9 +96,6 @@ def as_response_tool(tool: object) -> dict[str, object]:
         "description": tool.description or "",
         "parameters": tool.inputSchema,
     }
-
-
-model_tools = [as_response_tool(tool) for tool in selected_tools]
 ```
 
 Some MCP clients expose the schema as `input_schema` instead of `inputSchema`.
@@ -112,7 +114,10 @@ with the same `call_id`:
 import json
 
 
-async def call_mcp_tool(tool_call: dict[str, object]) -> dict[str, object]:
+async def call_mcp_tool(
+    mcp_client: ClientSession,
+    tool_call: dict[str, object],
+) -> dict[str, object]:
     name = tool_call.get("name")
     if name not in ALLOWED_MCP_TOOLS:
         raise RuntimeError(f"MCP tool {name!r} was not exposed")

--- a/agent/docs/source/how-to-guides/use-mcp-tools.md
+++ b/agent/docs/source/how-to-guides/use-mcp-tools.md
@@ -27,18 +27,14 @@ The following AgentApp performs one bounded MCP tool round and then streams the
 final model response:
 
 ```python
-from __future__ import annotations
-
 import asyncio
 import json
 import os
-from typing import Any, cast
 
 from flwr.agentapp import AgentApp, AgentSession
 from flwr.app import Context
-from mcp import CallToolResult, ClientSession, Tool
+from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
-from mcp.types import PaginatedRequestParams
 from openai import AsyncOpenAI
 
 MODEL = "openai/gpt-5.6-sol"
@@ -47,70 +43,7 @@ ALLOWED_MCP_TOOLS = {"search_documents", "read_document"}
 app = AgentApp()
 
 
-def as_response_tool(tool: Tool) -> dict[str, Any]:
-    """Convert an MCP tool definition to an Open Responses function tool."""
-    return {
-        "type": "function",
-        "name": tool.name,
-        "description": tool.description or "",
-        "parameters": tool.inputSchema,
-    }
-
-
-def serialize_mcp_result(result: CallToolResult) -> str:
-    """Serialize an MCP result for a function_call_output item."""
-    return result.model_dump_json(by_alias=True, exclude_none=True)
-
-
-async def list_all_tools(mcp_client: ClientSession) -> list[Tool]:
-    """List every tool exposed by a paginated MCP server."""
-    tools = []
-    cursor = None
-    while True:
-        params = (
-            PaginatedRequestParams(cursor=cursor)
-            if cursor is not None
-            else None
-        )
-        page = await mcp_client.list_tools(params=params)
-        tools.extend(page.tools)
-        cursor = page.nextCursor
-        if cursor is None:
-            return tools
-
-
-async def call_mcp_tool(
-    mcp_client: ClientSession,
-    tool_call: dict[str, Any],
-) -> dict[str, Any]:
-    """Validate and execute one model-requested MCP tool call."""
-    name = tool_call.get("name")
-    if not isinstance(name, str) or name not in ALLOWED_MCP_TOOLS:
-        raise RuntimeError(f"MCP tool {name!r} was not exposed")
-
-    raw_arguments = tool_call.get("arguments", "{}")
-    arguments = (
-        json.loads(raw_arguments)
-        if isinstance(raw_arguments, str)
-        else raw_arguments
-    )
-    if not isinstance(arguments, dict):
-        raise ValueError("MCP tool arguments must be a JSON object")
-
-    call_id = tool_call.get("call_id")
-    if not isinstance(call_id, str):
-        raise ValueError("MCP tool call requires a string call_id")
-
-    result = await mcp_client.call_tool(name, arguments)
-    return {
-        "type": "function_call_output",
-        "call_id": call_id,
-        "output": serialize_mcp_result(result),
-    }
-
-
 async def run_mcp(agent: AgentSession, context: Context) -> None:
-    """Discover MCP tools, execute one tool round, and publish the answer."""
     prompt = context.run_config.get("agent.input")
     if not isinstance(prompt, str) or not prompt.strip():
         raise ValueError("agent.input must be a non-empty string")
@@ -120,7 +53,7 @@ async def run_mcp(agent: AgentSession, context: Context) -> None:
         api_key=os.environ["FLWR_RUNTIME_API_KEY"],
         max_retries=0,
     ) as client:
-        input_items: list[dict[str, Any]] = [
+        input_items = [
             {"type": "message", "role": "user", "content": prompt.strip()}
         ]
 
@@ -131,14 +64,32 @@ async def run_mcp(agent: AgentSession, context: Context) -> None:
         ):
             async with ClientSession(read, write) as mcp_client:
                 await mcp_client.initialize()
+
+                discovered_tools = []
+                cursor = None
+                while True:
+                    page = await mcp_client.list_tools(cursor=cursor)
+                    discovered_tools.extend(page.tools)
+                    cursor = page.nextCursor
+                    if cursor is None:
+                        break
+
                 selected_tools = [
                     tool
-                    for tool in await list_all_tools(mcp_client)
+                    for tool in discovered_tools
                     if tool.name in ALLOWED_MCP_TOOLS
                 ]
                 if not selected_tools:
                     raise RuntimeError("The MCP server exposed no allowed tools")
-                model_tools = [as_response_tool(tool) for tool in selected_tools]
+                model_tools = [
+                    {
+                        "type": "function",
+                        "name": tool.name,
+                        "description": tool.description or "",
+                        "parameters": tool.inputSchema,
+                    }
+                    for tool in selected_tools
+                ]
 
                 response = await client.responses.create(
                     model=MODEL,
@@ -146,10 +97,7 @@ async def run_mcp(agent: AgentSession, context: Context) -> None:
                     tools=model_tools,
                     tool_choice="required",
                 )
-                response_output = [
-                    cast(dict[str, Any], item.to_dict())
-                    for item in response.output
-                ]
+                response_output = [item.to_dict() for item in response.output]
                 tool_calls = [
                     item
                     for item in response_output
@@ -158,10 +106,26 @@ async def run_mcp(agent: AgentSession, context: Context) -> None:
                 if not tool_calls:
                     raise RuntimeError("The model did not request an MCP tool")
 
-                function_outputs = [
-                    await call_mcp_tool(mcp_client, tool_call)
-                    for tool_call in tool_calls
-                ]
+                function_outputs = []
+                for tool_call in tool_calls:
+                    name = tool_call["name"]
+                    if name not in ALLOWED_MCP_TOOLS:
+                        raise RuntimeError(f"MCP tool {name!r} was not exposed")
+                    result = await mcp_client.call_tool(
+                        name,
+                        json.loads(tool_call["arguments"]),
+                    )
+                    function_outputs.append(
+                        {
+                            "type": "function_call_output",
+                            "call_id": tool_call["call_id"],
+                            "output": result.model_dump_json(
+                                by_alias=True,
+                                exclude_none=True,
+                            ),
+                        }
+                    )
+
                 input_items.extend(response_output)
                 input_items.extend(function_outputs)
 
@@ -170,27 +134,17 @@ async def run_mcp(agent: AgentSession, context: Context) -> None:
             input=input_items,
             stream=True,
         )
-        output_text = []
         async for event in stream:
             agent.events.emit(event.to_dict())
             if event.type in {
                 "error",
                 "response.failed",
-                "response.incomplete",
             }:
-                raise RuntimeError(f"Model response did not complete: {event}")
-            if event.type in {
-                "response.output_text.delta",
-                "response.refusal.delta",
-            }:
-                output_text.append(event.delta)
-
-        print("".join(output_text))
+                raise RuntimeError(f"Model response failed: {event}")
 
 
 @app.main()
 def main(agent: AgentSession, context: Context) -> None:
-    """Run the asynchronous MCP workflow from Flower's synchronous entry point."""
     asyncio.run(run_mcp(agent, context))
 ```
 

--- a/agent/docs/source/how-to-guides/use-mcp-tools.md
+++ b/agent/docs/source/how-to-guides/use-mcp-tools.md
@@ -1,0 +1,109 @@
+# Use tools from an MCP server
+
+Connect a Flower AgentApp to tools exposed by a Model Context Protocol (MCP)
+server. This integration currently runs inside your AgentApp; Flower does not
+provide a first-class MCP client or register arbitrary MCP servers with
+`agent.connectors`.
+
+Flower connectors and MCP tools therefore follow different execution paths:
+
+- `agent.connectors.tools(...)` and `agent.connectors.call(...)` use tools
+  registered and hosted by the Flower runtime.
+- An MCP client created by your AgentApp connects to the MCP server, discovers
+  its tools, and executes its calls.
+
+Both kinds of tools can be passed to the same Open Responses model request after
+the AgentApp converts the MCP definitions to function-tool schemas.
+
+## Add an MCP client
+
+Declare an MCP client dependency and manage its connection in the AgentApp.
+Discover the server's tools, then expose only an explicit allowlist.
+
+## Discover and allowlist tools
+
+First list the server's tools, then select an explicit set of tool names:
+
+```python
+ALLOWED_MCP_TOOLS = {
+    "search_documents",
+    "read_document",
+}
+
+list_result = await mcp_client.list_tools()
+discovered_tools = list_result.tools
+selected_tools = [
+    tool for tool in discovered_tools if tool.name in ALLOWED_MCP_TOOLS
+]
+```
+
+The exact client setup and result container depend on the MCP library and
+transport. The important boundary is that a server advertising a new tool does
+not make that tool model-accessible automatically.
+
+## Convert definitions to Open Responses tools
+
+For each selected MCP tool, map its name, description, and JSON input schema to
+an Open Responses function tool:
+
+```python
+def as_response_tool(tool: object) -> dict[str, object]:
+    return {
+        "type": "function",
+        "name": tool.name,
+        "description": tool.description or "",
+        "parameters": tool.inputSchema,
+    }
+
+
+model_tools = [as_response_tool(tool) for tool in selected_tools]
+```
+
+Some MCP clients expose the schema as `input_schema` instead of `inputSchema`.
+Use the field provided by your client without otherwise changing the JSON
+Schema. Pass `model_tools` through the `tools` field of
+`client.responses.create(...)`.
+
+## Dispatch function calls back to MCP
+
+When the model returns a `function_call`, reject any name outside the allowlist,
+parse its arguments, call the matching MCP tool, and create a
+`function_call_output` item with the same `call_id`:
+
+```python
+import json
+
+
+async def call_mcp_tool(tool_call: dict[str, object]) -> dict[str, object]:
+    name = tool_call.get("name")
+    if name not in ALLOWED_MCP_TOOLS:
+        raise RuntimeError(f"MCP tool {name!r} was not exposed")
+
+    raw_arguments = tool_call.get("arguments", "{}")
+    arguments = (
+        json.loads(raw_arguments)
+        if isinstance(raw_arguments, str)
+        else raw_arguments
+    )
+    result = await mcp_client.call_tool(name, arguments)
+    return {
+        "type": "function_call_output",
+        "call_id": tool_call["call_id"],
+        "output": serialize_mcp_result(result),
+    }
+```
+
+`serialize_mcp_result` represents application-specific normalization. Serialize
+the MCP result's text, structured content, or error to a string accepted by your
+model provider. Do not pass client-library objects directly to the model
+request.
+
+Append both the model's original function-call item and the corresponding
+function output to the next request. Bound the loop exactly as you would for
+Flower connectors; see {ref}`bound-connector-tool-loop`.
+
+## Current limitations
+
+Flower does not manage the MCP server, its credentials, or its activity events.
+The AgentApp must close the client, handle failures and timeouts, and receive
+secrets through the deployment rather than through `agent.input`.

--- a/agent/docs/source/how-to-guides/use-mcp-tools.md
+++ b/agent/docs/source/how-to-guides/use-mcp-tools.md
@@ -17,12 +17,43 @@ the AgentApp converts the MCP definitions to function-tool schemas.
 
 ## Add an MCP client
 
-Declare an MCP client dependency and manage its connection in the AgentApp.
-Discover the server's tools, then expose only an explicit allowlist.
+Add the MCP Python SDK to the AgentApp dependencies:
+
+```console
+$ uv add mcp
+```
+
+Bridge Flower's synchronous entry point to the asynchronous MCP client and keep
+the client lifecycle inside context managers:
+
+```python
+import asyncio
+import os
+
+from flwr.agentapp import AgentApp, AgentSession
+from flwr.app import Context
+from mcp import Client
+
+app = AgentApp()
+
+
+async def run_mcp(agent: AgentSession, context: Context) -> None:
+    async with Client(os.environ["MCP_ENDPOINT"]) as mcp_client:
+        await use_mcp_tools(mcp_client, agent, context)
+
+
+@app.main()
+def main(agent: AgentSession, context: Context) -> None:
+    asyncio.run(run_mcp(agent, context))
+```
+
+Set `MCP_ENDPOINT` to the URL of a running Streamable HTTP MCP server. The
+following sections build `use_mcp_tools`.
 
 ## Discover and allowlist tools
 
-First list the server's tools, then select an explicit set of tool names:
+Inside the asynchronous helper, list the server's tools and select an explicit
+set of tool names:
 
 ```python
 ALLOWED_MCP_TOOLS = {
@@ -30,11 +61,17 @@ ALLOWED_MCP_TOOLS = {
     "read_document",
 }
 
-list_result = await mcp_client.list_tools()
-discovered_tools = list_result.tools
-selected_tools = [
-    tool for tool in discovered_tools if tool.name in ALLOWED_MCP_TOOLS
-]
+
+async def use_mcp_tools(
+    mcp_client: Client,
+    agent: AgentSession,
+    context: Context,
+) -> None:
+    list_result = await mcp_client.list_tools()
+    selected_tools = [
+        tool for tool in list_result.tools if tool.name in ALLOWED_MCP_TOOLS
+    ]
+    # Convert selected_tools, pass them to the model, and dispatch tool calls.
 ```
 
 The exact client setup and result container depend on the MCP library and
@@ -66,9 +103,10 @@ Schema. Pass `model_tools` through the `tools` field of
 
 ## Dispatch function calls back to MCP
 
-When the model returns a `function_call`, reject any name outside the allowlist,
-parse its arguments, call the matching MCP tool, and create a
-`function_call_output` item with the same `call_id`:
+When the OpenAI SDK returns a `function_call`, first convert it with
+`function_call.to_dict()`. Then reject any name outside the allowlist, parse its
+arguments, call the matching MCP tool, and create a `function_call_output` item
+with the same `call_id`:
 
 ```python
 import json

--- a/agent/docs/source/how-to-guides/use-openai-sdk.md
+++ b/agent/docs/source/how-to-guides/use-openai-sdk.md
@@ -1,9 +1,10 @@
 # Use the OpenAI SDK in an AgentApp
 
 The OpenAI Python SDK is the standard way to make model requests from a Flower
-AgentApp. Flower provides an OpenAI-compatible Responses endpoint and its
-credentials while the AgentApp is running, so your code can use the SDK without
-a model-provider API key.
+AgentApp. Flower provides an OpenAI-compatible Responses endpoint and injects
+credentials for that endpoint while the AgentApp is running. These runtime
+credentials authenticate the AgentApp to Flower; they are not credentials for
+the upstream model provider.
 
 This guide targets Flower 1.35.0.
 
@@ -36,7 +37,11 @@ Then update its dependencies:
 $ uv add 'flwr>=1.35.0,<2.0' 'openai>=2.16.0,<3.0.0'
 ```
 
-Do not add a model-provider API key to the project or its configuration.
+Do not embed a model-provider API key in the AgentApp or its run configuration.
+On SuperGrid, Flower configures upstream model access for you. A self-hosted
+SuperLink must be configured separately with a model endpoint and any credential
+that endpoint requires. See [Run an AgentApp with a local
+SuperLink](run-with-local-superlink.md).
 
 ## Create the client inside the AgentApp
 

--- a/agent/docs/source/index.md
+++ b/agent/docs/source/index.md
@@ -61,6 +61,7 @@ how-to-guides/connect-accounts
 how-to-guides/create-automations
 how-to-guides/use-flower-hub
 how-to-guides/use-openai-sdk
+how-to-guides/use-mcp-tools
 how-to-guides/run-on-supergrid
 how-to-guides/troubleshoot-agent-runs
 how-to-guides/run-with-local-superlink

--- a/agent/docs/source/tutorials/write-your-first-agentapp.md
+++ b/agent/docs/source/tutorials/write-your-first-agentapp.md
@@ -87,7 +87,11 @@ def main(agent: AgentSession, context: Context) -> None:
 
 Flower also injects `FLWR_RUNTIME_BASE_URL` and `FLWR_RUNTIME_API_KEY` into the
 AgentApp process. The OpenAI client uses them to send the request through
-Flower, so the project does not need a model-provider API key.
+Flower. This tutorial runs on SuperGrid, where Flower configures upstream model
+access, so the project does not need a model-provider API key. When you run the
+same app on a self-hosted SuperLink, configure the model provider in the
+SuperLink environment as described in [Run an AgentApp with a local
+SuperLink](../how-to-guides/run-with-local-superlink.md).
 
 The SDK yields typed streaming events. The loop republishes each event through
 `agent.events.emit` so Flower Chat and other run-event clients can render the


### PR DESCRIPTION
## Summary
Clarify how AgentApps access models and mcp tools.

## Why

The existing documentation could imply that AgentApps never require upstream model-provider configuration. A self-hosted SuperLink requires a model API key or an Open Responses-compatible endpoint. The documentation also did not clearly explain the current MCP integration boundary, local inference compatibility, or how managed and foreground SuperLink processes are stopped.

## What
- Distinguishes AgentApp runtime credentials from upstream model-provider credentials.
- Documents the model configuration required by self-hosted SuperLink.
- Shows the error returned when `FLWR_MODEL_API_KEY` is missing.
- Explains that `/chat/completions`-only model servers are not directly compatible with Flower's Open Responses model plane.
- Adds guidance for fully local inference with Ollama or a custom protocol adapter.
- Adds an MCP integration guide covering tool discovery, allowlisting, schema conversion, and execution.
- Clarifies that Flower does not currently provide first-class MCP toolset support.
- Removes stale references to `agent.responses`.
- Clarifies the difference between stopping an AgentApp run and stopping a local SuperLink.