### PR TITLE
fix(framework): Support task messages on SuperNode

### DIFF
--- a/framework/py/flwr/server/superlink/linkstate/linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate.py
@@ -33,6 +33,10 @@ from flwr.superlink.federation import FederationManager
 class LinkState(CoreState):  # pylint: disable=R0904
     """Abstract LinkState."""
 
+    def get_node_id(self) -> int:
+        """Return the SuperLink node ID."""
+        return SUPERLINK_NODE_ID
+
     @property
     @abc.abstractmethod
     def federation_manager(self) -> FederationManager:

--- a/framework/py/flwr/supercore/corestate/corestate.py
+++ b/framework/py/flwr/supercore/corestate/corestate.py
@@ -40,6 +40,10 @@ from ..object_store import ObjectStore
 class CoreState(ABC):  # pylint: disable=R0904
     """Abstract base class for core state."""
 
+    @abstractmethod
+    def get_node_id(self) -> int:
+        """Return the ID of the node owning this CoreState."""
+
     @property
     @abstractmethod
     def object_store(self) -> ObjectStore:

--- a/framework/py/flwr/supercore/corestate/in_memory_corestate.py
+++ b/framework/py/flwr/supercore/corestate/in_memory_corestate.py
@@ -1171,7 +1171,7 @@ class InMemoryCoreState(
     ) -> bool:
         """Store one task-addressed Message."""
         message_id = message.metadata.message_id
-        if validate_task_message(message):
+        if validate_task_message(message, self.get_node_id()):
             return False
         src_task_id = cast(int, message.metadata.src_task_id)
         dst_task_id = cast(int, message.metadata.dst_task_id)

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -49,7 +49,6 @@ from flwr.common.constant import (
     HEARTBEAT_DEFAULT_INTERVAL,
     HEARTBEAT_PATIENCE,
     SERIES_ID_NUM_BYTES,
-    SUPERLINK_NODE_ID,
     TASK_ID_NUM_BYTES,
     Status,
     SubStatus,
@@ -1488,7 +1487,7 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
 
     def store_task_message(self, message: Message) -> bool:
         """Store one task-addressed Message."""
-        if validate_task_message(message):
+        if validate_task_message(message, self.get_node_id()):
             return False
 
         with self.session() as session:
@@ -1585,7 +1584,8 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
                 dst_task_ids, src_task_ids, order_by, limit
             )
             snapshots = [_task_message_snapshot_from_model(row) for row in rows]
-        return [_task_message_from_snapshot(row) for row in snapshots]
+        node_id = self.get_node_id()
+        return [_task_message_from_snapshot(row, node_id) for row in snapshots]
 
     def store_task_events(
         self,
@@ -1987,7 +1987,7 @@ def _task_message_snapshot_from_model(model: TaskMessageModel) -> dict[str, Any]
     }
 
 
-def _task_message_from_snapshot(row: dict[str, Any]) -> Message:
+def _task_message_from_snapshot(row: dict[str, Any], node_id: int) -> Message:
     """Convert a claimed task_message snapshot to a Message."""
     content, error = None, None
     if row["content"] is not None:
@@ -1998,8 +1998,8 @@ def _task_message_from_snapshot(row: dict[str, Any]) -> Message:
     metadata = Metadata(
         run_id=int64_to_uint64(row["run_id"]),
         message_id=row["message_id"],
-        src_node_id=SUPERLINK_NODE_ID,
-        dst_node_id=SUPERLINK_NODE_ID,
+        src_node_id=node_id,
+        dst_node_id=node_id,
         reply_to_message_id=row["reply_to_message_id"] or "",
         group_id="",  # Task messages don't have this field for now
         created_at=row["created_at"],

--- a/framework/py/flwr/supercore/corestate/utils.py
+++ b/framework/py/flwr/supercore/corestate/utils.py
@@ -20,7 +20,6 @@ from os import urandom
 
 from flwr.app import Context, Message
 from flwr.common import serde
-from flwr.common.constant import SUPERLINK_NODE_ID
 from flwr.proto.message_pb2 import Context as ProtoContext  # pylint: disable=E0611
 from flwr.supercore.date import now
 from flwr.supercore.utils import strict_json_loads
@@ -78,7 +77,9 @@ def validate_task_event_data(data: str) -> None:
         raise ValueError("Task event data must be a JSON object.")
 
 
-def validate_task_message(message: Message) -> list[str]:  # pylint: disable=R0912
+def validate_task_message(
+    message: Message, node_id: int
+) -> list[str]:  # pylint: disable=R0912
     """Validate a task Message."""
     validation_errors = []
     metadata = message.metadata
@@ -100,15 +101,14 @@ def validate_task_message(message: Message) -> list[str]:  # pylint: disable=R09
             "`metadata.src_task_id` and `metadata.dst_task_id` must be different."
         )
 
-    # Temporary: task messages are only supported in SuperLink for now.
-    if metadata.src_node_id != SUPERLINK_NODE_ID:
+    if metadata.src_node_id != node_id:
         validation_errors.append(
-            f"`metadata.src_node_id` is not {SUPERLINK_NODE_ID} (SuperLink node ID)"
+            f"`metadata.src_node_id` does not match CoreState node ID {node_id}"
         )
 
-    if metadata.dst_node_id != SUPERLINK_NODE_ID:
+    if metadata.dst_node_id != node_id:
         validation_errors.append(
-            f"`metadata.dst_node_id` is not {SUPERLINK_NODE_ID} (SuperLink node ID)"
+            f"`metadata.dst_node_id` does not match CoreState node ID {node_id}"
         )
 
     if metadata.created_at < _MIN_VALID_MESSAGE_CREATED_AT:

--- a/framework/py/flwr/supercore/corestate/utils_test.py
+++ b/framework/py/flwr/supercore/corestate/utils_test.py
@@ -30,6 +30,7 @@ def create_task_message(  # pylint: disable=too-many-arguments
     dst_task_id: int | None = 2,
     run_id: int = 1,
     *,
+    node_id: int = SUPERLINK_NODE_ID,
     reply_to_message_id: str = "",
     created_at: float | None = None,
     ttl: float = 60.0,
@@ -41,8 +42,8 @@ def create_task_message(  # pylint: disable=too-many-arguments
     metadata = Metadata(
         run_id=run_id,
         message_id="",
-        src_node_id=SUPERLINK_NODE_ID,
-        dst_node_id=SUPERLINK_NODE_ID,
+        src_node_id=node_id,
+        dst_node_id=node_id,
         reply_to_message_id=reply_to_message_id,
         group_id="",
         created_at=created_at if created_at is not None else now().timestamp(),
@@ -84,14 +85,23 @@ class UtilsTest(unittest.TestCase):
             with self.subTest(has_error=has_error):
                 message = create_task_message(has_error=has_error)
 
-                self.assertEqual(validate_task_message(message), [])
+                self.assertEqual(validate_task_message(message, SUPERLINK_NODE_ID), [])
+
+    def test_validate_task_message_rejects_other_corestate_node(self) -> None:
+        """Reject Task Messages addressed to a different CoreState node."""
+        message = create_task_message(node_id=123)
+
+        errors = validate_task_message(message, node_id=456)
+
+        _assert_has_error(errors, "metadata.src_node_id")
+        _assert_has_error(errors, "metadata.dst_node_id")
 
     def test_validate_task_message_rejects_missing_message_id(self) -> None:
         """Test that message_id must be set."""
         message = create_task_message()
         message.metadata.__dict__["_message_id"] = ""
 
-        errors = validate_task_message(message)
+        errors = validate_task_message(message, SUPERLINK_NODE_ID)
 
         _assert_has_error(errors, "metadata.message_id")
 
@@ -99,7 +109,7 @@ class UtilsTest(unittest.TestCase):
         """Test that run_id must be set."""
         message = create_task_message(run_id=0)
 
-        errors = validate_task_message(message)
+        errors = validate_task_message(message, SUPERLINK_NODE_ID)
 
         _assert_has_error(errors, "metadata.run_id")
 
@@ -107,7 +117,7 @@ class UtilsTest(unittest.TestCase):
         """Test that source task ID must be set."""
         message = create_task_message(src_task_id=None)
 
-        errors = validate_task_message(message)
+        errors = validate_task_message(message, SUPERLINK_NODE_ID)
 
         _assert_has_error(errors, "metadata.src_task_id")
 
@@ -115,7 +125,7 @@ class UtilsTest(unittest.TestCase):
         """Test that destination task ID must be set."""
         message = create_task_message(dst_task_id=None)
 
-        errors = validate_task_message(message)
+        errors = validate_task_message(message, SUPERLINK_NODE_ID)
 
         _assert_has_error(errors, "metadata.dst_task_id")
 
@@ -123,7 +133,7 @@ class UtilsTest(unittest.TestCase):
         """Test that source and destination task IDs must differ."""
         message = create_task_message(src_task_id=1, dst_task_id=1)
 
-        errors = validate_task_message(message)
+        errors = validate_task_message(message, SUPERLINK_NODE_ID)
 
         _assert_has_error(errors, "must be different")
 
@@ -131,7 +141,7 @@ class UtilsTest(unittest.TestCase):
         """Test that created_at must be a plausible timestamp."""
         message = create_task_message(created_at=0.0)
 
-        errors = validate_task_message(message)
+        errors = validate_task_message(message, SUPERLINK_NODE_ID)
 
         _assert_has_error(errors, "metadata.created_at")
 
@@ -139,7 +149,7 @@ class UtilsTest(unittest.TestCase):
         """Test that ttl must be positive."""
         message = create_task_message(ttl=0.0)
 
-        errors = validate_task_message(message)
+        errors = validate_task_message(message, SUPERLINK_NODE_ID)
 
         _assert_has_error(errors, "metadata.ttl")
 
@@ -147,7 +157,7 @@ class UtilsTest(unittest.TestCase):
         """Test that task messages must not be expired."""
         message = create_task_message(created_at=now().timestamp() - 10.0, ttl=1.0)
 
-        errors = validate_task_message(message)
+        errors = validate_task_message(message, SUPERLINK_NODE_ID)
 
         _assert_has_error(errors, "TTL has expired")
 
@@ -156,7 +166,7 @@ class UtilsTest(unittest.TestCase):
         message = create_task_message()
         message.metadata.__dict__["_message_type"] = ""
 
-        errors = validate_task_message(message)
+        errors = validate_task_message(message, SUPERLINK_NODE_ID)
 
         _assert_has_error(errors, "metadata.message_type")
 
@@ -165,7 +175,7 @@ class UtilsTest(unittest.TestCase):
         message = create_task_message()
         message.__dict__["_content"] = None
 
-        errors = validate_task_message(message)
+        errors = validate_task_message(message, SUPERLINK_NODE_ID)
 
         _assert_has_error(errors, "content` or `error")
 
@@ -174,6 +184,6 @@ class UtilsTest(unittest.TestCase):
         message = create_task_message()
         message.__dict__["_error"] = Error(0)
 
-        errors = validate_task_message(message)
+        errors = validate_task_message(message, SUPERLINK_NODE_ID)
 
         _assert_has_error(errors, "content` or `error")

--- a/framework/py/flwr/superlink/routers/runtime/responses.py
+++ b/framework/py/flwr/superlink/routers/runtime/responses.py
@@ -194,6 +194,9 @@ def _start_exchange(
     model_task_id = response.task_id
     request.metadata.dst_task_id = model_task_id
     request.metadata.__dict__["_run_id"] = task.run_id
+    node_id = state.get_node_id()
+    request.metadata.__dict__["_src_node_id"] = node_id
+    request.metadata.dst_node_id = node_id
     request.metadata.src_task_id = task.task_id
     request.metadata.__dict__["_message_id"] = request.object_id
     if not state.store_task_message(request):

--- a/framework/py/flwr/superlink/routers/runtime/responses_test.py
+++ b/framework/py/flwr/superlink/routers/runtime/responses_test.py
@@ -50,6 +50,7 @@ def _client(state: Mock) -> TestClient:
 
 def _state() -> Mock:
     state = Mock(spec=LinkState)
+    state.get_node_id.return_value = 789
     state.get_task_by_token.return_value = Task(
         task_id=123, run_id=789, type=TaskType.AGENT_APP
     )
@@ -129,6 +130,8 @@ def test_responses_returns_correlated_model_response() -> None:
     request = state.store_task_message.call_args.args[0]
     assert request.metadata.src_task_id == 123
     assert request.metadata.dst_task_id == 456
+    assert request.metadata.src_node_id == 789
+    assert request.metadata.dst_node_id == 789
     assert state.get_task_message.call_count == 2
     state.get_task_message.assert_called_with(
         dst_task_ids=[123],

--- a/framework/py/flwr/supernode/nodestate/nodestate.py
+++ b/framework/py/flwr/supernode/nodestate/nodestate.py
@@ -35,10 +35,6 @@ class NodeState(CoreState):
         """Set the node ID."""
 
     @abstractmethod
-    def get_node_id(self) -> int:
-        """Get the node ID."""
-
-    @abstractmethod
     def store_message(self, message: Message) -> str | None:
         """Store a message.
 

--- a/framework/py/flwr/supernode/nodestate/nodestate_test.py
+++ b/framework/py/flwr/supernode/nodestate/nodestate_test.py
@@ -24,9 +24,10 @@ from parameterized import parameterized
 
 from flwr.app import ConfigRecord, Message, Metadata, RecordDict
 from flwr.app.message import make_message
-from flwr.common.constant import ErrorCode
+from flwr.common.constant import SUPERLINK_NODE_ID, ErrorCode
 from flwr.supercore.constant import TaskType
 from flwr.supercore.corestate.corestate_test import StateTest as CoreStateTest
+from flwr.supercore.corestate.utils_test import create_task_message
 from flwr.supercore.date import now
 from flwr.supercore.fab import Fab
 from flwr.supercore.inflatable.inflatable_object import get_object_tree
@@ -72,9 +73,31 @@ class StateTest(CoreStateTest):  # pylint: disable=R0904
 
     def test_get_node_id_fails(self) -> None:
         """Test get_node_id fails correctly if node_id is not set."""
-        # Execute and assert
+        state = InMemoryNodeState(ObjectStoreFactory().store())
+
         with self.assertRaises(ValueError):
-            self.state.get_node_id()
+            state.get_node_id()
+
+    def test_store_task_message_uses_supernode_id(self) -> None:
+        """Task Messages should use the node ID of their CoreState."""
+        node_id = 123
+        self.state.set_node_id(node_id)
+        src_task_id = self.state.create_task(task_type=TaskType.CLIENT_APP, run_id=42)
+        dst_task_id = self.state.create_task(task_type=TaskType.MODEL, run_id=42)
+        assert src_task_id is not None and dst_task_id is not None
+        message = create_task_message(
+            src_task_id=src_task_id,
+            dst_task_id=dst_task_id,
+            run_id=42,
+            node_id=node_id,
+        )
+
+        self.assertTrue(self.state.store_task_message(message))
+        pulled = self.state.get_task_message(dst_task_ids=[dst_task_id])
+
+        self.assertEqual(len(pulled), 1)
+        self.assertEqual(pulled[0].metadata.src_node_id, node_id)
+        self.assertEqual(pulled[0].metadata.dst_node_id, node_id)
 
     def test_store_and_get_run(self) -> None:
         """Test storing and retrieving a run."""
@@ -457,4 +480,6 @@ class InMemoryStateTest(StateTest):
 
     def state_factory(self) -> NodeState:
         """Return InMemoryState."""
-        return InMemoryNodeState(ObjectStoreFactory().store())
+        state = InMemoryNodeState(ObjectStoreFactory().store())
+        state.set_node_id(SUPERLINK_NODE_ID)
+        return state


### PR DESCRIPTION
## Issue

### Description

Task message validation assumes the SuperLink node ID, causing messages created for tasks running on a SuperNode to be rejected. Runtime Responses message construction also relies on that fixed identity.

### Related issues/PRs

None.

## Proposal

### Explanation

Move the node identity contract to CoreState. LinkState returns the SuperLink node ID, while NodeState implementations return their configured node ID. Validate and reconstruct task messages using the owning CoreState identity, and use the same identity when creating Runtime Responses task messages.

The Responses endpoint remains registered only on SuperLink.